### PR TITLE
feat: Services/ViewModels に Swift Testing を追加

### DIFF
--- a/CareNote.xcodeproj/project.pbxproj
+++ b/CareNote.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		32FB2DE8BCDAB9EA5285250B /* GoogleSignInSwift in Frameworks */ = {isa = PBXBuildFile; productRef = C6A8EFE7C4356D0F17B5D689 /* GoogleSignInSwift */; };
 		33992576E1D90FE68CFBFFA2 /* GoogleSignIn in Frameworks */ = {isa = PBXBuildFile; productRef = 1DFFB0082E42BA992D89756B /* GoogleSignIn */; };
 		49EDC4D0E2DCC6A88931AC17 /* ClientSelectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FFDE09543BDF9E6601F1F2A /* ClientSelectView.swift */; };
+		4E553F6607752AD117DCE2E6 /* RecordingViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E51986CBBEC3607B0256C7A /* RecordingViewModelTests.swift */; };
 		577059F7C878462433B3DC11 /* SignInView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED7A610D0269818D75C76641 /* SignInView.swift */; };
 		65E5E0CD5DBC914A92B91130 /* ClientSelectViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7452B80D90D9172B77475447 /* ClientSelectViewModel.swift */; };
 		6DA2DDE0F90D3985BC3C5D17 /* AppEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2848993801DEF66A676C25D /* AppEnvironment.swift */; };
@@ -34,8 +35,10 @@
 		ACF047650FB8467229A5C694 /* RecordingScene.swift in Sources */ = {isa = PBXBuildFile; fileRef = B19118D3C407ABA870A521B2 /* RecordingScene.swift */; };
 		AFC68317B2584D1DD4BD0DEC /* CareNoteApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F9FC31CCE425A0E9107ACB3 /* CareNoteApp.swift */; };
 		B64BA4F7909AFDD553C357F5 /* RecordingListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 933487C9E5291192E20D3FD6 /* RecordingListViewModel.swift */; };
+		C60B40FD6A5D17715EAE0AD4 /* AuthViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BD36BBA888E8960D96DC910 /* AuthViewModelTests.swift */; };
 		C6CF4C9D8589E6E86057F63E /* RecordingConfirmView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96BF9442D22A121622206F23 /* RecordingConfirmView.swift */; };
 		C74386AC37344205E71E5B2B /* AppConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D1751BC835BB28519295961 /* AppConfig.swift */; };
+		CCA4CF007249D2BA99FD5315 /* TranscriptionServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46A7E7E108F739F5871EB716 /* TranscriptionServiceTests.swift */; };
 		D68884E97DC6ABD4E1501E05 /* WIFAuthService.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC5C0A2EB369429A8FD3D891 /* WIFAuthService.swift */; };
 		DEA5BEF6533AC992CA56ACE1 /* FirebaseAuth in Frameworks */ = {isa = PBXBuildFile; productRef = 780EB4E4898BE568D7C4B343 /* FirebaseAuth */; };
 		F503CBD6C43A313174F070AA /* OutboxSyncService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31A63277501286D0902113FA /* OutboxSyncService.swift */; };
@@ -62,15 +65,18 @@
 		314ECA9225E94AACAFBC6557 /* SceneSelectViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneSelectViewModel.swift; sourceTree = "<group>"; };
 		31A176AE8830BEDDEBD57A2F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		31A63277501286D0902113FA /* OutboxSyncService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OutboxSyncService.swift; sourceTree = "<group>"; };
+		46A7E7E108F739F5871EB716 /* TranscriptionServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptionServiceTests.swift; sourceTree = "<group>"; };
 		47604C61474A5EA44EABDF67 /* RecordingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingView.swift; sourceTree = "<group>"; };
 		4A269AFC38F3097F4CDCF8DF /* SceneSelectView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneSelectView.swift; sourceTree = "<group>"; };
 		5145C7CB43880EF7C55A94B3 /* StorageService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageService.swift; sourceTree = "<group>"; };
 		58D2B24492527E7C7CE59620 /* FirestoreModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirestoreModels.swift; sourceTree = "<group>"; };
 		7452B80D90D9172B77475447 /* ClientSelectViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientSelectViewModel.swift; sourceTree = "<group>"; };
 		7C870BA88FAE7FE80BBF4DD2 /* SwiftDataModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftDataModels.swift; sourceTree = "<group>"; };
+		7E51986CBBEC3607B0256C7A /* RecordingViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingViewModelTests.swift; sourceTree = "<group>"; };
 		933487C9E5291192E20D3FD6 /* RecordingListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingListViewModel.swift; sourceTree = "<group>"; };
 		96BF9442D22A121622206F23 /* RecordingConfirmView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingConfirmView.swift; sourceTree = "<group>"; };
 		97B373FAB82B749E309A7CA8 /* RecordingRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingRepository.swift; sourceTree = "<group>"; };
+		9BD36BBA888E8960D96DC910 /* AuthViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthViewModelTests.swift; sourceTree = "<group>"; };
 		9F9FC31CCE425A0E9107ACB3 /* CareNoteApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CareNoteApp.swift; sourceTree = "<group>"; };
 		A0B042EBE580E9D6CBA65F7C /* AudioRecorderService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioRecorderService.swift; sourceTree = "<group>"; };
 		A98BBDBB5774B595F092430F /* RecordingListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingListView.swift; sourceTree = "<group>"; };
@@ -215,6 +221,9 @@
 		716AE9A177EA66220562BECC /* CareNoteTests */ = {
 			isa = PBXGroup;
 			children = (
+				9BD36BBA888E8960D96DC910 /* AuthViewModelTests.swift */,
+				7E51986CBBEC3607B0256C7A /* RecordingViewModelTests.swift */,
+				46A7E7E108F739F5871EB716 /* TranscriptionServiceTests.swift */,
 			);
 			path = CareNoteTests;
 			sourceTree = "<group>";
@@ -345,6 +354,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C60B40FD6A5D17715EAE0AD4 /* AuthViewModelTests.swift in Sources */,
+				4E553F6607752AD117DCE2E6 /* RecordingViewModelTests.swift in Sources */,
+				CCA4CF007249D2BA99FD5315 /* TranscriptionServiceTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/CareNote/App/CareNoteApp.swift
+++ b/CareNote/App/CareNoteApp.swift
@@ -11,7 +11,9 @@ struct CareNoteApp: App {
     let modelContainer: ModelContainer
 
     init() {
-        FirebaseApp.configure()
+        if !CareNoteApp.isRunningTests {
+            FirebaseApp.configure()
+        }
 
         let schema = Schema([
             RecordingRecord.self,
@@ -31,6 +33,11 @@ struct CareNoteApp: App {
         } catch {
             fatalError("ModelContainer の初期化に失敗しました: \(error)")
         }
+    }
+
+    private static var isRunningTests: Bool {
+        ProcessInfo.processInfo.environment["XCTestBundlePath"] != nil
+            || NSClassFromString("XCTestCase") != nil
     }
 
     var body: some Scene {

--- a/CareNote/Features/Auth/AuthViewModel.swift
+++ b/CareNote/Features/Auth/AuthViewModel.swift
@@ -1,4 +1,5 @@
 import FirebaseAuth
+import FirebaseCore
 import GoogleSignIn
 import Observation
 import UIKit
@@ -25,6 +26,54 @@ enum AuthState: Sendable, Equatable {
     }
 }
 
+// MARK: - AuthProviding Protocol
+
+protocol AuthProviding: Sendable {
+    @MainActor func signInWithGoogle() async throws -> (userId: String, tenantId: String?)
+    func signOut() throws
+}
+
+// MARK: - AuthError
+
+enum AuthError: Error, Sendable {
+    case viewControllerNotFound
+    case googleIdTokenMissing
+}
+
+// MARK: - FirebaseGoogleAuthProvider
+
+final class FirebaseGoogleAuthProvider: AuthProviding {
+    @MainActor
+    func signInWithGoogle() async throws -> (userId: String, tenantId: String?) {
+        guard let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+              let rootViewController = windowScene.windows.first?.rootViewController else {
+            throw AuthError.viewControllerNotFound
+        }
+
+        let result = try await GIDSignIn.sharedInstance.signIn(withPresenting: rootViewController)
+
+        guard let idToken = result.user.idToken?.tokenString else {
+            throw AuthError.googleIdTokenMissing
+        }
+
+        let credential = GoogleAuthProvider.credential(
+            withIDToken: idToken,
+            accessToken: result.user.accessToken.tokenString
+        )
+
+        let authResult = try await Auth.auth().signIn(with: credential)
+        let tokenResult = try await authResult.user.getIDTokenResult()
+        let tenantId = tokenResult.claims["tenantId"] as? String
+
+        return (userId: authResult.user.uid, tenantId: tenantId)
+    }
+
+    func signOut() throws {
+        GIDSignIn.sharedInstance.signOut()
+        try Auth.auth().signOut()
+    }
+}
+
 // MARK: - AuthViewModel
 
 @Observable
@@ -34,10 +83,15 @@ final class AuthViewModel {
     var isLoading: Bool = false
     var errorMessage: String?
 
+    private let authProvider: AuthProviding
     private nonisolated(unsafe) var authStateHandle: AuthStateDidChangeListenerHandle?
 
+    init(authProvider: AuthProviding = FirebaseGoogleAuthProvider()) {
+        self.authProvider = authProvider
+    }
+
     deinit {
-        if let handle = authStateHandle {
+        if let handle = authStateHandle, FirebaseApp.app() != nil {
             Auth.auth().removeStateDidChangeListener(handle)
         }
     }
@@ -49,34 +103,14 @@ final class AuthViewModel {
         defer { isLoading = false }
 
         do {
-            guard let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
-                  let rootViewController = windowScene.windows.first?.rootViewController else {
-                errorMessage = "画面の取得に失敗しました"
-                return
-            }
+            let result = try await authProvider.signInWithGoogle()
 
-            let result = try await GIDSignIn.sharedInstance.signIn(withPresenting: rootViewController)
-
-            guard let idToken = result.user.idToken?.tokenString else {
-                errorMessage = "Google ID Token の取得に失敗しました"
-                return
-            }
-
-            let credential = GoogleAuthProvider.credential(
-                withIDToken: idToken,
-                accessToken: result.user.accessToken.tokenString
-            )
-
-            let authResult = try await Auth.auth().signIn(with: credential)
-            let tokenResult = try await authResult.user.getIDTokenResult()
-
-            guard let tenantId = tokenResult.claims["tenantId"] as? String,
-                  !tenantId.isEmpty else {
+            guard let tenantId = result.tenantId, !tenantId.isEmpty else {
                 errorMessage = "テナント情報の取得に失敗しました。管理者にお問い合わせください。"
                 return
             }
 
-            authState = .signedIn(userId: authResult.user.uid, tenantId: tenantId)
+            authState = .signedIn(userId: result.userId, tenantId: tenantId)
         } catch {
             errorMessage = "サインインに失敗しました: \(error.localizedDescription)"
         }
@@ -84,9 +118,8 @@ final class AuthViewModel {
 
     /// サインアウトする
     func signOut() {
-        GIDSignIn.sharedInstance.signOut()
         do {
-            try Auth.auth().signOut()
+            try authProvider.signOut()
         } catch {
             print("[AuthViewModel] signOut failed: \(error.localizedDescription)")
         }
@@ -96,6 +129,7 @@ final class AuthViewModel {
 
     /// Firebase Auth の認証状態を監視して authState を更新する
     func checkAuthState() {
+        guard FirebaseApp.app() != nil else { return }
         if let handle = authStateHandle {
             Auth.auth().removeStateDidChangeListener(handle)
         }

--- a/CareNote/Features/Recording/RecordingViewModel.swift
+++ b/CareNote/Features/Recording/RecordingViewModel.swift
@@ -23,13 +23,14 @@ final class RecordingViewModel {
     var audioURL: URL?
     var errorMessage: String?
 
-    private let audioRecorder = AudioRecorderService()
+    private let audioRecorder: any AudioRecording
     private var timerTask: Task<Void, Never>?
 
-    init(clientId: String, clientName: String, scene: RecordingScene) {
+    init(clientId: String, clientName: String, scene: RecordingScene, audioRecorder: any AudioRecording = AudioRecorderService()) {
         self.clientId = clientId
         self.clientName = clientName
         self.scene = scene
+        self.audioRecorder = audioRecorder
     }
 
     /// 録音を開始する
@@ -84,8 +85,8 @@ final class RecordingViewModel {
             while !Task.isCancelled {
                 try? await Task.sleep(for: .seconds(1))
                 guard !Task.isCancelled else { break }
-                if let self, let recorder = self.audioRecorder as AudioRecorderService? {
-                    self.elapsedTime = await recorder.elapsedTime
+                if let self {
+                    self.elapsedTime = await self.audioRecorder.elapsedTime
                 }
             }
         }

--- a/CareNote/Services/AudioRecorderService.swift
+++ b/CareNote/Services/AudioRecorderService.swift
@@ -11,9 +11,18 @@ enum AudioRecorderError: Error, Sendable {
     case fileNotFound
 }
 
+// MARK: - AudioRecording Protocol
+
+protocol AudioRecording: Actor {
+    var isRecording: Bool { get }
+    var elapsedTime: TimeInterval { get }
+    func startRecording() async throws -> URL
+    func stopRecording() async throws -> (url: URL, duration: TimeInterval)
+}
+
 // MARK: - AudioRecorderService
 
-actor AudioRecorderService {
+actor AudioRecorderService: AudioRecording {
 
     // MARK: - Properties
 

--- a/CareNote/Services/TranscriptionService.swift
+++ b/CareNote/Services/TranscriptionService.swift
@@ -91,7 +91,7 @@ actor TranscriptionService {
     // MARK: - Properties
 
     private let projectId: String
-    private let wifAuthService: WIFAuthService
+    private let accessTokenProvider: any AccessTokenProviding
     private let urlSession: URLSession
 
     // MARK: - Computed Properties
@@ -106,11 +106,11 @@ actor TranscriptionService {
 
     init(
         projectId: String,
-        wifAuthService: WIFAuthService,
+        accessTokenProvider: any AccessTokenProviding,
         urlSession: URLSession = .shared
     ) {
         self.projectId = projectId
-        self.wifAuthService = wifAuthService
+        self.accessTokenProvider = accessTokenProvider
         self.urlSession = urlSession
     }
 
@@ -123,7 +123,7 @@ actor TranscriptionService {
         // Get access token via WIF
         let accessToken: String
         do {
-            accessToken = try await wifAuthService.getAccessToken()
+            accessToken = try await accessTokenProvider.getAccessToken()
         } catch {
             throw TranscriptionError.authenticationFailed(error)
         }

--- a/CareNote/Services/WIFAuthService.swift
+++ b/CareNote/Services/WIFAuthService.swift
@@ -48,12 +48,18 @@ struct WIFAuthConfig: Sendable {
     }
 }
 
+// MARK: - AccessTokenProviding Protocol
+
+protocol AccessTokenProviding: Actor {
+    func getAccessToken() async throws -> String
+}
+
 // MARK: - WIFAuthService
 
 /// Workload Identity Federation authentication service (Spec S10).
 ///
 /// Flow: Firebase ID Token -> STS Token Exchange -> SA Impersonation
-actor WIFAuthService {
+actor WIFAuthService: AccessTokenProviding {
 
     // MARK: - Properties
 

--- a/CareNoteTests/AuthViewModelTests.swift
+++ b/CareNoteTests/AuthViewModelTests.swift
@@ -1,0 +1,105 @@
+@testable import CareNote
+import Testing
+
+// MARK: - MockAuthProvider
+
+final class MockAuthProvider: @unchecked Sendable, AuthProviding {
+    var signInResult: (userId: String, tenantId: String?) = ("user-1", "tenant-1")
+    var signInError: Error?
+    var signOutError: Error?
+
+    @MainActor
+    func signInWithGoogle() async throws -> (userId: String, tenantId: String?) {
+        if let error = signInError {
+            throw error
+        }
+        return signInResult
+    }
+
+    func signOut() throws {
+        if let error = signOutError {
+            throw error
+        }
+    }
+}
+
+// MARK: - AuthViewModelTests
+
+@Suite("AuthViewModel Tests")
+struct AuthViewModelTests {
+
+    @Test @MainActor
+    func signOut後はsignedOutになる() {
+        let mock = MockAuthProvider()
+        let vm = AuthViewModel(authProvider: mock)
+        vm.authState = .signedIn(userId: "user-1", tenantId: "tenant-1")
+
+        vm.signOut()
+
+        #expect(vm.authState == .signedOut)
+        #expect(vm.errorMessage == nil)
+    }
+
+    @Test @MainActor
+    func signIn成功時にsignedInになる() async {
+        let mock = MockAuthProvider()
+        mock.signInResult = (userId: "user-1", tenantId: "tenant-1")
+        let vm = AuthViewModel(authProvider: mock)
+
+        await vm.signInWithGoogle()
+
+        #expect(vm.authState == .signedIn(userId: "user-1", tenantId: "tenant-1"))
+        #expect(vm.errorMessage == nil)
+    }
+
+    @Test @MainActor
+    func tenantIdが空の場合はsignedOutのまま() async {
+        let mock = MockAuthProvider()
+        mock.signInResult = (userId: "user-1", tenantId: "")
+        let vm = AuthViewModel(authProvider: mock)
+
+        await vm.signInWithGoogle()
+
+        #expect(vm.authState == .signedOut)
+        #expect(vm.errorMessage != nil)
+    }
+
+    @Test @MainActor
+    func tenantIdがnilの場合はsignedOutのまま() async {
+        let mock = MockAuthProvider()
+        mock.signInResult = (userId: "user-1", tenantId: nil)
+        let vm = AuthViewModel(authProvider: mock)
+
+        await vm.signInWithGoogle()
+
+        #expect(vm.authState == .signedOut)
+        #expect(vm.errorMessage != nil)
+    }
+
+    @Test @MainActor
+    func signIn失敗時にerrorMessageが設定される() async {
+        let mock = MockAuthProvider()
+        mock.signInError = AuthError.viewControllerNotFound
+        let vm = AuthViewModel(authProvider: mock)
+
+        await vm.signInWithGoogle()
+
+        #expect(vm.authState == .signedOut)
+        #expect(vm.errorMessage != nil)
+        #expect(vm.errorMessage?.contains("サインインに失敗しました") == true)
+    }
+
+    @Test @MainActor
+    func signIn中はisLoadingがtrueになる() async {
+        let mock = MockAuthProvider()
+        mock.signInResult = (userId: "user-1", tenantId: "tenant-1")
+        let vm = AuthViewModel(authProvider: mock)
+
+        #expect(vm.isLoading == false)
+
+        await vm.signInWithGoogle()
+
+        // signIn完了後はisLoadingがfalseに戻る
+        #expect(vm.isLoading == false)
+    }
+}

--- a/CareNoteTests/RecordingViewModelTests.swift
+++ b/CareNoteTests/RecordingViewModelTests.swift
@@ -1,0 +1,144 @@
+@testable import CareNote
+import Foundation
+import Testing
+
+// MARK: - MockAudioRecorder
+
+actor MockAudioRecorder: AudioRecording {
+    var isRecording: Bool = false
+    var elapsedTime: TimeInterval = 0
+    var urlToReturn: URL = URL(fileURLWithPath: "/tmp/test.m4a")
+    var startError: Error?
+    var stopError: Error?
+
+    func startRecording() async throws -> URL {
+        if let error = startError {
+            throw error
+        }
+        isRecording = true
+        return urlToReturn
+    }
+
+    func stopRecording() async throws -> (url: URL, duration: TimeInterval) {
+        if let error = stopError {
+            throw error
+        }
+        isRecording = false
+        return (url: urlToReturn, duration: elapsedTime)
+    }
+
+    func setElapsedTime(_ time: TimeInterval) {
+        elapsedTime = time
+    }
+}
+
+// MARK: - RecordingViewModelTests
+
+@Suite("RecordingViewModel Tests")
+struct RecordingViewModelTests {
+
+    @Test @MainActor
+    func 初期状態はidle() {
+        let vm = RecordingViewModel(
+            clientId: "client-1",
+            clientName: "テスト利用者",
+            scene: .visit,
+            audioRecorder: MockAudioRecorder()
+        )
+
+        #expect(vm.recordingState == .idle)
+        #expect(vm.elapsedTime == 0)
+        #expect(vm.audioURL == nil)
+        #expect(vm.errorMessage == nil)
+    }
+
+    @Test @MainActor
+    func 録音開始でrecordingになる() async throws {
+        let mock = MockAudioRecorder()
+        let vm = RecordingViewModel(
+            clientId: "client-1",
+            clientName: "テスト利用者",
+            scene: .visit,
+            audioRecorder: mock
+        )
+
+        try await vm.startRecording()
+
+        #expect(vm.recordingState == .recording)
+        #expect(vm.audioURL != nil)
+    }
+
+    @Test @MainActor
+    func 録音停止でstoppedになる() async throws {
+        let mock = MockAudioRecorder()
+        await mock.setElapsedTime(10.5)
+        let vm = RecordingViewModel(
+            clientId: "client-1",
+            clientName: "テスト利用者",
+            scene: .visit,
+            audioRecorder: mock
+        )
+
+        try await vm.startRecording()
+        try await vm.stopRecording()
+
+        #expect(vm.recordingState == .stopped)
+    }
+
+    @Test @MainActor
+    func recording中に録音開始はガード() async throws {
+        let mock = MockAudioRecorder()
+        let vm = RecordingViewModel(
+            clientId: "client-1",
+            clientName: "テスト利用者",
+            scene: .visit,
+            audioRecorder: mock
+        )
+
+        try await vm.startRecording()
+        #expect(vm.recordingState == .recording)
+
+        // recording中に再度startRecordingを呼んでも状態は変わらない
+        try await vm.startRecording()
+        #expect(vm.recordingState == .recording)
+    }
+
+    @Test @MainActor
+    func idle状態から停止はガード() async throws {
+        let mock = MockAudioRecorder()
+        let vm = RecordingViewModel(
+            clientId: "client-1",
+            clientName: "テスト利用者",
+            scene: .visit,
+            audioRecorder: mock
+        )
+
+        #expect(vm.recordingState == .idle)
+
+        // idle状態でstopRecordingを呼んでも何も起きない
+        try await vm.stopRecording()
+        #expect(vm.recordingState == .idle)
+    }
+
+    @Test @MainActor
+    func formatElapsedTimeのフォーマット() {
+        let vm = RecordingViewModel(
+            clientId: "client-1",
+            clientName: "テスト利用者",
+            scene: .visit,
+            audioRecorder: MockAudioRecorder()
+        )
+
+        vm.elapsedTime = 0
+        #expect(vm.formatElapsedTime() == "00:00")
+
+        vm.elapsedTime = 65
+        #expect(vm.formatElapsedTime() == "01:05")
+
+        vm.elapsedTime = 3599
+        #expect(vm.formatElapsedTime() == "59:59")
+
+        vm.elapsedTime = 3600
+        #expect(vm.formatElapsedTime() == "60:00")
+    }
+}

--- a/CareNoteTests/TranscriptionServiceTests.swift
+++ b/CareNoteTests/TranscriptionServiceTests.swift
@@ -1,0 +1,193 @@
+@testable import CareNote
+import Foundation
+import Testing
+
+// MARK: - MockAccessTokenProvider
+
+actor MockAccessTokenProvider: AccessTokenProviding {
+    var tokenToReturn: String = "mock-access-token"
+    var errorToThrow: Error?
+
+    func setError(_ error: Error) {
+        self.errorToThrow = error
+    }
+
+    func getAccessToken() async throws -> String {
+        if let error = errorToThrow {
+            throw error
+        }
+        return tokenToReturn
+    }
+}
+
+// MARK: - MockURLProtocol
+
+final class MockURLProtocol: URLProtocol, @unchecked Sendable {
+    nonisolated(unsafe) static var requestHandler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        guard let handler = Self.requestHandler else {
+            fatalError("MockURLProtocol.requestHandler is not set")
+        }
+        do {
+            let (response, data) = try handler(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+}
+
+// MARK: - Helper
+
+private func makeMockURLSession() -> URLSession {
+    let config = URLSessionConfiguration.ephemeral
+    config.protocolClasses = [MockURLProtocol.self]
+    return URLSession(configuration: config)
+}
+
+private func makeVertexAIResponseJSON(text: String) -> Data {
+    """
+    {
+        "candidates": [{
+            "content": {
+                "parts": [{"text": "\(text)"}]
+            }
+        }]
+    }
+    """.data(using: .utf8)!
+}
+
+// MARK: - TranscriptionServiceTests
+
+@Suite("TranscriptionService Tests", .serialized)
+struct TranscriptionServiceTests {
+
+    @Test
+    func 正常系_文字起こしテキストが返る() async throws {
+        MockURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            return (response, makeVertexAIResponseJSON(text: "テスト文字起こし結果"))
+        }
+
+        let tokenProvider = MockAccessTokenProvider()
+        let service = TranscriptionService(
+            projectId: "test-project",
+            accessTokenProvider: tokenProvider,
+            urlSession: makeMockURLSession()
+        )
+
+        let result = try await service.transcribe(audioGCSUri: "gs://bucket/audio.m4a")
+        #expect(result == "テスト文字起こし結果")
+    }
+
+    @Test
+    func 認証失敗時にauthenticationFailedエラー() async {
+        let tokenProvider = MockAccessTokenProvider()
+        await tokenProvider.setError(WIFError.notAuthenticated)
+
+        let service = TranscriptionService(
+            projectId: "test-project",
+            accessTokenProvider: tokenProvider,
+            urlSession: makeMockURLSession()
+        )
+
+        await #expect(throws: TranscriptionError.self) {
+            try await service.transcribe(audioGCSUri: "gs://bucket/audio.m4a")
+        }
+    }
+
+    @Test
+    func HTTP_500でrequestFailedエラー() async {
+        MockURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 500,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            return (response, "Internal Server Error".data(using: .utf8)!)
+        }
+
+        let tokenProvider = MockAccessTokenProvider()
+        let service = TranscriptionService(
+            projectId: "test-project",
+            accessTokenProvider: tokenProvider,
+            urlSession: makeMockURLSession()
+        )
+
+        await #expect(throws: TranscriptionError.self) {
+            try await service.transcribe(audioGCSUri: "gs://bucket/audio.m4a")
+        }
+    }
+
+    @Test
+    func レスポンスにテキストがない場合noTextInResponseエラー() async {
+        MockURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            let body = """
+            {
+                "candidates": [{
+                    "content": {
+                        "parts": []
+                    }
+                }]
+            }
+            """.data(using: .utf8)!
+            return (response, body)
+        }
+
+        let tokenProvider = MockAccessTokenProvider()
+        let service = TranscriptionService(
+            projectId: "test-project",
+            accessTokenProvider: tokenProvider,
+            urlSession: makeMockURLSession()
+        )
+
+        await #expect(throws: TranscriptionError.self) {
+            try await service.transcribe(audioGCSUri: "gs://bucket/audio.m4a")
+        }
+    }
+
+    @Test
+    func 不正JSONでinvalidResponseエラー() async {
+        MockURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            return (response, "not json".data(using: .utf8)!)
+        }
+
+        let tokenProvider = MockAccessTokenProvider()
+        let service = TranscriptionService(
+            projectId: "test-project",
+            accessTokenProvider: tokenProvider,
+            urlSession: makeMockURLSession()
+        )
+
+        await #expect(throws: TranscriptionError.self) {
+            try await service.transcribe(audioGCSUri: "gs://bucket/audio.m4a")
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- Protocol 導入（`AudioRecording`, `AccessTokenProviding`, `AuthProviding`）で外部依存を DI 可能に
- `AuthViewModel` / `RecordingViewModel` / `TranscriptionService` の 17 テストケースを追加
- テスト環境での Firebase 初期化クラッシュ防止ガードを `CareNoteApp` に追加

## Changes
| ファイル | 変更内容 |
|---------|---------|
| `AudioRecorderService.swift` | `AudioRecording` protocol 抽出 |
| `WIFAuthService.swift` | `AccessTokenProviding` protocol 抽出 |
| `AuthViewModel.swift` | `AuthProviding` protocol + `FirebaseGoogleAuthProvider` + DI |
| `RecordingViewModel.swift` | `any AudioRecording` で DI |
| `TranscriptionService.swift` | `any AccessTokenProviding` で DI |
| `AuthViewModelTests.swift` | signIn/signOut 状態遷移 6テスト |
| `RecordingViewModelTests.swift` | 録音状態遷移 + フォーマット 6テスト |
| `TranscriptionServiceTests.swift` | 正常系 + エラー系 5テスト |
| `CareNoteApp.swift` | テスト環境 Firebase ガード |

## Test plan
- [x] `xcodebuild build` コンパイル成功
- [x] 17/17 テスト ALL PASS (0.132s)
- [ ] 既存機能への影響なし（デフォルト引数で呼び出し元変更不要）

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)