### PR TITLE
fix: E2Eバグ修正・削除永続化・電話シーン削除

### DIFF
--- a/CareNote.xcodeproj/project.pbxproj
+++ b/CareNote.xcodeproj/project.pbxproj
@@ -7,14 +7,13 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		067B9DD725C1C464134BF7AE /* FirebaseStorage in Frameworks */ = {isa = PBXBuildFile; productRef = DF12D570CF9D4E80C289E17D /* FirebaseStorage */; };
+		067B9DD725C1C464134BF7AE /* GoogleSignIn in Frameworks */ = {isa = PBXBuildFile; productRef = 1DFFB0082E42BA992D89756B /* GoogleSignIn */; };
 		0859FC46515B27F9B97FC1F6 /* SceneSelectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A269AFC38F3097F4CDCF8DF /* SceneSelectView.swift */; };
 		1068201B5BAD69F7242167F5 /* RecordingListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A98BBDBB5774B595F092430F /* RecordingListView.swift */; };
 		167F33E85C77C228D0FFFD44 /* RecordingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1773834D66185AC4FF05004 /* RecordingViewModel.swift */; };
 		2100435B19F33397ED56284E /* SwiftDataModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C870BA88FAE7FE80BBF4DD2 /* SwiftDataModels.swift */; };
 		26069C369BF6F266262D0692 /* ClientCacheService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F6099F7F11B6C29BA776D6C /* ClientCacheService.swift */; };
-		32FB2DE8BCDAB9EA5285250B /* GoogleSignInSwift in Frameworks */ = {isa = PBXBuildFile; productRef = C6A8EFE7C4356D0F17B5D689 /* GoogleSignInSwift */; };
-		33992576E1D90FE68CFBFFA2 /* GoogleSignIn in Frameworks */ = {isa = PBXBuildFile; productRef = 1DFFB0082E42BA992D89756B /* GoogleSignIn */; };
+		33992576E1D90FE68CFBFFA2 /* GoogleSignInSwift in Frameworks */ = {isa = PBXBuildFile; productRef = C6A8EFE7C4356D0F17B5D689 /* GoogleSignInSwift */; };
 		49EDC4D0E2DCC6A88931AC17 /* ClientSelectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FFDE09543BDF9E6601F1F2A /* ClientSelectView.swift */; };
 		4E553F6607752AD117DCE2E6 /* RecordingViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E51986CBBEC3607B0256C7A /* RecordingViewModelTests.swift */; };
 		577059F7C878462433B3DC11 /* SignInView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED7A610D0269818D75C76641 /* SignInView.swift */; };
@@ -100,9 +99,8 @@
 			files = (
 				DEA5BEF6533AC992CA56ACE1 /* FirebaseAuth in Frameworks */,
 				A6DB682594050D92691ACB99 /* FirebaseFirestore in Frameworks */,
-				067B9DD725C1C464134BF7AE /* FirebaseStorage in Frameworks */,
-				33992576E1D90FE68CFBFFA2 /* GoogleSignIn in Frameworks */,
-				32FB2DE8BCDAB9EA5285250B /* GoogleSignInSwift in Frameworks */,
+				067B9DD725C1C464134BF7AE /* GoogleSignIn in Frameworks */,
+				33992576E1D90FE68CFBFFA2 /* GoogleSignInSwift in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -307,7 +305,6 @@
 			packageProductDependencies = (
 				780EB4E4898BE568D7C4B343 /* FirebaseAuth */,
 				6C74E9D0C7331C6352278BE6 /* FirebaseFirestore */,
-				DF12D570CF9D4E80C289E17D /* FirebaseStorage */,
 				1DFFB0082E42BA992D89756B /* GoogleSignIn */,
 				C6A8EFE7C4356D0F17B5D689 /* GoogleSignInSwift */,
 			);
@@ -325,6 +322,7 @@
 				LastUpgradeCheck = 2630;
 				TargetAttributes = {
 					A016D254A1D66E8BB915EFBE = {
+						DevelopmentTeam = C96A7EHVW8;
 						ProvisioningStyle = Automatic;
 					};
 				};
@@ -487,6 +485,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
+				GENERATE_INFOPLIST_FILE = YES;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -508,6 +507,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = C96A7EHVW8;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = CareNote/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -527,6 +527,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
+				GENERATE_INFOPLIST_FILE = YES;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -604,6 +605,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = C96A7EHVW8;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = CareNote/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -690,11 +692,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 8BC989EC9182662D49B46DAF /* XCRemoteSwiftPackageReference "GoogleSignIn-iOS" */;
 			productName = GoogleSignInSwift;
-		};
-		DF12D570CF9D4E80C289E17D /* FirebaseStorage */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 37549340DB9B25215B889561 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
-			productName = FirebaseStorage;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/CareNote/App/CareNoteApp.swift
+++ b/CareNote/App/CareNoteApp.swift
@@ -79,15 +79,21 @@ struct MainTabView: View {
 
     @State private var selectedTab = 0
     @State private var recordingNavigationId = UUID()
+    @State private var recordingListViewModel: RecordingListViewModel?
 
     var body: some View {
         TabView(selection: $selectedTab) {
             NavigationStack {
-                RecordingListView(
-                    viewModel: RecordingListViewModel(
+                if let viewModel = recordingListViewModel {
+                    RecordingListView(viewModel: viewModel)
+                }
+            }
+            .task {
+                if recordingListViewModel == nil {
+                    recordingListViewModel = RecordingListViewModel(
                         recordingRepository: RecordingRepository(modelContext: modelContext)
                     )
-                )
+                }
             }
             .tabItem {
                 Label("ホーム", systemImage: "list.bullet")

--- a/CareNote/Features/Recording/RecordingViewModel.swift
+++ b/CareNote/Features/Recording/RecordingViewModel.swift
@@ -81,12 +81,13 @@ final class RecordingViewModel {
     @MainActor
     private func startTimer() {
         stopTimer()
+        let startTime = Date()
         timerTask = Task { [weak self] in
             while !Task.isCancelled {
-                try? await Task.sleep(for: .seconds(1))
+                try? await Task.sleep(for: .milliseconds(250))
                 guard !Task.isCancelled else { break }
                 if let self {
-                    self.elapsedTime = await self.audioRecorder.elapsedTime
+                    self.elapsedTime = Date().timeIntervalSince(startTime)
                 }
             }
         }

--- a/CareNote/Features/RecordingConfirm/RecordingConfirmViewModel.swift
+++ b/CareNote/Features/RecordingConfirm/RecordingConfirmViewModel.swift
@@ -100,7 +100,7 @@ final class RecordingConfirmViewModel {
             let wifService = WIFAuthService()
             let syncService = OutboxSyncService(
                 modelContainer: modelContext.container,
-                storageService: StorageService(),
+                storageService: StorageService(accessTokenProvider: wifService),
                 firestoreService: FirestoreService(),
                 transcriptionService: TranscriptionService(
                     projectId: AppConfig.gcpProject,
@@ -110,9 +110,27 @@ final class RecordingConfirmViewModel {
             )
 
             await syncService.startMonitoring()
-            await syncService.processQueueImmediately()
+            try await syncService.processQueueImmediately()
         } catch {
-            errorMessage = "保存に失敗しました: \(error.localizedDescription)"
+            // エラーチェーンを展開して詳細表示
+            let detail: String
+            if let syncError = error as? OutboxSyncError {
+                switch syncError {
+                case .uploadFailed(let inner):
+                    detail = "Upload: \(inner)"
+                case .transcriptionFailed(let inner):
+                    detail = "Transcription: \(inner)"
+                case .recordingNotFound(let id):
+                    detail = "Recording not found: \(id)"
+                case .maxRetriesExceeded(let id):
+                    detail = "Max retries: \(id)"
+                case .modelContainerNotAvailable:
+                    detail = "ModelContainer unavailable"
+                }
+            } else {
+                detail = "\(error)"
+            }
+            errorMessage = "保存に失敗しました: \(detail)"
             throw error
         }
     }

--- a/CareNote/Features/RecordingList/RecordingListView.swift
+++ b/CareNote/Features/RecordingList/RecordingListView.swift
@@ -36,8 +36,10 @@ struct RecordingListView: View {
         .refreshable {
             await viewModel.loadRecordings()
         }
-        .task {
-            await viewModel.loadRecordings()
+        .onAppear {
+            Task {
+                await viewModel.loadRecordings()
+            }
         }
         .navigationDestination(for: UUID.self) { recordingId in
             if let recording = viewModel.recordings.first(where: { $0.id == recordingId }) {

--- a/CareNote/Features/RecordingList/RecordingListViewModel.swift
+++ b/CareNote/Features/RecordingList/RecordingListViewModel.swift
@@ -38,8 +38,10 @@ final class RecordingListViewModel {
             try? FileManager.default.removeItem(atPath: audioPath)
         }
 
-        // TODO: SwiftData から削除する RecordingRepository.delete() メソッド追加
-        // MVP: リストから除外して再読み込み
+        // SwiftData から削除（関連 OutboxItem も含む）
+        try recordingRepository.delete(recording)
+
+        // リストからも除外
         recordings.removeAll { $0.id == recording.id }
     }
 }

--- a/CareNote/Features/SceneSelect/SceneSelectView.swift
+++ b/CareNote/Features/SceneSelect/SceneSelectView.swift
@@ -58,7 +58,6 @@ private struct SceneRow: View {
         switch scene {
         case .visit: return "figure.walk"
         case .meeting: return "person.3"
-        case .phone: return "phone"
         case .conference: return "rectangle.3.group.bubble"
         case .intake: return "doc.text"
         case .assessment: return "checklist"

--- a/CareNote/Models/RecordingScene.swift
+++ b/CareNote/Models/RecordingScene.swift
@@ -5,7 +5,6 @@ import Foundation
 enum RecordingScene: String, CaseIterable, Codable, Identifiable, Sendable {
     case visit = "訪問"
     case meeting = "担当者会議"
-    case phone = "電話"
     case conference = "カンファレンス"
     case intake = "インテーク"
     case assessment = "アセスメント"
@@ -17,7 +16,6 @@ enum RecordingScene: String, CaseIterable, Codable, Identifiable, Sendable {
         switch self {
         case .visit: return "訪問記録"
         case .meeting: return "担当者会議録"
-        case .phone: return "電話連絡記録"
         case .conference: return "カンファレンス記録"
         case .intake: return "インテーク記録"
         case .assessment: return "アセスメント記録"

--- a/CareNote/Repositories/RecordingRepository.swift
+++ b/CareNote/Repositories/RecordingRepository.swift
@@ -39,6 +39,31 @@ final class RecordingRepository: @unchecked Sendable {
         return try modelContext.fetch(descriptor).first
     }
 
+    /// 録音レコードと関連する OutboxItem を削除する
+    func delete(_ recording: RecordingRecord) throws {
+        let recordingId = recording.id
+
+        // 関連する OutboxItem を先に削除
+        let outboxDescriptor = FetchDescriptor<OutboxItem>(
+            predicate: #Predicate { $0.recordingId == recordingId }
+        )
+        if let outboxItems = try? modelContext.fetch(outboxDescriptor) {
+            for item in outboxItems {
+                modelContext.delete(item)
+            }
+        }
+
+        // ID で再取得してから削除（コンテキスト不整合を防ぐ）
+        let descriptor = FetchDescriptor<RecordingRecord>(
+            predicate: #Predicate { $0.id == recordingId }
+        )
+        if let record = try modelContext.fetch(descriptor).first {
+            modelContext.delete(record)
+        }
+
+        try modelContext.save()
+    }
+
     /// アップロード待ちの録音レコードを取得する
     func pendingUploads() throws -> [RecordingRecord] {
         let pending = UploadStatus.pending.rawValue

--- a/CareNote/Services/AudioRecorderService.swift
+++ b/CareNote/Services/AudioRecorderService.swift
@@ -29,7 +29,7 @@ actor AudioRecorderService: AudioRecording {
     private var audioRecorder: AVAudioRecorder?
     private var recordingURL: URL?
     private var recordingStartTime: Date?
-    private var timer: Timer?
+    private var timerTask: Task<Void, Never>?
 
     private(set) var isRecording: Bool = false
     private(set) var elapsedTime: TimeInterval = 0
@@ -131,10 +131,11 @@ actor AudioRecorderService: AudioRecording {
         stopElapsedTimeTimer()
 
         let startTime = Date()
-        timer = Timer.scheduledTimer(withTimeInterval: 0.1, repeats: true) { [weak self] _ in
-            guard let self else { return }
-            Task {
-                await self.updateElapsedTime(since: startTime)
+        timerTask = Task { [weak self] in
+            while !Task.isCancelled {
+                try? await Task.sleep(for: .milliseconds(100))
+                guard !Task.isCancelled else { break }
+                await self?.updateElapsedTime(since: startTime)
             }
         }
     }
@@ -144,7 +145,7 @@ actor AudioRecorderService: AudioRecording {
     }
 
     private func stopElapsedTimeTimer() {
-        timer?.invalidate()
-        timer = nil
+        timerTask?.cancel()
+        timerTask = nil
     }
 }

--- a/CareNote/Services/OutboxSyncService.swift
+++ b/CareNote/Services/OutboxSyncService.swift
@@ -87,20 +87,38 @@ actor OutboxSyncService {
     /// Process all pending items immediately, bypassing the isConnected check.
     /// Use this when triggering processing right after enqueuing an item,
     /// since NWPathMonitor callback may not have fired yet.
-    func processQueueImmediately() async {
+    /// Throws the last error encountered so the caller can surface it to the user.
+    func processQueueImmediately() async throws {
         guard !isProcessing else { return }
         isProcessing = true
         defer { isProcessing = false }
 
         let items = await fetchPendingItems()
+        var lastError: Error?
 
         for item in items {
+            // Skip stale items whose audio file no longer exists (e.g., app reinstalled)
+            if let recording = await fetchRecording(id: item.recordingId) {
+                if !FileManager.default.fileExists(atPath: recording.localAudioPath) {
+                    await removeItem(item.id)
+                    continue
+                }
+            } else {
+                await removeItem(item.id)
+                continue
+            }
+
             do {
                 try await processItem(item)
                 await removeItem(item.id)
             } catch {
                 await incrementRetryCount(item.id)
+                lastError = error
             }
+        }
+
+        if let error = lastError {
+            throw error
         }
     }
 

--- a/CareNote/Services/StorageService.swift
+++ b/CareNote/Services/StorageService.swift
@@ -1,4 +1,3 @@
-import FirebaseStorage
 import Foundation
 
 // MARK: - StorageError
@@ -6,27 +5,34 @@ import Foundation
 enum StorageError: Error, Sendable {
     case fileNotFound
     case uploadFailed(Error)
-    case bucketNotConfigured
 }
 
 // MARK: - StorageService
 
-/// Cloud Storage for Firebase upload service.
+/// Cloud Storage upload service using GCS JSON API with WIF authentication.
 actor StorageService {
 
     // MARK: - Properties
 
-    private let storage: Storage
+    private let bucketName: String
+    private let accessTokenProvider: any AccessTokenProviding
+    private let urlSession: URLSession
 
     // MARK: - Initialization
 
-    init(storage: Storage = Storage.storage()) {
-        self.storage = storage
+    init(
+        bucketName: String = AppConfig.storageBucket,
+        accessTokenProvider: any AccessTokenProviding,
+        urlSession: URLSession = .shared
+    ) {
+        self.bucketName = bucketName
+        self.accessTokenProvider = accessTokenProvider
+        self.urlSession = urlSession
     }
 
     // MARK: - Public Methods
 
-    /// Upload an audio file to Cloud Storage.
+    /// Upload an audio file to Cloud Storage via GCS JSON API.
     /// - Parameters:
     ///   - localURL: The local file URL of the audio recording.
     ///   - tenantId: The tenant identifier for multi-tenant path separation.
@@ -41,99 +47,44 @@ actor StorageService {
             throw StorageError.fileNotFound
         }
 
-        let storagePath = "\(tenantId)/\(recordingId).m4a"
-        let storageRef = storage.reference().child(storagePath)
-
-        let metadata = StorageMetadata()
-        metadata.contentType = "audio/mp4"
-
+        let accessToken: String
         do {
-            nonisolated(unsafe) let ref = storageRef
-            _ = try await ref.putFileAsync(from: localURL, metadata: metadata)
+            accessToken = try await accessTokenProvider.getAccessToken()
         } catch {
             throw StorageError.uploadFailed(error)
         }
 
-        // Construct gs:// URI
-        let bucket = storage.reference().bucket
-        let gcsUri = "gs://\(bucket)/\(storagePath)"
+        let objectName = "\(tenantId)/\(recordingId).m4a"
+        let encodedName = objectName.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? objectName
 
-        return gcsUri
-    }
-
-    /// Upload an audio file with progress reporting via AsyncStream.
-    /// - Parameters:
-    ///   - localURL: The local file URL of the audio recording.
-    ///   - tenantId: The tenant identifier for multi-tenant path separation.
-    ///   - recordingId: The unique recording identifier.
-    /// - Returns: A tuple of the progress stream and the upload task result.
-    func uploadAudioWithProgress(
-        localURL: URL,
-        tenantId: String,
-        recordingId: String
-    ) async throws -> (progress: AsyncStream<Double>, gcsUri: String) {
-        guard FileManager.default.fileExists(atPath: localURL.path) else {
-            throw StorageError.fileNotFound
+        guard let url = URL(
+            string: "https://storage.googleapis.com/upload/storage/v1/b/\(bucketName)/o?uploadType=media&name=\(encodedName)"
+        ) else {
+            throw StorageError.uploadFailed(
+                NSError(domain: "StorageService", code: -1, userInfo: [NSLocalizedDescriptionKey: "Invalid upload URL"])
+            )
         }
 
-        let storagePath = "\(tenantId)/\(recordingId).m4a"
-        let storageRef = storage.reference().child(storagePath)
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+        request.setValue("audio/mp4", forHTTPHeaderField: "Content-Type")
 
-        let metadata = StorageMetadata()
-        metadata.contentType = "audio/mp4"
+        let audioData = try Data(contentsOf: localURL)
+        request.httpBody = audioData
 
-        // Create AsyncStream for progress
-        var progressContinuation: AsyncStream<Double>.Continuation?
-        let progressStream = AsyncStream<Double> { continuation in
-            progressContinuation = continuation
+        let (data, response) = try await urlSession.data(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse,
+              (200...299).contains(httpResponse.statusCode)
+        else {
+            let statusCode = (response as? HTTPURLResponse)?.statusCode ?? -1
+            let body = String(data: data, encoding: .utf8) ?? "Unknown"
+            throw StorageError.uploadFailed(
+                NSError(domain: "StorageService", code: statusCode, userInfo: [NSLocalizedDescriptionKey: "HTTP \(statusCode): \(body)"])
+            )
         }
 
-        // Start upload task
-        nonisolated(unsafe) let uploadTask = storageRef.putFile(from: localURL, metadata: metadata)
-
-        // Observe progress
-        uploadTask.observe(.progress) { snapshot in
-            if let progress = snapshot.progress {
-                let fractionCompleted = progress.fractionCompleted
-                progressContinuation?.yield(fractionCompleted)
-            }
-        }
-
-        // Observe completion
-        let gcsUri: String = try await withCheckedThrowingContinuation { continuation in
-            uploadTask.observe(.success) { [weak self] _ in
-                progressContinuation?.yield(1.0)
-                progressContinuation?.finish()
-
-                guard let self else {
-                    continuation.resume(throwing: StorageError.bucketNotConfigured)
-                    return
-                }
-
-                Task {
-                    let bucket = await self.getBucket()
-                    let uri = "gs://\(bucket)/\(storagePath)"
-                    continuation.resume(returning: uri)
-                }
-            }
-
-            uploadTask.observe(.failure) { snapshot in
-                progressContinuation?.finish()
-                let error = snapshot.error ?? NSError(
-                    domain: "StorageService",
-                    code: -1,
-                    userInfo: [NSLocalizedDescriptionKey: "Upload failed"]
-                )
-                continuation.resume(throwing: StorageError.uploadFailed(error))
-            }
-        }
-
-        return (progress: progressStream, gcsUri: gcsUri)
-    }
-
-    // MARK: - Private Methods
-
-    private func getBucket() -> String {
-        storage.reference().bucket
+        return "gs://\(bucketName)/\(objectName)"
     }
 }

--- a/firestore.rules
+++ b/firestore.rules
@@ -2,13 +2,9 @@ rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
 
-    function isTenantMember(tenantId) {
-      return request.auth != null
-        && exists(/databases/$(database)/documents/tenants/$(tenantId)/members/$(request.auth.uid));
-    }
-
     match /tenants/{tenantId}/{document=**} {
-      allow read, write: if isTenantMember(tenantId);
+      allow read, write: if request.auth != null
+        && request.auth.token.tenantId == tenantId;
     }
   }
 }

--- a/project.yml
+++ b/project.yml
@@ -31,6 +31,7 @@ targets:
         SWIFT_VERSION: "6.0"
         GENERATE_INFOPLIST_FILE: false
         CODE_SIGN_STYLE: Automatic
+        DEVELOPMENT_TEAM: C96A7EHVW8
       configs:
         Debug:
           SWIFT_ACTIVE_COMPILATION_CONDITIONS: DEBUG
@@ -41,8 +42,6 @@ targets:
         product: FirebaseAuth
       - package: firebase-ios-sdk
         product: FirebaseFirestore
-      - package: firebase-ios-sdk
-        product: FirebaseStorage
       - package: GoogleSignIn-iOS
         product: GoogleSignIn
       - package: GoogleSignIn-iOS
@@ -60,3 +59,4 @@ targets:
     settings:
       base:
         SWIFT_VERSION: "6.0"
+        GENERATE_INFOPLIST_FILE: true


### PR DESCRIPTION
## Summary
- 録音削除の永続化: SwiftData delete + OutboxItem連動削除、MainTabViewで@StateによるViewModel保持
- StorageService: Firebase SDK → GCS JSON API (WIF認証) に書き換え
- タイマー・AudioRecorder修正: Date()ベース計算、Timer→Task.sleepループ
- OutboxSyncService: processQueueImmediately()追加、staleアイテム自動除去
- 電話シーン削除 (iOSが通話録音APIを第三者アプリに提供していないため)
- Firestoreルール: custom claim (tenantId) ベースに変更
- デバッグprint文全削除、.task/.onAppear重複解消

## Test plan
- [x] 実機で録音→アップロード→文字起こしのE2Eフロー動作確認済み
- [x] 録音削除後、タブ切替しても復活しないことを実機確認済み
- [x] 電話シーンがシーン選択画面に表示されないことを確認済み
- [x] ビルド成功・ユニットテスト全パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)