### PR TITLE
feat: 録音の一時停止/再開機能を追加

### DIFF
--- a/CareNote/Features/Recording/RecordingView.swift
+++ b/CareNote/Features/Recording/RecordingView.swift
@@ -31,9 +31,9 @@ struct RecordingView: View {
             // Timer Display
             Text(viewModel.formatElapsedTime())
                 .font(.system(size: 72, weight: .light, design: .monospaced))
-                .foregroundStyle(viewModel.recordingState == .recording ? .red : .primary)
+                .foregroundStyle(timerColor)
 
-            // Pulse Animation
+            // Pulse Animation & Buttons
             ZStack {
                 if viewModel.recordingState == .recording {
                     Circle()
@@ -57,31 +57,46 @@ struct RecordingView: View {
                         )
                 }
 
-                // Record Button
-                Button {
-                    Task {
-                        await handleRecordButtonTap()
-                    }
-                } label: {
-                    Circle()
-                        .fill(viewModel.recordingState == .recording ? .red : .red.opacity(0.85))
-                        .frame(width: 80, height: 80)
-                        .overlay {
-                            if viewModel.recordingState == .recording {
-                                RoundedRectangle(cornerRadius: 6)
-                                    .fill(.white)
-                                    .frame(width: 28, height: 28)
-                            } else {
-                                Circle()
-                                    .fill(.white)
-                                    .frame(width: 28, height: 28)
-                            }
+                HStack(spacing: 40) {
+                    // Main Button: Start / Pause / Resume
+                    Button {
+                        Task {
+                            await handleMainButtonTap()
                         }
-                        .shadow(color: .red.opacity(0.3), radius: 8, y: 4)
+                    } label: {
+                        Circle()
+                            .fill(mainButtonColor)
+                            .frame(width: 80, height: 80)
+                            .overlay {
+                                mainButtonIcon
+                            }
+                            .shadow(color: .red.opacity(0.3), radius: 8, y: 4)
+                    }
+                    .buttonStyle(.plain)
+
+                    // Stop Button (visible during recording or paused)
+                    if viewModel.recordingState == .recording || viewModel.recordingState == .paused {
+                        Button {
+                            Task {
+                                try? await viewModel.stopRecording()
+                            }
+                        } label: {
+                            Circle()
+                                .fill(.gray.opacity(0.2))
+                                .frame(width: 56, height: 56)
+                                .overlay {
+                                    RoundedRectangle(cornerRadius: 4)
+                                        .fill(.red)
+                                        .frame(width: 20, height: 20)
+                                }
+                        }
+                        .buttonStyle(.plain)
+                        .transition(.scale.combined(with: .opacity))
+                    }
                 }
-                .buttonStyle(.plain)
             }
             .frame(height: 180)
+            .animation(.easeInOut(duration: 0.2), value: viewModel.recordingState)
 
             // State Label
             Text(stateLabel)
@@ -100,7 +115,7 @@ struct RecordingView: View {
             }
         }
         .padding()
-        .navigationBarBackButtonHidden(viewModel.recordingState == .recording)
+        .navigationBarBackButtonHidden(viewModel.recordingState == .recording || viewModel.recordingState == .paused)
         .navigationDestination(isPresented: $navigateToConfirm) {
             if let url = viewModel.audioURL {
                 RecordingConfirmView(
@@ -131,6 +146,14 @@ struct RecordingView: View {
 
     // MARK: - Private
 
+    private var timerColor: Color {
+        switch viewModel.recordingState {
+        case .recording: return .red
+        case .paused: return .orange
+        default: return .primary
+        }
+    }
+
     private var stateLabel: String {
         switch viewModel.recordingState {
         case .idle: return "タップして録音開始"
@@ -140,15 +163,42 @@ struct RecordingView: View {
         }
     }
 
+    private var mainButtonColor: Color {
+        switch viewModel.recordingState {
+        case .idle, .stopped: return .red.opacity(0.85)
+        case .recording: return .red
+        case .paused: return .green
+        }
+    }
+
+    @ViewBuilder
+    private var mainButtonIcon: some View {
+        switch viewModel.recordingState {
+        case .idle, .stopped:
+            Circle()
+                .fill(.white)
+                .frame(width: 28, height: 28)
+        case .recording:
+            Image(systemName: "pause.fill")
+                .font(.title2)
+                .foregroundStyle(.white)
+        case .paused:
+            Image(systemName: "play.fill")
+                .font(.title2)
+                .foregroundStyle(.white)
+                .offset(x: 2)
+        }
+    }
+
     @MainActor
-    private func handleRecordButtonTap() async {
+    private func handleMainButtonTap() async {
         switch viewModel.recordingState {
         case .idle, .stopped:
             try? await viewModel.startRecording()
         case .recording:
-            try? await viewModel.stopRecording()
+            try? await viewModel.pauseRecording()
         case .paused:
-            break
+            try? await viewModel.resumeRecording()
         }
     }
 }

--- a/CareNote/Features/Recording/RecordingViewModel.swift
+++ b/CareNote/Features/Recording/RecordingViewModel.swift
@@ -25,6 +25,7 @@ final class RecordingViewModel {
 
     private let audioRecorder: any AudioRecording
     private var timerTask: Task<Void, Never>?
+    private var accumulatedTime: TimeInterval = 0
 
     init(clientId: String, clientName: String, scene: RecordingScene, audioRecorder: any AudioRecording = AudioRecorderService()) {
         self.clientId = clientId
@@ -43,6 +44,7 @@ final class RecordingViewModel {
             audioURL = url
             recordingState = .recording
             elapsedTime = 0
+            accumulatedTime = 0
             errorMessage = nil
             startTimer()
         } catch {
@@ -51,10 +53,41 @@ final class RecordingViewModel {
         }
     }
 
+    /// 録音を一時停止する
+    @MainActor
+    func pauseRecording() async throws {
+        guard recordingState == .recording else { return }
+
+        do {
+            try await audioRecorder.pauseRecording()
+            recordingState = .paused
+            accumulatedTime = elapsedTime
+            stopTimer()
+        } catch {
+            errorMessage = "一時停止に失敗しました: \(error.localizedDescription)"
+            throw error
+        }
+    }
+
+    /// 録音を再開する
+    @MainActor
+    func resumeRecording() async throws {
+        guard recordingState == .paused else { return }
+
+        do {
+            try await audioRecorder.resumeRecording()
+            recordingState = .recording
+            startTimer()
+        } catch {
+            errorMessage = "録音の再開に失敗しました: \(error.localizedDescription)"
+            throw error
+        }
+    }
+
     /// 録音を停止する
     @MainActor
     func stopRecording() async throws {
-        guard recordingState == .recording else { return }
+        guard recordingState == .recording || recordingState == .paused else { return }
 
         do {
             let result = try await audioRecorder.stopRecording()
@@ -82,12 +115,13 @@ final class RecordingViewModel {
     private func startTimer() {
         stopTimer()
         let startTime = Date()
+        let baseTime = accumulatedTime
         timerTask = Task { [weak self] in
             while !Task.isCancelled {
                 try? await Task.sleep(for: .milliseconds(250))
                 guard !Task.isCancelled else { break }
                 if let self {
-                    self.elapsedTime = Date().timeIntervalSince(startTime)
+                    self.elapsedTime = baseTime + Date().timeIntervalSince(startTime)
                 }
             }
         }

--- a/CareNote/Services/AudioRecorderService.swift
+++ b/CareNote/Services/AudioRecorderService.swift
@@ -15,8 +15,11 @@ enum AudioRecorderError: Error, Sendable {
 
 protocol AudioRecording: Actor {
     var isRecording: Bool { get }
+    var isPaused: Bool { get }
     var elapsedTime: TimeInterval { get }
     func startRecording() async throws -> URL
+    func pauseRecording() async throws
+    func resumeRecording() async throws
     func stopRecording() async throws -> (url: URL, duration: TimeInterval)
 }
 
@@ -32,7 +35,9 @@ actor AudioRecorderService: AudioRecording {
     private var timerTask: Task<Void, Never>?
 
     private(set) var isRecording: Bool = false
+    private(set) var isPaused: Bool = false
     private(set) var elapsedTime: TimeInterval = 0
+    private var accumulatedTime: TimeInterval = 0
 
     // MARK: - Recording Settings
 
@@ -83,7 +88,9 @@ actor AudioRecorderService: AudioRecording {
             recordingURL = fileURL
             recordingStartTime = Date()
             isRecording = true
+            isPaused = false
             elapsedTime = 0
+            accumulatedTime = 0
 
             startElapsedTimeTimer()
 
@@ -91,6 +98,34 @@ actor AudioRecorderService: AudioRecording {
         } catch {
             throw AudioRecorderError.recordingFailed(error)
         }
+    }
+
+    /// Pause the current recording.
+    func pauseRecording() async throws {
+        guard isRecording, !isPaused, let recorder = audioRecorder else {
+            throw AudioRecorderError.notRecording
+        }
+
+        recorder.pause()
+        isPaused = true
+
+        // Accumulate elapsed time and stop timer
+        if let startTime = recordingStartTime {
+            accumulatedTime += Date().timeIntervalSince(startTime)
+        }
+        stopElapsedTimeTimer()
+    }
+
+    /// Resume the current recording after pause.
+    func resumeRecording() async throws {
+        guard isRecording, isPaused, let recorder = audioRecorder else {
+            throw AudioRecorderError.notRecording
+        }
+
+        recorder.record()
+        isPaused = false
+        recordingStartTime = Date()
+        startElapsedTimeTimer()
     }
 
     /// Stop the current recording.
@@ -102,9 +137,16 @@ actor AudioRecorderService: AudioRecording {
 
         recorder.stop()
 
-        let duration = recorder.currentTime > 0
-            ? recorder.currentTime
-            : Date().timeIntervalSince(recordingStartTime ?? Date())
+        // Calculate total duration including accumulated paused segments
+        let currentSegment: TimeInterval
+        if isPaused {
+            currentSegment = 0
+        } else if let startTime = recordingStartTime {
+            currentSegment = Date().timeIntervalSince(startTime)
+        } else {
+            currentSegment = 0
+        }
+        let duration = accumulatedTime + currentSegment
 
         stopElapsedTimeTimer()
 
@@ -121,6 +163,8 @@ actor AudioRecorderService: AudioRecording {
         recordingURL = nil
         recordingStartTime = nil
         isRecording = false
+        isPaused = false
+        accumulatedTime = 0
 
         return (url: url, duration: duration)
     }
@@ -131,17 +175,18 @@ actor AudioRecorderService: AudioRecording {
         stopElapsedTimeTimer()
 
         let startTime = Date()
+        let baseTime = accumulatedTime
         timerTask = Task { [weak self] in
             while !Task.isCancelled {
                 try? await Task.sleep(for: .milliseconds(100))
                 guard !Task.isCancelled else { break }
-                await self?.updateElapsedTime(since: startTime)
+                await self?.updateElapsedTime(since: startTime, baseTime: baseTime)
             }
         }
     }
 
-    private func updateElapsedTime(since startTime: Date) {
-        elapsedTime = Date().timeIntervalSince(startTime)
+    private func updateElapsedTime(since startTime: Date, baseTime: TimeInterval) {
+        elapsedTime = baseTime + Date().timeIntervalSince(startTime)
     }
 
     private func stopElapsedTimeTimer() {

--- a/CareNoteTests/RecordingViewModelTests.swift
+++ b/CareNoteTests/RecordingViewModelTests.swift
@@ -6,17 +6,35 @@ import Testing
 
 actor MockAudioRecorder: AudioRecording {
     var isRecording: Bool = false
+    var isPaused: Bool = false
     var elapsedTime: TimeInterval = 0
     var urlToReturn: URL = URL(fileURLWithPath: "/tmp/test.m4a")
     var startError: Error?
     var stopError: Error?
+    var pauseError: Error?
+    var resumeError: Error?
 
     func startRecording() async throws -> URL {
         if let error = startError {
             throw error
         }
         isRecording = true
+        isPaused = false
         return urlToReturn
+    }
+
+    func pauseRecording() async throws {
+        if let error = pauseError {
+            throw error
+        }
+        isPaused = true
+    }
+
+    func resumeRecording() async throws {
+        if let error = resumeError {
+            throw error
+        }
+        isPaused = false
     }
 
     func stopRecording() async throws -> (url: URL, duration: TimeInterval) {
@@ -24,6 +42,7 @@ actor MockAudioRecorder: AudioRecording {
             throw error
         }
         isRecording = false
+        isPaused = false
         return (url: urlToReturn, duration: elapsedTime)
     }
 
@@ -117,6 +136,90 @@ struct RecordingViewModelTests {
 
         // idle状態でstopRecordingを呼んでも何も起きない
         try await vm.stopRecording()
+        #expect(vm.recordingState == .idle)
+    }
+
+    @Test @MainActor
+    func 録音一時停止でpausedになる() async throws {
+        let mock = MockAudioRecorder()
+        let vm = RecordingViewModel(
+            clientId: "client-1",
+            clientName: "テスト利用者",
+            scene: .visit,
+            audioRecorder: mock
+        )
+
+        try await vm.startRecording()
+        #expect(vm.recordingState == .recording)
+
+        try await vm.pauseRecording()
+        #expect(vm.recordingState == .paused)
+    }
+
+    @Test @MainActor
+    func 一時停止から再開でrecordingになる() async throws {
+        let mock = MockAudioRecorder()
+        let vm = RecordingViewModel(
+            clientId: "client-1",
+            clientName: "テスト利用者",
+            scene: .visit,
+            audioRecorder: mock
+        )
+
+        try await vm.startRecording()
+        try await vm.pauseRecording()
+        #expect(vm.recordingState == .paused)
+
+        try await vm.resumeRecording()
+        #expect(vm.recordingState == .recording)
+    }
+
+    @Test @MainActor
+    func 一時停止中に停止でstoppedになる() async throws {
+        let mock = MockAudioRecorder()
+        await mock.setElapsedTime(15.0)
+        let vm = RecordingViewModel(
+            clientId: "client-1",
+            clientName: "テスト利用者",
+            scene: .visit,
+            audioRecorder: mock
+        )
+
+        try await vm.startRecording()
+        try await vm.pauseRecording()
+        #expect(vm.recordingState == .paused)
+
+        try await vm.stopRecording()
+        #expect(vm.recordingState == .stopped)
+    }
+
+    @Test @MainActor
+    func idle状態から一時停止はガード() async throws {
+        let mock = MockAudioRecorder()
+        let vm = RecordingViewModel(
+            clientId: "client-1",
+            clientName: "テスト利用者",
+            scene: .visit,
+            audioRecorder: mock
+        )
+
+        #expect(vm.recordingState == .idle)
+        try await vm.pauseRecording()
+        #expect(vm.recordingState == .idle)
+    }
+
+    @Test @MainActor
+    func idle状態から再開はガード() async throws {
+        let mock = MockAudioRecorder()
+        let vm = RecordingViewModel(
+            clientId: "client-1",
+            clientName: "テスト利用者",
+            scene: .visit,
+            audioRecorder: mock
+        )
+
+        #expect(vm.recordingState == .idle)
+        try await vm.resumeRecording()
         #expect(vm.recordingState == .idle)
     }
 


### PR DESCRIPTION
## Summary
- 録音中にタップで一時停止、再タップで再開できる機能を追加
- 停止ボタンをメインボタンから分離（右横に配置）し、一時停止中でも録音完了可能に
- 経過時間は一時停止中カウント停止、一時停止中はタイマーがオレンジ色に変化

## Changes
- `AudioRecorderService`: `pauseRecording()` / `resumeRecording()` 追加（AVAudioRecorder.pause/record）
- `RecordingViewModel`: pause/resume ロジック + accumulatedTime ベースのタイマー
- `RecordingView`: UI刷新（一時停止/再開アイコン切替、停止ボタン分離）
- テスト: 11テスト全PASS（新規5テスト追加）

## Test plan
- [x] ビルド成功（BUILD SUCCEEDED）
- [x] 全11テストPASS
- [ ] シミュレータで録音→一時停止→再開→停止の操作確認
- [ ] 一時停止中に停止ボタンで録音完了の確認
- [ ] 経過時間が一時停止中に停止することの確認

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)