### PR TITLE
feat: エラー時の再試行ボタンを追加

### DIFF
--- a/CareNote/Features/RecordingList/RecordingListView.swift
+++ b/CareNote/Features/RecordingList/RecordingListView.swift
@@ -43,7 +43,9 @@ struct RecordingListView: View {
         }
         .navigationDestination(for: UUID.self) { recordingId in
             if let recording = viewModel.recordings.first(where: { $0.id == recordingId }) {
-                RecordingDetailView(recording: recording)
+                RecordingDetailView(recording: recording) {
+                    try await viewModel.retryRecording(recording)
+                }
             }
         }
     }
@@ -142,6 +144,8 @@ private struct TranscriptionStatusBadge: View {
 
 struct RecordingDetailView: View {
     let recording: RecordingRecord
+    var onRetry: (() async throws -> Void)?
+    @State private var isRetrying = false
 
     var body: some View {
         ScrollView {
@@ -184,8 +188,34 @@ struct RecordingDetailView: View {
                                 .foregroundStyle(.secondary)
                         }
                     } else if recording.transcriptionStatus == TranscriptionStatus.error.rawValue {
-                        Text("文字起こしに失敗しました")
-                            .foregroundStyle(.red)
+                        VStack(alignment: .leading, spacing: 12) {
+                            Text("文字起こしに失敗しました")
+                                .foregroundStyle(.red)
+
+                            if let onRetry {
+                                Button {
+                                    Task {
+                                        isRetrying = true
+                                        try? await onRetry()
+                                        isRetrying = false
+                                    }
+                                } label: {
+                                    HStack {
+                                        if isRetrying {
+                                            ProgressView()
+                                                .controlSize(.small)
+                                        } else {
+                                            Image(systemName: "arrow.clockwise")
+                                        }
+                                        Text("再試行")
+                                    }
+                                    .frame(maxWidth: .infinity)
+                                }
+                                .buttonStyle(.borderedProminent)
+                                .tint(.blue)
+                                .disabled(isRetrying)
+                            }
+                        }
                     } else {
                         Text("文字起こし待機中")
                             .foregroundStyle(.secondary)

--- a/CareNote/Features/RecordingList/RecordingListViewModel.swift
+++ b/CareNote/Features/RecordingList/RecordingListViewModel.swift
@@ -29,6 +29,19 @@ final class RecordingListViewModel {
         isLoading = false
     }
 
+    /// 録音の文字起こしを再試行する
+    @MainActor
+    func retryRecording(_ recording: RecordingRecord) async throws {
+        // 既存の OutboxItem を削除して新規作成（retryCount リセット）
+        try recordingRepository.resetOutboxItem(for: recording.id)
+
+        // ステータスをリセット
+        recording.uploadStatus = UploadStatus.pending.rawValue
+        recording.transcriptionStatus = TranscriptionStatus.pending.rawValue
+        recording.transcription = nil
+        try recordingRepository.save()
+    }
+
     /// 録音を削除する
     @MainActor
     func deleteRecording(_ recording: RecordingRecord) async throws {

--- a/CareNote/Repositories/RecordingRepository.swift
+++ b/CareNote/Repositories/RecordingRepository.swift
@@ -64,6 +64,27 @@ final class RecordingRepository: @unchecked Sendable {
         try modelContext.save()
     }
 
+    /// 現在のコンテキスト変更を保存する
+    func save() throws {
+        try modelContext.save()
+    }
+
+    /// 指定録音の OutboxItem を削除し、新しいものを作成する（リトライリセット）
+    func resetOutboxItem(for recordingId: UUID) throws {
+        let outboxDescriptor = FetchDescriptor<OutboxItem>(
+            predicate: #Predicate { $0.recordingId == recordingId }
+        )
+        if let items = try? modelContext.fetch(outboxDescriptor) {
+            for item in items {
+                modelContext.delete(item)
+            }
+        }
+
+        let newItem = OutboxItem(recordingId: recordingId)
+        modelContext.insert(newItem)
+        try modelContext.save()
+    }
+
     /// アップロード待ちの録音レコードを取得する
     func pendingUploads() throws -> [RecordingRecord] {
         let pending = UploadStatus.pending.rawValue

--- a/CareNote/Services/OutboxSyncService.swift
+++ b/CareNote/Services/OutboxSyncService.swift
@@ -347,6 +347,23 @@ actor OutboxSyncService {
         guard let item = try? context.fetch(descriptor).first else { return }
 
         item.retryCount += 1
+
+        // 最大リトライ超過時、RecordingRecord のステータスを error に更新
+        if item.retryCount >= Self.maxRetryCount {
+            let recordingId = item.recordingId
+            let recDescriptor = FetchDescriptor<RecordingRecord>(
+                predicate: #Predicate<RecordingRecord> { $0.id == recordingId }
+            )
+            if let record = try? context.fetch(recDescriptor).first {
+                if record.uploadStatus == UploadStatus.pending.rawValue {
+                    record.uploadStatus = UploadStatus.error.rawValue
+                }
+                if record.transcriptionStatus != TranscriptionStatus.done.rawValue {
+                    record.transcriptionStatus = TranscriptionStatus.error.rawValue
+                }
+            }
+        }
+
         try? context.save()
     }
 }


### PR DESCRIPTION
## Summary
- 録音詳細画面で文字起こし/アップロード失敗時に「再試行」ボタンを表示
- OutboxItem再作成（retryCountリセット）+ RecordingRecordのステータスをpendingにリセット
- OutboxSyncServiceで最大リトライ超過時にRecordingRecordのステータスをerrorに更新するよう修正

## Changes
- `RecordingListView.swift`: RecordingDetailViewにエラー時の再試行ボタンUI追加
- `RecordingListViewModel.swift`: `retryRecording()` メソッド追加
- `RecordingRepository.swift`: `resetOutboxItem()` / `save()` メソッド追加
- `OutboxSyncService.swift`: `incrementRetryCount()` でmax超過時にRecordingRecordステータスをerror更新

## Test plan
- [x] ビルド成功（BUILD SUCCEEDED）
- [x] 全22テストPASS
- [ ] エラー状態の録音詳細画面で再試行ボタンが表示されることを確認
- [ ] 再試行後にステータスがpendingにリセットされることを確認

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)