### PR TITLE
test: 再試行機能のユニットテスト追加 (#22)

### DIFF
--- a/CareNote.xcodeproj/project.pbxproj
+++ b/CareNote.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		2100435B19F33397ED56284E /* SwiftDataModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C870BA88FAE7FE80BBF4DD2 /* SwiftDataModels.swift */; };
 		26069C369BF6F266262D0692 /* ClientCacheService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F6099F7F11B6C29BA776D6C /* ClientCacheService.swift */; };
 		33992576E1D90FE68CFBFFA2 /* GoogleSignInSwift in Frameworks */ = {isa = PBXBuildFile; productRef = C6A8EFE7C4356D0F17B5D689 /* GoogleSignInSwift */; };
+		47FE4B218F49277FBB05F518 /* RecordingListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88B74F6BC7FCB2B9178B42F7 /* RecordingListViewModelTests.swift */; };
 		49EDC4D0E2DCC6A88931AC17 /* ClientSelectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FFDE09543BDF9E6601F1F2A /* ClientSelectView.swift */; };
 		4E553F6607752AD117DCE2E6 /* RecordingViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E51986CBBEC3607B0256C7A /* RecordingViewModelTests.swift */; };
 		577059F7C878462433B3DC11 /* SignInView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED7A610D0269818D75C76641 /* SignInView.swift */; };
@@ -35,6 +36,8 @@
 		ACF047650FB8467229A5C694 /* RecordingScene.swift in Sources */ = {isa = PBXBuildFile; fileRef = B19118D3C407ABA870A521B2 /* RecordingScene.swift */; };
 		AFC68317B2584D1DD4BD0DEC /* CareNoteApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F9FC31CCE425A0E9107ACB3 /* CareNoteApp.swift */; };
 		B64BA4F7909AFDD553C357F5 /* RecordingListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 933487C9E5291192E20D3FD6 /* RecordingListViewModel.swift */; };
+		B699C2BBB845DE4A8ACC0619 /* RecordingRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13ED2870967AA1A35CE8FA37 /* RecordingRepositoryTests.swift */; };
+		C6072255D88F74D009713EF5 /* OutboxSyncServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 042E6E584A73ED207A24A590 /* OutboxSyncServiceTests.swift */; };
 		C60B40FD6A5D17715EAE0AD4 /* AuthViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BD36BBA888E8960D96DC910 /* AuthViewModelTests.swift */; };
 		C6CF4C9D8589E6E86057F63E /* RecordingConfirmView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96BF9442D22A121622206F23 /* RecordingConfirmView.swift */; };
 		C74386AC37344205E71E5B2B /* AppConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D1751BC835BB28519295961 /* AppConfig.swift */; };
@@ -59,6 +62,8 @@
 		0201FF49E15F02E9E9054426 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		036156B4FFB1416DCC51D265 /* AuthViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthViewModel.swift; sourceTree = "<group>"; };
 		037EF32E53608FE7657893D8 /* RecordingConfirmViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingConfirmViewModel.swift; sourceTree = "<group>"; };
+		042E6E584A73ED207A24A590 /* OutboxSyncServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OutboxSyncServiceTests.swift; sourceTree = "<group>"; };
+		13ED2870967AA1A35CE8FA37 /* RecordingRepositoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingRepositoryTests.swift; sourceTree = "<group>"; };
 		1CEEA689FBC6B94B6C315907 /* CareNote.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = CareNote.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		1D1751BC835BB28519295961 /* AppConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfig.swift; sourceTree = "<group>"; };
 		2D764EF3D3EA6CDB7FD4A7B9 /* CareNoteTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = CareNoteTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -75,6 +80,7 @@
 		7452B80D90D9172B77475447 /* ClientSelectViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientSelectViewModel.swift; sourceTree = "<group>"; };
 		7C870BA88FAE7FE80BBF4DD2 /* SwiftDataModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftDataModels.swift; sourceTree = "<group>"; };
 		7E51986CBBEC3607B0256C7A /* RecordingViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingViewModelTests.swift; sourceTree = "<group>"; };
+		88B74F6BC7FCB2B9178B42F7 /* RecordingListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingListViewModelTests.swift; sourceTree = "<group>"; };
 		933487C9E5291192E20D3FD6 /* RecordingListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingListViewModel.swift; sourceTree = "<group>"; };
 		96BF9442D22A121622206F23 /* RecordingConfirmView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingConfirmView.swift; sourceTree = "<group>"; };
 		97B373FAB82B749E309A7CA8 /* RecordingRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingRepository.swift; sourceTree = "<group>"; };
@@ -226,6 +232,9 @@
 			isa = PBXGroup;
 			children = (
 				9BD36BBA888E8960D96DC910 /* AuthViewModelTests.swift */,
+				042E6E584A73ED207A24A590 /* OutboxSyncServiceTests.swift */,
+				88B74F6BC7FCB2B9178B42F7 /* RecordingListViewModelTests.swift */,
+				13ED2870967AA1A35CE8FA37 /* RecordingRepositoryTests.swift */,
 				7E51986CBBEC3607B0256C7A /* RecordingViewModelTests.swift */,
 				46A7E7E108F739F5871EB716 /* TranscriptionServiceTests.swift */,
 			);
@@ -372,6 +381,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				C60B40FD6A5D17715EAE0AD4 /* AuthViewModelTests.swift in Sources */,
+				C6072255D88F74D009713EF5 /* OutboxSyncServiceTests.swift in Sources */,
+				47FE4B218F49277FBB05F518 /* RecordingListViewModelTests.swift in Sources */,
+				B699C2BBB845DE4A8ACC0619 /* RecordingRepositoryTests.swift in Sources */,
 				4E553F6607752AD117DCE2E6 /* RecordingViewModelTests.swift in Sources */,
 				CCA4CF007249D2BA99FD5315 /* TranscriptionServiceTests.swift in Sources */,
 			);

--- a/CareNote/Services/OutboxSyncService.swift
+++ b/CareNote/Services/OutboxSyncService.swift
@@ -337,7 +337,7 @@ actor OutboxSyncService {
     }
 
     @MainActor
-    private func incrementRetryCount(_ id: UUID) {
+    func incrementRetryCount(_ id: UUID) {
         let context = modelContainer.mainContext
 
         let descriptor = FetchDescriptor<OutboxItem>(

--- a/CareNoteTests/OutboxSyncServiceTests.swift
+++ b/CareNoteTests/OutboxSyncServiceTests.swift
@@ -1,0 +1,124 @@
+@testable import CareNote
+import Foundation
+import SwiftData
+import Testing
+
+// MARK: - Mock AccessTokenProvider
+
+private actor StubAccessTokenProvider: AccessTokenProviding {
+    func getAccessToken() async throws -> String {
+        "mock-token"
+    }
+}
+
+@Suite("OutboxSyncService incrementRetryCount Tests")
+struct OutboxSyncServiceTests {
+
+    private static func makeContainer() throws -> ModelContainer {
+        let config = ModelConfiguration(isStoredInMemoryOnly: true)
+        return try ModelContainer(
+            for: RecordingRecord.self, OutboxItem.self, ClientCache.self,
+            configurations: config
+        )
+    }
+
+    private static func makeService(container: ModelContainer) -> OutboxSyncService {
+        let tokenProvider = StubAccessTokenProvider()
+        return OutboxSyncService(
+            modelContainer: container,
+            storageService: StorageService(
+                bucketName: "test-bucket",
+                accessTokenProvider: tokenProvider
+            ),
+            firestoreService: FirestoreService(),
+            transcriptionService: TranscriptionService(
+                projectId: "test-project",
+                accessTokenProvider: tokenProvider
+            ),
+            tenantId: "test-tenant"
+        )
+    }
+
+    @Test @MainActor
+    func incrementRetryCountで通常時はretryCount増加のみ() async throws {
+        let container = try Self.makeContainer()
+        let context = container.mainContext
+        let service = Self.makeService(container: container)
+
+        let recordingId = UUID()
+        let recording = RecordingRecord(
+            id: recordingId,
+            clientId: "client-1",
+            clientName: "テスト利用者",
+            scene: RecordingScene.visit.rawValue,
+            localAudioPath: "/tmp/test.m4a"
+        )
+        context.insert(recording)
+
+        let item = OutboxItem(recordingId: recordingId, retryCount: 0)
+        context.insert(item)
+        try context.save()
+
+        await service.incrementRetryCount(item.id)
+
+        #expect(item.retryCount == 1)
+        #expect(recording.uploadStatus == UploadStatus.pending.rawValue)
+        #expect(recording.transcriptionStatus == TranscriptionStatus.pending.rawValue)
+    }
+
+    @Test @MainActor
+    func incrementRetryCountでmax超過時にステータスがerrorになる() async throws {
+        let container = try Self.makeContainer()
+        let context = container.mainContext
+        let service = Self.makeService(container: container)
+
+        let recordingId = UUID()
+        let recording = RecordingRecord(
+            id: recordingId,
+            clientId: "client-1",
+            clientName: "テスト利用者",
+            scene: RecordingScene.visit.rawValue,
+            localAudioPath: "/tmp/test.m4a"
+        )
+        context.insert(recording)
+
+        // retryCount=2 → increment で 3 に到達（maxRetryCount=3）
+        let item = OutboxItem(recordingId: recordingId, retryCount: 2)
+        context.insert(item)
+        try context.save()
+
+        await service.incrementRetryCount(item.id)
+
+        #expect(item.retryCount == 3)
+        #expect(recording.uploadStatus == UploadStatus.error.rawValue)
+        #expect(recording.transcriptionStatus == TranscriptionStatus.error.rawValue)
+    }
+
+    @Test @MainActor
+    func incrementRetryCountでtranscriptionStatusがdoneの場合は変更しない() async throws {
+        let container = try Self.makeContainer()
+        let context = container.mainContext
+        let service = Self.makeService(container: container)
+
+        let recordingId = UUID()
+        let recording = RecordingRecord(
+            id: recordingId,
+            clientId: "client-1",
+            clientName: "テスト利用者",
+            scene: RecordingScene.visit.rawValue,
+            localAudioPath: "/tmp/test.m4a",
+            uploadStatus: UploadStatus.pending.rawValue,
+            transcriptionStatus: TranscriptionStatus.done.rawValue
+        )
+        context.insert(recording)
+
+        let item = OutboxItem(recordingId: recordingId, retryCount: 2)
+        context.insert(item)
+        try context.save()
+
+        await service.incrementRetryCount(item.id)
+
+        #expect(recording.uploadStatus == UploadStatus.error.rawValue)
+        #expect(recording.transcriptionStatus == TranscriptionStatus.done.rawValue)
+    }
+}

--- a/CareNoteTests/RecordingListViewModelTests.swift
+++ b/CareNoteTests/RecordingListViewModelTests.swift
@@ -1,0 +1,87 @@
+@testable import CareNote
+import Foundation
+import SwiftData
+import Testing
+
+@Suite("RecordingListViewModel Tests")
+struct RecordingListViewModelTests {
+
+    private static func makeContainer() throws -> ModelContainer {
+        let config = ModelConfiguration(isStoredInMemoryOnly: true)
+        return try ModelContainer(
+            for: RecordingRecord.self, OutboxItem.self, ClientCache.self,
+            configurations: config
+        )
+    }
+
+    private static func makeErrorRecording(id: UUID = UUID(), context: ModelContext) -> RecordingRecord {
+        let recording = RecordingRecord(
+            id: id,
+            clientId: "client-1",
+            clientName: "テスト利用者",
+            scene: RecordingScene.visit.rawValue,
+            recordedAt: Date(),
+            durationSeconds: 30.0,
+            localAudioPath: "/tmp/test.m4a",
+            uploadStatus: UploadStatus.error.rawValue,
+            transcription: "失敗したテキスト",
+            transcriptionStatus: TranscriptionStatus.error.rawValue
+        )
+        context.insert(recording)
+        return recording
+    }
+
+    @Test @MainActor
+    func retryRecordingでステータスがpendingにリセットされる() async throws {
+        let container = try Self.makeContainer()
+        let context = container.mainContext
+        let repo = RecordingRepository(modelContext: context)
+        let vm = RecordingListViewModel(recordingRepository: repo)
+
+        let recordingId = UUID()
+        let recording = Self.makeErrorRecording(id: recordingId, context: context)
+
+        // エラー状態の OutboxItem を作成（retryCount=3）
+        let oldItem = OutboxItem(recordingId: recordingId, retryCount: 3)
+        context.insert(oldItem)
+        try context.save()
+
+        #expect(recording.uploadStatus == UploadStatus.error.rawValue)
+        #expect(recording.transcriptionStatus == TranscriptionStatus.error.rawValue)
+
+        // retryRecording を実行
+        try await vm.retryRecording(recording)
+
+        // ステータスが pending にリセットされていること
+        #expect(recording.uploadStatus == UploadStatus.pending.rawValue)
+        #expect(recording.transcriptionStatus == TranscriptionStatus.pending.rawValue)
+        #expect(recording.transcription == nil)
+
+        // OutboxItem が retryCount=0 で再作成されていること
+        let descriptor = FetchDescriptor<OutboxItem>(
+            predicate: #Predicate { $0.recordingId == recordingId }
+        )
+        let items = try context.fetch(descriptor)
+        #expect(items.count == 1)
+        #expect(items.first?.retryCount == 0)
+    }
+
+    @Test @MainActor
+    func deleteRecordingでリストから除外される() async throws {
+        let container = try Self.makeContainer()
+        let context = container.mainContext
+        let repo = RecordingRepository(modelContext: context)
+        let vm = RecordingListViewModel(recordingRepository: repo)
+
+        let recording = Self.makeErrorRecording(context: context)
+        try context.save()
+
+        // loadRecordings でリストに読み込む
+        await vm.loadRecordings()
+        #expect(vm.recordings.count == 1)
+
+        // 削除
+        try await vm.deleteRecording(recording)
+        #expect(vm.recordings.isEmpty)
+    }
+}

--- a/CareNoteTests/RecordingRepositoryTests.swift
+++ b/CareNoteTests/RecordingRepositoryTests.swift
@@ -1,0 +1,112 @@
+@testable import CareNote
+import Foundation
+import SwiftData
+import Testing
+
+@Suite("RecordingRepository Tests")
+struct RecordingRepositoryTests {
+
+    /// インメモリ ModelContainer を作成するヘルパー
+    private static func makeContainer() throws -> ModelContainer {
+        let config = ModelConfiguration(isStoredInMemoryOnly: true)
+        return try ModelContainer(
+            for: RecordingRecord.self, OutboxItem.self, ClientCache.self,
+            configurations: config
+        )
+    }
+
+    /// テスト用 RecordingRecord を作成するヘルパー
+    private static func makeRecording(id: UUID = UUID()) -> RecordingRecord {
+        RecordingRecord(
+            id: id,
+            clientId: "client-1",
+            clientName: "テスト利用者",
+            scene: RecordingScene.visit.rawValue,
+            recordedAt: Date(),
+            durationSeconds: 30.0,
+            localAudioPath: "/tmp/test.m4a"
+        )
+    }
+
+    // MARK: - resetOutboxItem
+
+    @Test @MainActor
+    func resetOutboxItemで既存OutboxItemが削除され新規作成される() throws {
+        let container = try Self.makeContainer()
+        let context = container.mainContext
+        let repo = RecordingRepository(modelContext: context)
+
+        let recordingId = UUID()
+        let recording = Self.makeRecording(id: recordingId)
+        context.insert(recording)
+
+        // 既存の OutboxItem（retryCount=2）を作成
+        let oldItem = OutboxItem(recordingId: recordingId, retryCount: 2)
+        context.insert(oldItem)
+        try context.save()
+
+        // resetOutboxItem を実行
+        try repo.resetOutboxItem(for: recordingId)
+
+        // OutboxItem が1件のみ存在し、retryCount=0 であること
+        let descriptor = FetchDescriptor<OutboxItem>(
+            predicate: #Predicate { $0.recordingId == recordingId }
+        )
+        let items = try context.fetch(descriptor)
+        #expect(items.count == 1)
+        #expect(items.first?.retryCount == 0)
+    }
+
+    @Test @MainActor
+    func resetOutboxItemでOutboxItemが存在しなくても新規作成される() throws {
+        let container = try Self.makeContainer()
+        let context = container.mainContext
+        let repo = RecordingRepository(modelContext: context)
+
+        let recordingId = UUID()
+        let recording = Self.makeRecording(id: recordingId)
+        context.insert(recording)
+        try context.save()
+
+        // OutboxItem なしの状態で resetOutboxItem を実行
+        try repo.resetOutboxItem(for: recordingId)
+
+        let descriptor = FetchDescriptor<OutboxItem>(
+            predicate: #Predicate { $0.recordingId == recordingId }
+        )
+        let items = try context.fetch(descriptor)
+        #expect(items.count == 1)
+        #expect(items.first?.retryCount == 0)
+    }
+
+    // MARK: - delete
+
+    @Test @MainActor
+    func deleteで関連OutboxItemも削除される() throws {
+        let container = try Self.makeContainer()
+        let context = container.mainContext
+        let repo = RecordingRepository(modelContext: context)
+
+        let recordingId = UUID()
+        let recording = Self.makeRecording(id: recordingId)
+        context.insert(recording)
+
+        let outboxItem = OutboxItem(recordingId: recordingId)
+        context.insert(outboxItem)
+        try context.save()
+
+        try repo.delete(recording)
+
+        // RecordingRecord が削除されていること
+        let recDescriptor = FetchDescriptor<RecordingRecord>(
+            predicate: #Predicate { $0.id == recordingId }
+        )
+        #expect(try context.fetch(recDescriptor).isEmpty)
+
+        // OutboxItem も削除されていること
+        let outboxDescriptor = FetchDescriptor<OutboxItem>(
+            predicate: #Predicate { $0.recordingId == recordingId }
+        )
+        #expect(try context.fetch(outboxDescriptor).isEmpty)
+    }
+}


### PR DESCRIPTION
## Summary
- RecordingRepositoryTests: `resetOutboxItem` の既存削除+新規作成、OutboxItemなしからの新規作成、`delete`の連動削除
- RecordingListViewModelTests: `retryRecording` のステータスリセット（error→pending）、`deleteRecording` のリスト除外
- OutboxSyncServiceTests: `incrementRetryCount` の通常時retryCount増加のみ、max超過時のステータスerror更新、transcriptionStatusがdone時の保持

## Changes
- `OutboxSyncService.incrementRetryCount` を `private` → `internal` に変更（`@testable` でテスト可能に）
- 新規テストファイル3件追加（計8テストケース）

## Test plan
- [x] 全テストSuite passed（RecordingRepository, RecordingListViewModel, OutboxSyncService）
- [x] 既存テスト（Auth, Recording, Transcription）への影響なし

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)