### PR TITLE
feat: 文字起こし結果の自動ポーリング更新 (#16)

### DIFF
--- a/CareNote/App/CareNoteApp.swift
+++ b/CareNote/App/CareNoteApp.swift
@@ -47,7 +47,7 @@ struct CareNoteApp: App {
                 case .signedOut:
                     SignInView(viewModel: authViewModel)
                 case .signedIn(_, let tenantId):
-                    MainTabView()
+                    MainTabView(tenantId: tenantId)
                         .task {
                             let cacheService = ClientCacheService(
                                 firestoreService: FirestoreService(),
@@ -77,6 +77,8 @@ extension Notification.Name {
 struct MainTabView: View {
     @Environment(\.modelContext) private var modelContext
 
+    let tenantId: String
+
     @State private var selectedTab = 0
     @State private var recordingNavigationId = UUID()
     @State private var recordingListViewModel: RecordingListViewModel?
@@ -91,7 +93,9 @@ struct MainTabView: View {
             .task {
                 if recordingListViewModel == nil {
                     recordingListViewModel = RecordingListViewModel(
-                        recordingRepository: RecordingRepository(modelContext: modelContext)
+                        recordingRepository: RecordingRepository(modelContext: modelContext),
+                        firestoreService: FirestoreService(),
+                        tenantId: tenantId
                     )
                 }
             }

--- a/CareNote/Features/RecordingList/RecordingListView.swift
+++ b/CareNote/Features/RecordingList/RecordingListView.swift
@@ -39,7 +39,11 @@ struct RecordingListView: View {
         .onAppear {
             Task {
                 await viewModel.loadRecordings()
+                viewModel.startPolling()
             }
+        }
+        .onDisappear {
+            viewModel.stopPolling()
         }
         .navigationDestination(for: UUID.self) { recordingId in
             if let recording = viewModel.recordings.first(where: { $0.id == recordingId }) {

--- a/CareNote/Features/RecordingList/RecordingListViewModel.swift
+++ b/CareNote/Features/RecordingList/RecordingListViewModel.swift
@@ -4,20 +4,30 @@ import SwiftData
 
 // MARK: - RecordingListViewModel
 
-@Observable
+@Observable @MainActor
 final class RecordingListViewModel {
     var recordings: [RecordingRecord] = []
     var isLoading: Bool = false
     var errorMessage: String?
 
     private let recordingRepository: RecordingRepository
+    private let firestoreService: FirestoreService?
+    private let tenantId: String?
 
-    init(recordingRepository: RecordingRepository) {
+    private static let pollingInterval: TimeInterval = 5.0
+    private var pollingTask: Task<Void, Never>?
+
+    init(
+        recordingRepository: RecordingRepository,
+        firestoreService: FirestoreService? = nil,
+        tenantId: String? = nil
+    ) {
         self.recordingRepository = recordingRepository
+        self.firestoreService = firestoreService
+        self.tenantId = tenantId
     }
 
     /// 録音一覧を読み込む
-    @MainActor
     func loadRecordings() async {
         isLoading = true
         do {
@@ -30,12 +40,9 @@ final class RecordingListViewModel {
     }
 
     /// 録音の文字起こしを再試行する
-    @MainActor
     func retryRecording(_ recording: RecordingRecord) async throws {
-        // 既存の OutboxItem を削除して新規作成（retryCount リセット）
         try recordingRepository.resetOutboxItem(for: recording.id)
 
-        // ステータスをリセット
         recording.uploadStatus = UploadStatus.pending.rawValue
         recording.transcriptionStatus = TranscriptionStatus.pending.rawValue
         recording.transcription = nil
@@ -43,18 +50,76 @@ final class RecordingListViewModel {
     }
 
     /// 録音を削除する
-    @MainActor
     func deleteRecording(_ recording: RecordingRecord) async throws {
-        // ローカル音声ファイルを削除
         let audioPath = recording.localAudioPath
         if FileManager.default.fileExists(atPath: audioPath) {
             try? FileManager.default.removeItem(atPath: audioPath)
         }
 
-        // SwiftData から削除（関連 OutboxItem も含む）
         try recordingRepository.delete(recording)
-
-        // リストからも除外
         recordings.removeAll { $0.id == recording.id }
+    }
+
+    // MARK: - Polling
+
+    /// processing 状態のアイテムがある間、Firestore をポーリングして更新する
+    func startPolling() {
+        stopPolling()
+        pollingTask = Task {
+            while !Task.isCancelled {
+                await pollProcessingRecordings()
+
+                if !hasProcessingRecordings() {
+                    return
+                }
+
+                try? await Task.sleep(nanoseconds: UInt64(Self.pollingInterval * 1_000_000_000))
+            }
+        }
+    }
+
+    /// ポーリングを停止する
+    func stopPolling() {
+        pollingTask?.cancel()
+        pollingTask = nil
+    }
+
+    private func hasProcessingRecordings() -> Bool {
+        let processingStatuses = [
+            TranscriptionStatus.pending.rawValue,
+            TranscriptionStatus.processing.rawValue,
+        ]
+        return recordings.contains { processingStatuses.contains($0.transcriptionStatus) && $0.firestoreId != nil }
+    }
+
+    private func pollProcessingRecordings() async {
+        guard let firestoreService, let tenantId else { return }
+
+        let processingStatuses = [
+            TranscriptionStatus.pending.rawValue,
+            TranscriptionStatus.processing.rawValue,
+        ]
+        let processingRecordings = recordings.filter {
+            processingStatuses.contains($0.transcriptionStatus) && $0.firestoreId != nil
+        }
+
+        for recording in processingRecordings {
+            guard let firestoreId = recording.firestoreId else { continue }
+
+            do {
+                guard let remote = try await firestoreService.fetchRecording(
+                    tenantId: tenantId,
+                    recordingId: firestoreId
+                ) else { continue }
+
+                if remote.transcriptionStatus != recording.transcriptionStatus {
+                    recording.transcriptionStatus = remote.transcriptionStatus
+                    recording.transcription = remote.transcription
+                    try? recordingRepository.save()
+                }
+            } catch {
+                // ポーリングエラーは静かに無視（次回リトライ）
+            }
+        }
     }
 }

--- a/CareNote/Services/FirestoreService.swift
+++ b/CareNote/Services/FirestoreService.swift
@@ -116,6 +116,44 @@ actor FirestoreService {
         }
     }
 
+    /// Fetch a single recording by Firestore document ID.
+    /// - Parameters:
+    ///   - tenantId: The tenant identifier.
+    ///   - recordingId: The Firestore document ID.
+    /// - Returns: The recording data, or nil if not found.
+    func fetchRecording(tenantId: String, recordingId: String) async throws -> FirestoreRecording? {
+        do {
+            let document = try await recordingsCollection(tenantId: tenantId)
+                .document(recordingId)
+                .getDocument()
+
+            guard document.exists, let data = document.data() else {
+                return nil
+            }
+
+            let recordedAt = (data["recordedAt"] as? Timestamp)?.dateValue() ?? Date()
+            let createdAt = (data["createdAt"] as? Timestamp)?.dateValue() ?? Date()
+            let updatedAt = (data["updatedAt"] as? Timestamp)?.dateValue() ?? Date()
+
+            return FirestoreRecording(
+                id: document.documentID,
+                clientId: data["clientId"] as? String ?? "",
+                clientName: data["clientName"] as? String ?? "",
+                scene: data["scene"] as? String ?? "",
+                recordedAt: recordedAt,
+                durationSeconds: data["durationSeconds"] as? Double ?? 0,
+                audioStoragePath: data["audioStoragePath"] as? String,
+                transcription: data["transcription"] as? String,
+                transcriptionStatus: data["transcriptionStatus"] as? String ?? TranscriptionStatus.pending.rawValue,
+                createdBy: data["createdBy"] as? String ?? "",
+                createdAt: createdAt,
+                updatedAt: updatedAt
+            )
+        } catch {
+            throw FirestoreError.operationFailed(error)
+        }
+    }
+
     /// Fetch all recordings for a given tenant.
     /// - Parameter tenantId: The tenant identifier.
     /// - Returns: An array of `FirestoreRecording` including document IDs.


### PR DESCRIPTION
## Summary
- 「処理中」の録音がある間、5秒間隔でFirestoreから最新の文字起こしステータスを自動取得
- 全件完了（done/error）後はポーリング自動停止
- 手動Pull-to-Refreshなしで文字起こし完了が反映される

## Changes
- `FirestoreService`: 単一recording取得メソッド `fetchRecording(tenantId:recordingId:)` 追加
- `RecordingListViewModel`: ポーリングロジック追加、`@MainActor`クラスレベル統一
- `RecordingListView`: `onAppear`/`onDisappear` でポーリング開始/停止
- `CareNoteApp`: `MainTabView`に`tenantId`を渡し、`FirestoreService`をViewModel注入

## Test plan
- [x] ビルド成功
- [x] 既存テスト全Suite passed
- [ ] 実機/シミュレータで録音→文字起こし処理中→自動更新を確認

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)