### PR TITLE
feat: 文字起こし結果の編集・修正機能 (#17)

### DIFF
--- a/CareNote/Features/RecordingList/RecordingListView.swift
+++ b/CareNote/Features/RecordingList/RecordingListView.swift
@@ -47,9 +47,15 @@ struct RecordingListView: View {
         }
         .navigationDestination(for: UUID.self) { recordingId in
             if let recording = viewModel.recordings.first(where: { $0.id == recordingId }) {
-                RecordingDetailView(recording: recording) {
-                    try await viewModel.retryRecording(recording)
-                }
+                RecordingDetailView(
+                    recording: recording,
+                    onRetry: {
+                        try await viewModel.retryRecording(recording)
+                    },
+                    onSave: { text in
+                        try await viewModel.saveTranscription(recording, text: text)
+                    }
+                )
             }
         }
     }
@@ -149,7 +155,11 @@ private struct TranscriptionStatusBadge: View {
 struct RecordingDetailView: View {
     let recording: RecordingRecord
     var onRetry: (() async throws -> Void)?
+    var onSave: ((String) async throws -> Void)?
     @State private var isRetrying = false
+    @State private var isEditing = false
+    @State private var editedText = ""
+    @State private var isSaving = false
 
     var body: some View {
         ScrollView {
@@ -174,11 +184,62 @@ struct RecordingDetailView: View {
 
                 // Transcription Section
                 VStack(alignment: .leading, spacing: 8) {
-                    Text("文字起こし")
-                        .font(.headline)
+                    HStack {
+                        Text("文字起こし")
+                            .font(.headline)
 
-                    if recording.transcriptionStatus == TranscriptionStatus.done.rawValue,
-                       let transcription = recording.transcription
+                        Spacer()
+
+                        if recording.transcriptionStatus == TranscriptionStatus.done.rawValue,
+                           recording.transcription != nil, !isEditing
+                        {
+                            Button {
+                                editedText = recording.transcription ?? ""
+                                isEditing = true
+                            } label: {
+                                Label("編集", systemImage: "pencil")
+                                    .font(.subheadline)
+                            }
+                        }
+                    }
+
+                    if isEditing {
+                        TextEditor(text: $editedText)
+                            .font(.body)
+                            .frame(minHeight: 200)
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 8)
+                                    .stroke(.secondary.opacity(0.3))
+                            )
+
+                        HStack {
+                            Button("キャンセル") {
+                                isEditing = false
+                            }
+                            .buttonStyle(.bordered)
+
+                            Spacer()
+
+                            Button {
+                                Task {
+                                    isSaving = true
+                                    try? await onSave?(editedText)
+                                    isEditing = false
+                                    isSaving = false
+                                }
+                            } label: {
+                                if isSaving {
+                                    ProgressView()
+                                        .controlSize(.small)
+                                } else {
+                                    Text("保存")
+                                }
+                            }
+                            .buttonStyle(.borderedProminent)
+                            .disabled(isSaving)
+                        }
+                    } else if recording.transcriptionStatus == TranscriptionStatus.done.rawValue,
+                              let transcription = recording.transcription
                     {
                         Text(transcription)
                             .font(.body)

--- a/CareNote/Features/RecordingList/RecordingListViewModel.swift
+++ b/CareNote/Features/RecordingList/RecordingListViewModel.swift
@@ -60,6 +60,22 @@ final class RecordingListViewModel {
         recordings.removeAll { $0.id == recording.id }
     }
 
+    /// 文字起こしテキストを編集・保存する（SwiftData + Firestore）
+    func saveTranscription(_ recording: RecordingRecord, text: String) async throws {
+        recording.transcription = text
+        try recordingRepository.save()
+
+        // Firestore にも同期
+        if let firestoreService, let tenantId, let firestoreId = recording.firestoreId {
+            try await firestoreService.updateTranscription(
+                tenantId: tenantId,
+                recordingId: firestoreId,
+                transcription: text,
+                status: .done
+            )
+        }
+    }
+
     // MARK: - Polling
 
     /// processing 状態のアイテムがある間、Firestore をポーリングして更新する

--- a/CareNoteTests/RecordingListViewModelTests.swift
+++ b/CareNoteTests/RecordingListViewModelTests.swift
@@ -67,6 +67,34 @@ struct RecordingListViewModelTests {
     }
 
     @Test @MainActor
+    func saveTranscriptionでテキストがSwiftDataに保存される() async throws {
+        let container = try Self.makeContainer()
+        let context = container.mainContext
+        let repo = RecordingRepository(modelContext: context)
+        let vm = RecordingListViewModel(recordingRepository: repo)
+
+        let recording = RecordingRecord(
+            id: UUID(),
+            clientId: "client-1",
+            clientName: "テスト利用者",
+            scene: RecordingScene.visit.rawValue,
+            localAudioPath: "/tmp/test.m4a",
+            transcription: "元のテキスト",
+            transcriptionStatus: TranscriptionStatus.done.rawValue
+        )
+        context.insert(recording)
+        try context.save()
+
+        try await vm.saveTranscription(recording, text: "修正後のテキスト")
+
+        #expect(recording.transcription == "修正後のテキスト")
+
+        // SwiftData に永続化されていることを確認
+        let fetched = try repo.findById(recording.id)
+        #expect(fetched?.transcription == "修正後のテキスト")
+    }
+
+    @Test @MainActor
     func deleteRecordingでリストから除外される() async throws {
         let container = try Self.makeContainer()
         let context = container.mainContext


### PR DESCRIPTION
## Summary
- RecordingDetailViewに編集ボタン追加（done状態の文字起こしのみ表示）
- TextEditorで文字起こしテキストを編集・保存可能
- SwiftData + Firestore同時保存（上書き）

## Changes
- `RecordingDetailView`: 編集ボタン、TextEditor、保存/キャンセルUI追加
- `RecordingListViewModel`: `saveTranscription()` メソッド追加
- `RecordingListViewModelTests`: saveTranscriptionテスト追加

## Test plan
- [x] ビルド成功
- [x] 全テストSuite passed
- [ ] 実機/シミュレータで文字起こし完了→編集→保存を確認

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)