### PR TITLE
refactor: AudioPlayerView品質改善

### DIFF
--- a/CareNote.xcodeproj/project.pbxproj
+++ b/CareNote.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		067B9DD725C1C464134BF7AE /* GoogleSignIn in Frameworks */ = {isa = PBXBuildFile; productRef = 1DFFB0082E42BA992D89756B /* GoogleSignIn */; };
 		0859FC46515B27F9B97FC1F6 /* SceneSelectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A269AFC38F3097F4CDCF8DF /* SceneSelectView.swift */; };
 		1068201B5BAD69F7242167F5 /* RecordingListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A98BBDBB5774B595F092430F /* RecordingListView.swift */; };
+		13A5A2945594CCE9F062EE03 /* TimeFormatting.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7B1618532B76B0B38896644 /* TimeFormatting.swift */; };
 		167F33E85C77C228D0FFFD44 /* RecordingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1773834D66185AC4FF05004 /* RecordingViewModel.swift */; };
 		2100435B19F33397ED56284E /* SwiftDataModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C870BA88FAE7FE80BBF4DD2 /* SwiftDataModels.swift */; };
 		26069C369BF6F266262D0692 /* ClientCacheService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F6099F7F11B6C29BA776D6C /* ClientCacheService.swift */; };
@@ -96,6 +97,7 @@
 		C66B8FD7F4EEDA2F428C0A1F /* ClientRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientRepository.swift; sourceTree = "<group>"; };
 		CE80E23E3C3633F29AC0F0DA /* TranscriptionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptionService.swift; sourceTree = "<group>"; };
 		DA628FEE8E8929DE6D2651EC /* GoogleService-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
+		E7B1618532B76B0B38896644 /* TimeFormatting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeFormatting.swift; sourceTree = "<group>"; };
 		E882F166342B21411BFDB30A /* FirestoreService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirestoreService.swift; sourceTree = "<group>"; };
 		EC5C0A2EB369429A8FD3D891 /* WIFAuthService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WIFAuthService.swift; sourceTree = "<group>"; };
 		ED7A610D0269818D75C76641 /* SignInView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInView.swift; sourceTree = "<group>"; };
@@ -248,6 +250,7 @@
 			isa = PBXGroup;
 			children = (
 				F2848993801DEF66A676C25D /* AppEnvironment.swift */,
+				E7B1618532B76B0B38896644 /* TimeFormatting.swift */,
 			);
 			path = Infrastructure;
 			sourceTree = "<group>";
@@ -430,6 +433,7 @@
 				577059F7C878462433B3DC11 /* SignInView.swift in Sources */,
 				8F8930B68A64B56B8FF49023 /* StorageService.swift in Sources */,
 				2100435B19F33397ED56284E /* SwiftDataModels.swift in Sources */,
+				13A5A2945594CCE9F062EE03 /* TimeFormatting.swift in Sources */,
 				867BA544A9DB963182049D63 /* TranscriptionService.swift in Sources */,
 				D68884E97DC6ABD4E1501E05 /* WIFAuthService.swift in Sources */,
 			);

--- a/CareNote/Components/AudioPlayerView.swift
+++ b/CareNote/Components/AudioPlayerView.swift
@@ -14,6 +14,7 @@ struct AudioPlayerView: View {
     @State private var totalDuration: TimeInterval = 0
     @State private var isDragging = false
     @State private var trackingTask: Task<Void, Never>?
+    @State private var errorMessage: String?
 
     var body: some View {
         VStack(spacing: 8) {
@@ -26,14 +27,14 @@ struct AudioPlayerView: View {
             .tint(.accentColor)
 
             HStack {
-                Text(formatTime(currentTime))
+                Text(formatMMSS(currentTime))
                     .font(.caption)
                     .foregroundStyle(.secondary)
                     .monospacedDigit()
 
                 Spacer()
 
-                Text(formatTime(totalDuration))
+                Text(formatMMSS(totalDuration))
                     .font(.caption)
                     .foregroundStyle(.secondary)
                     .monospacedDigit()
@@ -51,9 +52,12 @@ struct AudioPlayerView: View {
                     .foregroundStyle(.tint)
             }
             .buttonStyle(.plain)
-        }
-        .onAppear {
-            prepareDuration()
+
+            if let errorMessage {
+                Text(errorMessage)
+                    .font(.caption)
+                    .foregroundStyle(.red)
+            }
         }
         .onDisappear {
             stopPlayback()
@@ -62,12 +66,8 @@ struct AudioPlayerView: View {
 
     // MARK: - Private
 
-    private func prepareDuration() {
-        guard let p = try? AVAudioPlayer(contentsOf: audioURL) else { return }
-        totalDuration = p.duration
-    }
-
     private func startPlayback() {
+        errorMessage = nil
         do {
             let session = AVAudioSession.sharedInstance()
             try session.setCategory(.playback)
@@ -80,18 +80,18 @@ struct AudioPlayerView: View {
             totalDuration = p.duration
             startTracking()
         } catch {
-            // 再生エラーは静かに無視
+            errorMessage = "再生に失敗しました"
         }
     }
 
     private func stopPlayback() {
+        trackingTask?.cancel()
+        trackingTask = nil
         player?.stop()
         player = nil
         isPlaying = false
         progress = 0
         currentTime = 0
-        trackingTask?.cancel()
-        trackingTask = nil
     }
 
     private func seekTo(progress: Double) {
@@ -122,12 +122,5 @@ struct AudioPlayerView: View {
                 }
             }
         }
-    }
-
-    private func formatTime(_ time: TimeInterval) -> String {
-        let totalSeconds = Int(time)
-        let minutes = totalSeconds / 60
-        let seconds = totalSeconds % 60
-        return String(format: "%02d:%02d", minutes, seconds)
     }
 }

--- a/CareNote/Features/RecordingConfirm/RecordingConfirmViewModel.swift
+++ b/CareNote/Features/RecordingConfirm/RecordingConfirmViewModel.swift
@@ -101,10 +101,7 @@ final class RecordingConfirmViewModel {
 
     /// 録音時間を MM:SS 形式でフォーマットする
     var formattedDuration: String {
-        let totalSeconds = Int(duration)
-        let minutes = totalSeconds / 60
-        let seconds = totalSeconds % 60
-        return String(format: "%02d:%02d", minutes, seconds)
+        formatMMSS(duration)
     }
 
 }

--- a/CareNote/Features/RecordingList/RecordingListView.swift
+++ b/CareNote/Features/RecordingList/RecordingListView.swift
@@ -160,6 +160,7 @@ struct RecordingDetailView: View {
     @State private var isEditing = false
     @State private var editedText = ""
     @State private var isSaving = false
+    @State private var hasLocalAudio = false
 
     var body: some View {
         ScrollView {
@@ -176,14 +177,14 @@ struct RecordingDetailView: View {
                     )
                     DetailRow(
                         label: "録音時間",
-                        value: formatDuration(recording.durationSeconds)
+                        value: formatMMSS(recording.durationSeconds)
                     )
                 }
                 .padding()
                 .background(.thinMaterial, in: RoundedRectangle(cornerRadius: 12))
 
                 // Playback Section
-                if FileManager.default.fileExists(atPath: recording.localAudioPath) {
+                if hasLocalAudio {
                     VStack(alignment: .leading, spacing: 8) {
                         Text("再生")
                             .font(.headline)
@@ -305,13 +306,9 @@ struct RecordingDetailView: View {
         }
         .navigationTitle("録音詳細")
         .navigationBarTitleDisplayMode(.inline)
-    }
-
-    private func formatDuration(_ seconds: Double) -> String {
-        let totalSeconds = Int(seconds)
-        let minutes = totalSeconds / 60
-        let secs = totalSeconds % 60
-        return String(format: "%02d:%02d", minutes, secs)
+        .onAppear {
+            hasLocalAudio = FileManager.default.fileExists(atPath: recording.localAudioPath)
+        }
     }
 }
 

--- a/CareNote/Infrastructure/TimeFormatting.swift
+++ b/CareNote/Infrastructure/TimeFormatting.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+/// TimeInterval を MM:SS 形式にフォーマットする
+func formatMMSS(_ time: TimeInterval) -> String {
+    let totalSeconds = Int(time)
+    let minutes = totalSeconds / 60
+    let seconds = totalSeconds % 60
+    return String(format: "%02d:%02d", minutes, seconds)
+}


### PR DESCRIPTION
## Summary
- `formatMMSS` 共通ユーティリティ抽出（3箇所の同一 MM:SS フォーマッタを統合）
- 再生エラー時のユーザーフィードバック追加（サイレント失敗を解消）
- `prepareDuration` 削除（不要な AVAudioPlayer 二重生成）
- Task cancel 順序修正（cancel → nil の正しい順序に）
- `fileExists` を `onAppear` に移動（body 再評価時の I/O 回避）

## Test plan
- [x] ビルド成功
- [x] 全テスト PASS（22件）
- [ ] 実機で再生・シーク・エラー表示の動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)