### PR TITLE
fix: SwiftData マイグレーションクラッシュ修正

### DIFF
--- a/CareNote/Models/SwiftDataModels.swift
+++ b/CareNote/Models/SwiftDataModels.swift
@@ -18,7 +18,7 @@ final class RecordingRecord {
     var uploadStatus: String
     var transcription: String?
     var transcriptionStatus: String
-    var outputType: String
+    var outputType: String?
     var templateId: UUID?
     var templateNameSnapshot: String?
     var templatePromptSnapshot: String?
@@ -35,7 +35,7 @@ final class RecordingRecord {
         uploadStatus: String = UploadStatus.pending.rawValue,
         transcription: String? = nil,
         transcriptionStatus: String = TranscriptionStatus.pending.rawValue,
-        outputType: String = OutputType.transcription.rawValue,
+        outputType: String? = OutputType.transcription.rawValue,
         templateId: UUID? = nil,
         templateNameSnapshot: String? = nil,
         templatePromptSnapshot: String? = nil


### PR DESCRIPTION
## Summary
- RecordingRecord.outputType を `String` → `String?` に変更
- 既存DBに非オプショナルフィールドを追加すると軽量マイグレーションが失敗しアプリ起動時にクラッシュする問題を修正

## Root Cause
Build 3 (v0.1.0) で RecordingRecord に `outputType: String` を追加したが、既存レコードにはこのフィールドが存在しないため SwiftData の軽量マイグレーションが失敗。

## Test plan
- [x] ビルド成功
- [x] 全テスト PASS
- [ ] TestFlight Build 4 で既存データがある端末で起動確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)