### PR TITLE
fix: テンプレート選択のバグ修正とUI改善

### DIFF
--- a/CareNote.xcodeproj/project.pbxproj
+++ b/CareNote.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		6B0117657090C55B8D4A4A43 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 0201FF49E15F02E9E9054426 /* Assets.xcassets */; };
 		6DA2DDE0F90D3985BC3C5D17 /* AppEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2848993801DEF66A676C25D /* AppEnvironment.swift */; };
 		792F0B0FB46944FA0363CDC5 /* AudioPlayerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43708B0DF054C4C514B8D58E /* AudioPlayerView.swift */; };
+		7CA851BF8A07B0D97F3903A3 /* RecordingConfirmViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0C0F8FB680432239DF40DE4 /* RecordingConfirmViewModelTests.swift */; };
 		854789E2D53FE67EB38E7E4D /* ClientRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = C66B8FD7F4EEDA2F428C0A1F /* ClientRepository.swift */; };
 		867BA544A9DB963182049D63 /* TranscriptionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE80E23E3C3633F29AC0F0DA /* TranscriptionService.swift */; };
 		8A4E94E3CD9A0B866817E387 /* FirestoreModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58D2B24492527E7C7CE59620 /* FirestoreModels.swift */; };
@@ -98,6 +99,7 @@
 		C66B8FD7F4EEDA2F428C0A1F /* ClientRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientRepository.swift; sourceTree = "<group>"; };
 		CE80E23E3C3633F29AC0F0DA /* TranscriptionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptionService.swift; sourceTree = "<group>"; };
 		DA628FEE8E8929DE6D2651EC /* GoogleService-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
+		E0C0F8FB680432239DF40DE4 /* RecordingConfirmViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingConfirmViewModelTests.swift; sourceTree = "<group>"; };
 		E7B1618532B76B0B38896644 /* TimeFormatting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeFormatting.swift; sourceTree = "<group>"; };
 		E882F166342B21411BFDB30A /* FirestoreService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirestoreService.swift; sourceTree = "<group>"; };
 		EC5C0A2EB369429A8FD3D891 /* WIFAuthService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WIFAuthService.swift; sourceTree = "<group>"; };
@@ -241,6 +243,7 @@
 			children = (
 				9BD36BBA888E8960D96DC910 /* AuthViewModelTests.swift */,
 				042E6E584A73ED207A24A590 /* OutboxSyncServiceTests.swift */,
+				E0C0F8FB680432239DF40DE4 /* RecordingConfirmViewModelTests.swift */,
 				88B74F6BC7FCB2B9178B42F7 /* RecordingListViewModelTests.swift */,
 				13ED2870967AA1A35CE8FA37 /* RecordingRepositoryTests.swift */,
 				7E51986CBBEC3607B0256C7A /* RecordingViewModelTests.swift */,
@@ -399,6 +402,7 @@
 			files = (
 				C60B40FD6A5D17715EAE0AD4 /* AuthViewModelTests.swift in Sources */,
 				C6072255D88F74D009713EF5 /* OutboxSyncServiceTests.swift in Sources */,
+				7CA851BF8A07B0D97F3903A3 /* RecordingConfirmViewModelTests.swift in Sources */,
 				47FE4B218F49277FBB05F518 /* RecordingListViewModelTests.swift in Sources */,
 				B699C2BBB845DE4A8ACC0619 /* RecordingRepositoryTests.swift in Sources */,
 				4E553F6607752AD117DCE2E6 /* RecordingViewModelTests.swift in Sources */,

--- a/CareNote/Features/RecordingConfirm/RecordingConfirmView.swift
+++ b/CareNote/Features/RecordingConfirm/RecordingConfirmView.swift
@@ -10,57 +10,52 @@ struct RecordingConfirmView: View {
     @State private var showSaveSuccess = false
 
     var body: some View {
-        VStack(spacing: 24) {
-            // Recording Info Card
-            VStack(spacing: 12) {
-                InfoRow(label: "利用者", value: viewModel.clientName)
-                InfoRow(label: "シーン", value: viewModel.scene.rawValue)
-                InfoRow(label: "録音時間", value: viewModel.formattedDuration)
-            }
-            .padding()
-            .background(.thinMaterial, in: RoundedRectangle(cornerRadius: 12))
-            .padding(.horizontal)
-            .padding(.top, 16)
+        ScrollView {
+            VStack(spacing: 20) {
+                // Recording Info Card
+                VStack(spacing: 12) {
+                    InfoRow(label: "利用者", value: viewModel.clientName)
+                    InfoRow(label: "シーン", value: viewModel.scene.rawValue)
+                    InfoRow(label: "録音時間", value: viewModel.formattedDuration)
+                }
+                .padding()
+                .background(.thinMaterial, in: RoundedRectangle(cornerRadius: 12))
 
-            // Playback Section
-            AudioPlayerView(audioURL: viewModel.audioURL)
-                .padding(.horizontal)
+                // Playback Section
+                AudioPlayerView(audioURL: viewModel.audioURL)
 
-            // Template Selection
-            VStack(alignment: .leading, spacing: 8) {
-                Text("出力形式")
-                    .font(.subheadline)
-                    .foregroundStyle(.secondary)
-                    .padding(.horizontal)
+                // Template Selection
+                VStack(alignment: .leading, spacing: 12) {
+                    Label("出力形式を選択", systemImage: "doc.text")
+                        .font(.headline)
 
-                ScrollView(.horizontal, showsIndicators: false) {
-                    HStack(spacing: 8) {
+                    VStack(spacing: 8) {
                         ForEach(viewModel.templates) { template in
-                            TemplateChip(
-                                name: template.name,
+                            TemplateOptionRow(
+                                template: template,
                                 isSelected: viewModel.selectedTemplate?.id == template.id
                             ) {
                                 viewModel.selectedTemplate = template
                             }
                         }
                     }
-                    .padding(.horizontal)
+                }
+
+                // Error Message
+                if let error = viewModel.errorMessage {
+                    Text(error)
+                        .font(.footnote)
+                        .foregroundStyle(.red)
+                        .multilineTextAlignment(.center)
                 }
             }
-
-            Spacer()
-
-            // Error Message
-            if let error = viewModel.errorMessage {
-                Text(error)
-                    .font(.footnote)
-                    .foregroundStyle(.red)
-                    .multilineTextAlignment(.center)
-                    .padding(.horizontal)
-            }
-
+            .padding(.horizontal)
+            .padding(.top, 8)
+            .padding(.bottom, 120)
+        }
+        .safeAreaInset(edge: .bottom) {
             // Action Buttons
-            VStack(spacing: 12) {
+            VStack(spacing: 10) {
                 Button {
                     Task {
                         do {
@@ -76,7 +71,7 @@ struct RecordingConfirmView: View {
                             .frame(maxWidth: .infinity)
                             .frame(height: 20)
                     } else {
-                        Text("保存して文字起こし")
+                        Label("保存して文字起こし", systemImage: "arrow.up.doc")
                             .frame(maxWidth: .infinity)
                     }
                 }
@@ -95,7 +90,8 @@ struct RecordingConfirmView: View {
                 .disabled(viewModel.isSaving)
             }
             .padding(.horizontal)
-            .padding(.bottom, 24)
+            .padding(.vertical, 12)
+            .background(.ultraThinMaterial)
         }
         .navigationTitle("録音確認")
         .navigationBarTitleDisplayMode(.inline)
@@ -134,26 +130,62 @@ private struct InfoRow: View {
     }
 }
 
-// MARK: - TemplateChip
+// MARK: - TemplateOptionRow
 
-private struct TemplateChip: View {
-    let name: String
+private struct TemplateOptionRow: View {
+    let template: OutputTemplate
     let isSelected: Bool
     let action: () -> Void
 
+    private var description: String {
+        switch OutputType(rawValue: template.outputType) {
+        case .transcription:
+            return "音声をそのままテキストに変換"
+        case .visitRecord:
+            return "訪問記録フォーマットで整理"
+        case .meetingMinutes:
+            return "議題・決定事項を構造化"
+        case .summary:
+            return "要点を簡潔にまとめる"
+        case .custom, .none:
+            return "カスタムテンプレート"
+        }
+    }
+
     var body: some View {
         Button(action: action) {
-            Text(name)
-                .font(.subheadline)
-                .padding(.horizontal, 12)
-                .padding(.vertical, 8)
-                .background(
-                    isSelected ? Color.accentColor : Color(.systemGray5),
-                    in: Capsule()
-                )
-                .foregroundStyle(isSelected ? .white : .primary)
+            HStack(spacing: 12) {
+                Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
+                    .font(.title3)
+                    .foregroundStyle(isSelected ? Color.accentColor : .secondary)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(template.name)
+                        .font(.subheadline)
+                        .fontWeight(.medium)
+                        .foregroundStyle(.primary)
+
+                    Text(description)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                Spacer()
+            }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 12)
+            .background(
+                RoundedRectangle(cornerRadius: 10)
+                    .fill(isSelected ? Color.accentColor.opacity(0.08) : Color(.systemGray6))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 10)
+                    .stroke(isSelected ? Color.accentColor : .clear, lineWidth: 1.5)
+            )
         }
         .buttonStyle(.plain)
+        .accessibilityLabel("\(template.name): \(description)")
+        .accessibilityAddTraits(isSelected ? .isSelected : [])
     }
 }
 

--- a/CareNote/Features/RecordingConfirm/RecordingConfirmViewModel.swift
+++ b/CareNote/Features/RecordingConfirm/RecordingConfirmViewModel.swift
@@ -39,12 +39,19 @@ final class RecordingConfirmViewModel {
         self.tenantId = tenantId
     }
 
-    /// テンプレート一覧を読み込む
+    /// テンプレート一覧を読み込む（0件ならseedしてリトライ）
     func loadTemplates() {
         let descriptor = FetchDescriptor<OutputTemplate>(
             sortBy: [SortDescriptor(\.createdAt)]
         )
-        let fetched = (try? modelContext.fetch(descriptor)) ?? []
+        var fetched = (try? modelContext.fetch(descriptor)) ?? []
+
+        // テンプレートが0件の場合、seedしてリトライ
+        if fetched.isEmpty {
+            PresetTemplates.seedIfNeeded(modelContext: modelContext)
+            fetched = (try? modelContext.fetch(descriptor)) ?? []
+        }
+
         // プリセットを先に表示
         templates = fetched.sorted { a, b in
             if a.isPreset != b.isPreset { return a.isPreset }

--- a/CareNoteTests/RecordingConfirmViewModelTests.swift
+++ b/CareNoteTests/RecordingConfirmViewModelTests.swift
@@ -1,0 +1,120 @@
+@testable import CareNote
+import Foundation
+import SwiftData
+import Testing
+
+@Suite("RecordingConfirmViewModel Tests")
+struct RecordingConfirmViewModelTests {
+
+    private static func makeContainer() throws -> ModelContainer {
+        let config = ModelConfiguration(isStoredInMemoryOnly: true)
+        return try ModelContainer(
+            for: RecordingRecord.self, OutboxItem.self, ClientCache.self, OutputTemplate.self,
+            configurations: config
+        )
+    }
+
+    @Test @MainActor
+    func loadTemplatesでプリセットが自動seedされる() throws {
+        let container = try Self.makeContainer()
+        let context = container.mainContext
+
+        let vm = RecordingConfirmViewModel(
+            audioURL: URL(fileURLWithPath: "/tmp/test.m4a"),
+            clientId: "c1",
+            clientName: "テスト",
+            scene: .visit,
+            duration: 60,
+            modelContext: context,
+            tenantId: "t1"
+        )
+
+        // テンプレートが0件の状態でloadTemplatesを呼ぶ
+        vm.loadTemplates()
+
+        // プリセット4件がseedされて読み込まれる
+        #expect(vm.templates.count == 4)
+        #expect(vm.selectedTemplate != nil)
+        #expect(vm.templates.allSatisfy { $0.isPreset })
+    }
+
+    @Test @MainActor
+    func loadTemplatesで既存テンプレートがある場合は再seedしない() throws {
+        let container = try Self.makeContainer()
+        let context = container.mainContext
+
+        // 事前にseed
+        PresetTemplates.seedIfNeeded(modelContext: context)
+
+        let vm = RecordingConfirmViewModel(
+            audioURL: URL(fileURLWithPath: "/tmp/test.m4a"),
+            clientId: "c1",
+            clientName: "テスト",
+            scene: .visit,
+            duration: 60,
+            modelContext: context,
+            tenantId: "t1"
+        )
+
+        vm.loadTemplates()
+
+        // 4件のまま（重複seedされない）
+        #expect(vm.templates.count == 4)
+    }
+
+    @Test @MainActor
+    func loadTemplatesでプリセットが先頭にソートされる() throws {
+        let container = try Self.makeContainer()
+        let context = container.mainContext
+
+        // カスタムテンプレートを先に追加
+        let custom = OutputTemplate(
+            name: "カスタム1",
+            prompt: "テスト",
+            outputType: OutputType.custom.rawValue,
+            isPreset: false
+        )
+        context.insert(custom)
+        try context.save()
+
+        let vm = RecordingConfirmViewModel(
+            audioURL: URL(fileURLWithPath: "/tmp/test.m4a"),
+            clientId: "c1",
+            clientName: "テスト",
+            scene: .visit,
+            duration: 60,
+            modelContext: context,
+            tenantId: "t1"
+        )
+
+        vm.loadTemplates()
+
+        // 4プリセット + 1カスタム = 5件
+        #expect(vm.templates.count == 5)
+        // プリセットが先頭
+        #expect(vm.templates.first?.isPreset == true)
+        // カスタムが末尾
+        #expect(vm.templates.last?.isPreset == false)
+        #expect(vm.templates.last?.name == "カスタム1")
+    }
+
+    @Test @MainActor
+    func デフォルト選択は最初のプリセット() throws {
+        let container = try Self.makeContainer()
+        let context = container.mainContext
+
+        let vm = RecordingConfirmViewModel(
+            audioURL: URL(fileURLWithPath: "/tmp/test.m4a"),
+            clientId: "c1",
+            clientName: "テスト",
+            scene: .visit,
+            duration: 60,
+            modelContext: context,
+            tenantId: "t1"
+        )
+
+        vm.loadTemplates()
+
+        #expect(vm.selectedTemplate?.name == "文字起こし（デフォルト）")
+    }
+}


### PR DESCRIPTION
## Summary
- `loadTemplates()` にフォールバック機構追加: テンプレートが0件の場合、画面内で自動seedしてリトライ（Build 3クラッシュ後のDB状態対応）
- テンプレート選択UIを横スクロールチップ → 縦リスト形式に全面変更
  - 各テンプレートに説明文（「音声をそのままテキストに変換」等）を追加
  - チェックマーク + 背景ハイライトで選択状態を明確化
  - タップ領域を十分に確保
- アクションボタンを `safeAreaInset` に固定配置
- アクセシビリティ対応（ラベル、選択状態traits）
- RecordingConfirmViewModelのテスト4件追加

## Test plan
- [x] 全テストPASS（新規4件含む）
- [x] ビルド成功確認
- [x] テンプレート自動seed機構のテスト
- [x] プリセット優先ソートのテスト
- [ ] TestFlight実機確認（テンプレート選択動作）

Closes #32, Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)