### PR TITLE
fix: テンプレート選択が動作しない根本原因を修正

### DIFF
--- a/CareNote/Features/Recording/RecordingView.swift
+++ b/CareNote/Features/Recording/RecordingView.swift
@@ -11,6 +11,7 @@ struct RecordingView: View {
 
     @State private var pulseAnimation = false
     @State private var navigateToConfirm = false
+    @State private var confirmViewModel: RecordingConfirmViewModel?
 
     var body: some View {
         VStack(spacing: 32) {
@@ -117,18 +118,8 @@ struct RecordingView: View {
         .padding()
         .navigationBarBackButtonHidden(viewModel.recordingState == .recording || viewModel.recordingState == .paused)
         .navigationDestination(isPresented: $navigateToConfirm) {
-            if let url = viewModel.audioURL {
-                RecordingConfirmView(
-                    viewModel: RecordingConfirmViewModel(
-                        audioURL: url,
-                        clientId: viewModel.clientId,
-                        clientName: viewModel.clientName,
-                        scene: viewModel.scene,
-                        duration: viewModel.elapsedTime,
-                        modelContext: modelContext,
-                        tenantId: authViewModel.authState.tenantId ?? ""
-                    )
-                )
+            if let vm = confirmViewModel {
+                RecordingConfirmView(viewModel: vm)
             }
         }
         .onChange(of: viewModel.recordingState) { _, newState in
@@ -138,7 +129,16 @@ struct RecordingView: View {
                 pulseAnimation = false
             }
 
-            if newState == .stopped {
+            if newState == .stopped, let url = viewModel.audioURL {
+                confirmViewModel = RecordingConfirmViewModel(
+                    audioURL: url,
+                    clientId: viewModel.clientId,
+                    clientName: viewModel.clientName,
+                    scene: viewModel.scene,
+                    duration: viewModel.elapsedTime,
+                    modelContext: modelContext,
+                    tenantId: authViewModel.authState.tenantId ?? ""
+                )
                 navigateToConfirm = true
             }
         }

--- a/CareNote/Features/RecordingConfirm/RecordingConfirmView.swift
+++ b/CareNote/Features/RecordingConfirm/RecordingConfirmView.swift
@@ -96,7 +96,7 @@ struct RecordingConfirmView: View {
         .navigationTitle("録音確認")
         .navigationBarTitleDisplayMode(.inline)
         .navigationBarBackButtonHidden(viewModel.isSaving)
-        .onAppear {
+        .task {
             viewModel.loadTemplates()
         }
         .alert("保存完了", isPresented: $showSaveSuccess) {

--- a/CareNote/Features/RecordingConfirm/RecordingConfirmViewModel.swift
+++ b/CareNote/Features/RecordingConfirm/RecordingConfirmViewModel.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Observation
+import os.log
 import SwiftData
 
 // MARK: - RecordingConfirmViewModel
@@ -39,17 +40,25 @@ final class RecordingConfirmViewModel {
         self.tenantId = tenantId
     }
 
-    /// テンプレート一覧を読み込む（0件ならseedしてリトライ）
+    private static let logger = Logger(subsystem: "jp.carenote.app", category: "RecordingConfirmVM")
+
+    /// テンプレート一覧を読み込む（プリセット0件ならseedしてリトライ）
     func loadTemplates() {
+        Self.logger.info("loadTemplates called")
+
         let descriptor = FetchDescriptor<OutputTemplate>(
             sortBy: [SortDescriptor(\.createdAt)]
         )
         var fetched = (try? modelContext.fetch(descriptor)) ?? []
+        Self.logger.info("Initial fetch: \(fetched.count) templates")
 
-        // テンプレートが0件の場合、seedしてリトライ
-        if fetched.isEmpty {
+        // プリセットが0件の場合、seedしてリトライ
+        let hasPresets = fetched.contains { $0.isPreset }
+        if !hasPresets {
+            Self.logger.warning("No preset templates found, attempting seed fallback")
             PresetTemplates.seedIfNeeded(modelContext: modelContext)
             fetched = (try? modelContext.fetch(descriptor)) ?? []
+            Self.logger.info("After seed fallback: \(fetched.count) templates")
         }
 
         // プリセットを先に表示
@@ -62,6 +71,8 @@ final class RecordingConfirmViewModel {
         if selectedTemplate == nil {
             selectedTemplate = templates.first
         }
+
+        Self.logger.info("loadTemplates done: \(self.templates.count) templates, selected=\(self.selectedTemplate?.name ?? "nil")")
     }
 
     /// 録音を保存し文字起こしを開始する

--- a/CareNote/Models/PresetTemplates.swift
+++ b/CareNote/Models/PresetTemplates.swift
@@ -1,4 +1,5 @@
 import Foundation
+import os.log
 import SwiftData
 
 // MARK: - PresetTemplates
@@ -89,15 +90,27 @@ enum PresetTemplates {
         ),
     ]
 
+    private static let logger = Logger(subsystem: "jp.carenote.app", category: "PresetTemplates")
+
     /// プリセットテンプレートを ModelContext に挿入する（既に存在する場合はスキップ）
     @MainActor
     static func seedIfNeeded(modelContext: ModelContext) {
+        logger.info("seedIfNeeded called")
+
         let descriptor = FetchDescriptor<OutputTemplate>(
             predicate: #Predicate<OutputTemplate> { $0.isPreset }
         )
 
-        let existingCount = (try? modelContext.fetchCount(descriptor)) ?? 0
-        guard existingCount == 0 else { return }
+        var existingCount = 0
+        do {
+            existingCount = try modelContext.fetchCount(descriptor)
+        } catch {
+            logger.error("fetchCount failed: \(error.localizedDescription)")
+            existingCount = -1
+        }
+
+        logger.info("Existing preset count: \(existingCount)")
+        guard existingCount == 0 || existingCount == -1 else { return }
 
         for preset in all {
             let template = OutputTemplate(
@@ -109,6 +122,11 @@ enum PresetTemplates {
             modelContext.insert(template)
         }
 
-        try? modelContext.save()
+        do {
+            try modelContext.save()
+            logger.info("Seeded \(self.all.count) preset templates successfully")
+        } catch {
+            logger.error("Failed to save seeded templates: \(error.localizedDescription)")
+        }
     }
 }


### PR DESCRIPTION
## Summary
- RecordingViewの`navigationDestination`クロージャ内でViewModelが毎回再生成される問題を修正（`@State`で保持）
- `loadTemplates()`のseedフォールバック条件を「テンプレート0件」→「プリセット0件」に変更（カスタムテンプレートのみ存在する場合もseed実行）
- `.onAppear` → `.task` でSwiftUIライフサイクルの信頼性向上
- `PresetTemplates.seedIfNeeded()`にos.logログ追加とエラーハンドリング改善

## Test plan
- [x] 全35テストPASS（修正前は2件失敗）
- [ ] TestFlight Build 6で実機テスト：テンプレート選択が動作することを確認

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)