### PR TITLE
refactor: コード品質改善（重複排除・ロジック修正・DI対応）

### DIFF
--- a/CareNote/Features/Recording/RecordingViewModel.swift
+++ b/CareNote/Features/Recording/RecordingViewModel.swift
@@ -103,10 +103,7 @@ final class RecordingViewModel {
 
     /// 経過時間を MM:SS 形式でフォーマットする
     func formatElapsedTime() -> String {
-        let totalSeconds = Int(elapsedTime)
-        let minutes = totalSeconds / 60
-        let seconds = totalSeconds % 60
-        return String(format: "%02d:%02d", minutes, seconds)
+        formatMMSS(elapsedTime)
     }
 
     // MARK: - Private

--- a/CareNote/Features/RecordingConfirm/RecordingConfirmViewModel.swift
+++ b/CareNote/Features/RecordingConfirm/RecordingConfirmViewModel.swift
@@ -21,6 +21,7 @@ final class RecordingConfirmViewModel {
 
     private let modelContext: ModelContext
     private let tenantId: String
+    private let syncServiceFactory: @Sendable (ModelContainer, String) -> OutboxSyncService
 
     init(
         audioURL: URL,
@@ -29,7 +30,8 @@ final class RecordingConfirmViewModel {
         scene: RecordingScene,
         duration: TimeInterval,
         modelContext: ModelContext,
-        tenantId: String
+        tenantId: String,
+        syncServiceFactory: (@Sendable (ModelContainer, String) -> OutboxSyncService)? = nil
     ) {
         self.audioURL = audioURL
         self.clientId = clientId
@@ -38,6 +40,21 @@ final class RecordingConfirmViewModel {
         self.duration = duration
         self.modelContext = modelContext
         self.tenantId = tenantId
+        self.syncServiceFactory = syncServiceFactory ?? Self.defaultSyncServiceFactory
+    }
+
+    private static let defaultSyncServiceFactory: @Sendable (ModelContainer, String) -> OutboxSyncService = { container, tenantId in
+        let wifService = WIFAuthService()
+        return OutboxSyncService(
+            modelContainer: container,
+            storageService: StorageService(accessTokenProvider: wifService),
+            firestoreService: FirestoreService(),
+            transcriptionService: TranscriptionService(
+                projectId: AppConfig.gcpProject,
+                accessTokenProvider: wifService
+            ),
+            tenantId: tenantId
+        )
     }
 
     private static let logger = Logger(subsystem: "jp.carenote.app", category: "RecordingConfirmVM")
@@ -103,20 +120,7 @@ final class RecordingConfirmViewModel {
             try modelContext.save()
 
             // 3. OutboxSyncService を生成して即時処理
-            let wifService = WIFAuthService()
-            let syncService = OutboxSyncService(
-                modelContainer: modelContext.container,
-                storageService: StorageService(accessTokenProvider: wifService),
-                firestoreService: FirestoreService(),
-                transcriptionService: TranscriptionService(
-                    projectId: AppConfig.gcpProject,
-                    accessTokenProvider: wifService
-                ),
-                tenantId: tenantId
-            )
-
-            await syncService.startMonitoring()
-            defer { Task { await syncService.stopMonitoring() } }
+            let syncService = syncServiceFactory(modelContext.container, tenantId)
             try await syncService.processQueueImmediately()
         } catch {
             // エラーチェーンを展開して詳細表示

--- a/CareNote/Services/OutboxSyncService.swift
+++ b/CareNote/Services/OutboxSyncService.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Network
+import os.log
 import SwiftData
 
 // MARK: - OutboxSyncError
@@ -33,6 +34,8 @@ actor OutboxSyncService {
 
     private var pathMonitor: NWPathMonitor?
     private var monitorQueue: DispatchQueue?
+    private static let logger = Logger(subsystem: "jp.carenote.app", category: "OutboxSync")
+
     private var isProcessing = false
     private var isConnected = false
 
@@ -75,6 +78,12 @@ actor OutboxSyncService {
         for item in items {
             guard isConnected else { break }
 
+            // リトライ時は exponential backoff で待機
+            if item.retryCount > 0 {
+                let delay = Self.baseRetryDelay * pow(2.0, Double(item.retryCount - 1))
+                try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+            }
+
             do {
                 try await processItem(item)
                 await removeItem(item.id)
@@ -106,6 +115,12 @@ actor OutboxSyncService {
             } else {
                 await removeItem(item.id)
                 continue
+            }
+
+            // リトライ時は exponential backoff で待機
+            if item.retryCount > 0 {
+                let delay = Self.baseRetryDelay * pow(2.0, Double(item.retryCount - 1))
+                try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
             }
 
             do {
@@ -246,12 +261,6 @@ actor OutboxSyncService {
             transcription: transcription,
             transcriptionStatus: .done
         )
-
-        // Apply exponential backoff delay if this was a retry
-        if item.retryCount > 0 {
-            let delay = Self.baseRetryDelay * pow(2.0, Double(item.retryCount - 1))
-            try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
-        }
     }
 
     @MainActor
@@ -288,7 +297,11 @@ actor OutboxSyncService {
         record.transcription = transcription
         record.transcriptionStatus = transcriptionStatus.rawValue
 
-        try? context.save()
+        do {
+            try context.save()
+        } catch {
+            Self.logger.error("Failed to save recording status: \(error.localizedDescription)")
+        }
     }
 
     @MainActor
@@ -302,7 +315,11 @@ actor OutboxSyncService {
         guard let item = try? context.fetch(descriptor).first else { return }
 
         context.delete(item)
-        try? context.save()
+        do {
+            try context.save()
+        } catch {
+            Self.logger.error("Failed to remove outbox item: \(error.localizedDescription)")
+        }
     }
 
     @MainActor
@@ -336,7 +353,11 @@ actor OutboxSyncService {
         )
         guard let record = try? context.fetch(descriptor).first else { return }
         record.firestoreId = firestoreId
-        try? context.save()
+        do {
+            try context.save()
+        } catch {
+            Self.logger.error("Failed to save firestoreId: \(error.localizedDescription)")
+        }
     }
 
     @MainActor
@@ -367,6 +388,10 @@ actor OutboxSyncService {
             }
         }
 
-        try? context.save()
+        do {
+            try context.save()
+        } catch {
+            Self.logger.error("Failed to save retry count: \(error.localizedDescription)")
+        }
     }
 }


### PR DESCRIPTION
## Summary
- `formatElapsedTime()` のグローバル `formatMMSS()` との重複排除
- `OutboxSyncService` の exponential backoff を正しい位置（リトライ前）に移動
- `OutboxSyncService` の `try?` 握りつぶしを `do/catch` + `os.log` に改善
- `RecordingConfirmViewModel` に `syncServiceFactory` DI を導入（テスト時モック注入可能）
- `saveAndTranscribe()` の不要な `startMonitoring()/stopMonitoring()` 除去

## Test plan
- [x] 全35テストPASS（既存テスト変更なし）
- [x] 既存の呼び出し元に影響なし（`syncServiceFactory` はデフォルト値あり）

🤖 Generated with [Claude Code](https://claude.com/claude-code)