### PR TITLE
refactor: Service層プロトコル抽象化とfirestoreId nilガード

### DIFF
--- a/CareNote.xcodeproj/project.pbxproj
+++ b/CareNote.xcodeproj/project.pbxproj
@@ -546,7 +546,7 @@
 				CODE_SIGN_ENTITLEMENTS = CareNote/CareNote.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 5;
+				CURRENT_PROJECT_VERSION = 6;
 				DEVELOPMENT_TEAM = C96A7EHVW8;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = CareNote/Info.plist;
@@ -644,7 +644,7 @@
 				CODE_SIGN_ENTITLEMENTS = CareNote/CareNote.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 5;
+				CURRENT_PROJECT_VERSION = 6;
 				DEVELOPMENT_TEAM = C96A7EHVW8;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = CareNote/Info.plist;

--- a/CareNote/Services/FirestoreService.swift
+++ b/CareNote/Services/FirestoreService.swift
@@ -10,10 +10,17 @@ enum FirestoreError: Error, Sendable {
     case operationFailed(Error)
 }
 
+// MARK: - RecordingStoring
+
+protocol RecordingStoring: Sendable {
+    func createRecording(tenantId: String, recording: FirestoreRecording) async throws -> String
+    func updateTranscription(tenantId: String, recordingId: String, transcription: String, status: TranscriptionStatus) async throws
+}
+
 // MARK: - FirestoreService
 
 /// Firestore CRUD service with multi-tenant structure: `tenants/{tenantId}/...`
-actor FirestoreService {
+actor FirestoreService: RecordingStoring {
 
     // MARK: - Properties
 

--- a/CareNote/Services/OutboxSyncService.swift
+++ b/CareNote/Services/OutboxSyncService.swift
@@ -27,9 +27,9 @@ actor OutboxSyncService {
     // MARK: - Properties
 
     private let modelContainer: ModelContainer
-    private let storageService: StorageService
-    private let firestoreService: FirestoreService
-    private let transcriptionService: TranscriptionService
+    private let storageService: any AudioUploading
+    private let firestoreService: any RecordingStoring
+    private let transcriptionService: any Transcribing
     private let tenantId: String
 
     private var pathMonitor: NWPathMonitor?
@@ -43,9 +43,9 @@ actor OutboxSyncService {
 
     init(
         modelContainer: ModelContainer,
-        storageService: StorageService,
-        firestoreService: FirestoreService,
-        transcriptionService: TranscriptionService,
+        storageService: any AudioUploading,
+        firestoreService: any RecordingStoring,
+        transcriptionService: any Transcribing,
         tenantId: String
     ) {
         self.modelContainer = modelContainer
@@ -224,14 +224,17 @@ actor OutboxSyncService {
             }
         }
 
-        if let fid = firestoreId {
-            try? await firestoreService.updateTranscription(
-                tenantId: tenantId,
-                recordingId: fid,
-                transcription: "",
-                status: .processing
-            )
+        guard let fid = firestoreId else {
+            Self.logger.error("firestoreId is nil after Step 2 for recording \(item.recordingId) — skipping transcription")
+            return
         }
+
+        try? await firestoreService.updateTranscription(
+            tenantId: tenantId,
+            recordingId: fid,
+            transcription: "",
+            status: .processing
+        )
 
         // Step 3: Trigger transcription (with template prompt if available)
         let transcription: String
@@ -245,14 +248,12 @@ actor OutboxSyncService {
         }
 
         // Step 4: Update Firestore with transcription result
-        if let fid = firestoreId {
-            try await firestoreService.updateTranscription(
-                tenantId: tenantId,
-                recordingId: fid,
-                transcription: transcription,
-                status: .done
-            )
-        }
+        try await firestoreService.updateTranscription(
+            tenantId: tenantId,
+            recordingId: fid,
+            transcription: transcription,
+            status: .done
+        )
 
         // Step 5: Update local SwiftData record
         await updateRecordingStatus(

--- a/CareNote/Services/StorageService.swift
+++ b/CareNote/Services/StorageService.swift
@@ -7,10 +7,16 @@ enum StorageError: Error, Sendable {
     case uploadFailed(Error)
 }
 
+// MARK: - AudioUploading
+
+protocol AudioUploading: Sendable {
+    func uploadAudio(localURL: URL, tenantId: String, recordingId: String) async throws -> String
+}
+
 // MARK: - StorageService
 
 /// Cloud Storage upload service using GCS JSON API with WIF authentication.
-actor StorageService {
+actor StorageService: AudioUploading {
 
     // MARK: - Properties
 

--- a/CareNote/Services/TranscriptionService.swift
+++ b/CareNote/Services/TranscriptionService.swift
@@ -67,10 +67,16 @@ struct VertexAIResponse: Codable, Sendable {
     }
 }
 
+// MARK: - Transcribing
+
+protocol Transcribing: Sendable {
+    func transcribe(audioGCSUri: String, templatePrompt: String?) async throws -> String
+}
+
 // MARK: - TranscriptionService
 
 /// Vertex AI Gemini 2.5 Flash transcription service (Spec S11).
-actor TranscriptionService {
+actor TranscriptionService: Transcribing {
 
     // MARK: - Constants
 


### PR DESCRIPTION
## Summary
- Service層（Storage, Transcription, Firestore）にプロトコル抽象化を導入し、OutboxSyncServiceの依存注入をテスト可能に
- `processItem()`でfirestoreId nil時の早期リターンを追加し、データ整合性を保護
- ビルド・全テストパス確認済み

## Changes
- `AudioUploading` protocol → `StorageService` conformance
- `Transcribing` protocol → `TranscriptionService` conformance
- `RecordingStoring` protocol → `FirestoreService` conformance
- `OutboxSyncService` init/properties を `any Protocol` 型に変更
- firestoreId nil ガード追加（Step 2後にnilなら早期リターン+ログ）

## Test plan
- [x] ビルド成功（iOS Simulator）
- [x] 全既存テストパス
- [ ] 次PR: mock serviceを使ったsaveAndTranscribe()テスト追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)