### PR TITLE
feat: Sign in with Apple + メール認証追加（App Store Review対応）

### DIFF
--- a/CareNote.xcodeproj/project.pbxproj
+++ b/CareNote.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		6DA2DDE0F90D3985BC3C5D17 /* AppEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2848993801DEF66A676C25D /* AppEnvironment.swift */; };
 		792F0B0FB46944FA0363CDC5 /* AudioPlayerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43708B0DF054C4C514B8D58E /* AudioPlayerView.swift */; };
 		7CA851BF8A07B0D97F3903A3 /* RecordingConfirmViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0C0F8FB680432239DF40DE4 /* RecordingConfirmViewModelTests.swift */; };
+		8234CBC662F2FB30E1866158 /* AppleSignInCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9E130263BC2FE596468916F /* AppleSignInCoordinator.swift */; };
 		83167C60FCA3768F00D80442 /* TemplateCreateViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3ECEF75B614C6A2B223AB02F /* TemplateCreateViewModel.swift */; };
 		854789E2D53FE67EB38E7E4D /* ClientRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = C66B8FD7F4EEDA2F428C0A1F /* ClientRepository.swift */; };
 		867BA544A9DB963182049D63 /* TranscriptionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE80E23E3C3633F29AC0F0DA /* TranscriptionService.swift */; };
@@ -134,6 +135,7 @@
 		E7B1618532B76B0B38896644 /* TimeFormatting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeFormatting.swift; sourceTree = "<group>"; };
 		E882F166342B21411BFDB30A /* FirestoreService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirestoreService.swift; sourceTree = "<group>"; };
 		E9B4E2778FEE530A1DC4DF06 /* TemplateListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemplateListViewModelTests.swift; sourceTree = "<group>"; };
+		E9E130263BC2FE596468916F /* AppleSignInCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleSignInCoordinator.swift; sourceTree = "<group>"; };
 		EC5C0A2EB369429A8FD3D891 /* WIFAuthService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WIFAuthService.swift; sourceTree = "<group>"; };
 		ECB12BF484200EAC264DAC63 /* PresetTemplates.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresetTemplates.swift; sourceTree = "<group>"; };
 		ED7A610D0269818D75C76641 /* SignInView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInView.swift; sourceTree = "<group>"; };
@@ -272,6 +274,7 @@
 		6EF4D7F9B91C4EC70E35F1A7 /* Auth */ = {
 			isa = PBXGroup;
 			children = (
+				E9E130263BC2FE596468916F /* AppleSignInCoordinator.swift */,
 				036156B4FFB1416DCC51D265 /* AuthViewModel.swift */,
 				ED7A610D0269818D75C76641 /* SignInView.swift */,
 			);
@@ -521,6 +524,7 @@
 			files = (
 				C74386AC37344205E71E5B2B /* AppConfig.swift in Sources */,
 				6DA2DDE0F90D3985BC3C5D17 /* AppEnvironment.swift in Sources */,
+				8234CBC662F2FB30E1866158 /* AppleSignInCoordinator.swift in Sources */,
 				792F0B0FB46944FA0363CDC5 /* AudioPlayerView.swift in Sources */,
 				A66F72A55AF844FA523B9941 /* AudioRecorderService.swift in Sources */,
 				94DF9E5A0CCD3408F6EC31B7 /* AuthViewModel.swift in Sources */,

--- a/CareNote/CareNote.entitlements
+++ b/CareNote/CareNote.entitlements
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict/>
+<dict>
+	<key>com.apple.developer.applesignin</key>
+	<array>
+		<string>Default</string>
+	</array>
+</dict>
 </plist>

--- a/CareNote/Features/Auth/AppleSignInCoordinator.swift
+++ b/CareNote/Features/Auth/AppleSignInCoordinator.swift
@@ -1,0 +1,74 @@
+import AuthenticationServices
+import CryptoKit
+@preconcurrency import FirebaseAuth
+import os.log
+
+// MARK: - AppleSignInCoordinator
+
+@MainActor
+final class AppleSignInCoordinator {
+    private static let logger = Logger(subsystem: "jp.carenote.app", category: "AppleSignIn")
+
+    private var currentNonce: String?
+
+    /// SignInWithAppleButton の onRequest で呼び出し、nonce を設定する
+    func configureRequest(_ request: ASAuthorizationAppleIDRequest) {
+        let nonce = Self.randomNonceString()
+        currentNonce = nonce
+        request.requestedScopes = [.fullName, .email]
+        request.nonce = Self.sha256(nonce)
+    }
+
+    /// SignInWithAppleButton の onCompletion で呼び出し、Firebase Auth と連携する
+    func handleResult(_ result: Result<ASAuthorization, Error>) async throws
+        -> (userId: String, tenantId: String?, role: UserRole)
+    {
+        let authorization = try result.get()
+
+        guard let appleIDCredential = authorization.credential as? ASAuthorizationAppleIDCredential else {
+            throw AuthError.appleIdTokenMissing
+        }
+
+        guard let appleIDToken = appleIDCredential.identityToken,
+              let idTokenString = String(data: appleIDToken, encoding: .utf8) else {
+            throw AuthError.appleIdTokenMissing
+        }
+
+        guard let nonce = currentNonce else {
+            throw AuthError.appleIdTokenMissing
+        }
+
+        let credential = OAuthProvider.appleCredential(
+            withIDToken: idTokenString,
+            rawNonce: nonce,
+            fullName: appleIDCredential.fullName
+        )
+
+        let authResult = try await Auth.auth().signIn(with: credential)
+        let tokenResult = try await authResult.user.getIDTokenResult()
+        let tenantId = tokenResult.claims["tenantId"] as? String
+        let role = UserRole.from(firestoreValue: tokenResult.claims["role"] as? String)
+
+        Self.logger.info("Apple Sign-In succeeded: userId=\(authResult.user.uid)")
+        return (userId: authResult.user.uid, tenantId: tenantId, role: role)
+    }
+
+    // MARK: - Nonce Utilities
+
+    private static func randomNonceString(length: Int = 32) -> String {
+        precondition(length > 0)
+        var randomBytes = [UInt8](repeating: 0, count: length)
+        let errorCode = SecRandomCopyBytes(kSecRandomDefault, randomBytes.count, &randomBytes)
+        if errorCode != errSecSuccess {
+            fatalError("Unable to generate nonce. SecRandomCopyBytes failed with OSStatus \(errorCode)")
+        }
+        let charset: [Character] = Array("0123456789ABCDEFGHIJKLMNOPQRSTUVXYZabcdefghijklmnopqrstuvwxyz-._")
+        return String(randomBytes.map { charset[Int($0) % charset.count] })
+    }
+
+    private static func sha256(_ input: String) -> String {
+        let inputData = Data(input.utf8)
+        let hashedData = SHA256.hash(data: inputData)
+        return hashedData.compactMap { String(format: "%02x", $0) }.joined()
+    }
+}

--- a/CareNote/Features/Auth/AuthViewModel.swift
+++ b/CareNote/Features/Auth/AuthViewModel.swift
@@ -1,3 +1,4 @@
+import AuthenticationServices
 @preconcurrency import FirebaseAuth
 import FirebaseCore
 @preconcurrency import GoogleSignIn
@@ -44,6 +45,8 @@ protocol AuthProviding: Sendable {
 enum AuthError: Error, Sendable {
     case viewControllerNotFound
     case googleIdTokenMissing
+    case appleIdTokenMissing
+    case appleSignInCancelled
 }
 
 // MARK: - FirebaseGoogleAuthProvider
@@ -81,6 +84,24 @@ final class FirebaseGoogleAuthProvider: AuthProviding {
     }
 }
 
+// MARK: - EmailAuthProviding Protocol
+
+protocol EmailAuthProviding: Sendable {
+    func signIn(email: String, password: String) async throws -> (userId: String, tenantId: String?, role: UserRole)
+}
+
+// MARK: - FirebaseEmailAuthProvider
+
+final class FirebaseEmailAuthProvider: EmailAuthProviding {
+    func signIn(email: String, password: String) async throws -> (userId: String, tenantId: String?, role: UserRole) {
+        let authResult = try await Auth.auth().signIn(withEmail: email, password: password)
+        let tokenResult = try await authResult.user.getIDTokenResult()
+        let tenantId = tokenResult.claims["tenantId"] as? String
+        let role = UserRole.from(firestoreValue: tokenResult.claims["role"] as? String)
+        return (userId: authResult.user.uid, tenantId: tenantId, role: role)
+    }
+}
+
 // MARK: - AuthViewModel
 
 @Observable
@@ -92,11 +113,17 @@ final class AuthViewModel {
     var displayName: String?
 
     private let authProvider: AuthProviding
+    let appleSignInCoordinator = AppleSignInCoordinator()
+    private let emailAuthProvider: EmailAuthProviding
     private nonisolated(unsafe) var authStateHandle: AuthStateDidChangeListenerHandle?
     private static let logger = Logger(subsystem: "jp.carenote.app", category: "AuthVM")
 
-    init(authProvider: AuthProviding = FirebaseGoogleAuthProvider()) {
+    init(
+        authProvider: AuthProviding = FirebaseGoogleAuthProvider(),
+        emailAuthProvider: EmailAuthProviding = FirebaseEmailAuthProvider()
+    ) {
         self.authProvider = authProvider
+        self.emailAuthProvider = emailAuthProvider
     }
 
     deinit {
@@ -113,6 +140,52 @@ final class AuthViewModel {
 
         do {
             let result = try await authProvider.signInWithGoogle()
+
+            guard let tenantId = result.tenantId, !tenantId.isEmpty else {
+                errorMessage = "テナント情報の取得に失敗しました。管理者にお問い合わせください。"
+                return
+            }
+
+            let isAdmin = result.role == .admin
+            authState = .signedIn(userId: result.userId, tenantId: tenantId, isAdmin: isAdmin)
+            updateDisplayName()
+        } catch {
+            errorMessage = "サインインに失敗しました: \(error.localizedDescription)"
+        }
+    }
+
+    /// Apple Sign-In の結果を処理し、Firebase Auth と連携する
+    func handleAppleSignInResult(_ result: Result<ASAuthorization, Error>) async {
+        isLoading = true
+        errorMessage = nil
+        defer { isLoading = false }
+
+        do {
+            let authResult = try await appleSignInCoordinator.handleResult(result)
+
+            guard let tenantId = authResult.tenantId, !tenantId.isEmpty else {
+                errorMessage = "テナント情報の取得に失敗しました。管理者にお問い合わせください。"
+                return
+            }
+
+            let isAdmin = authResult.role == .admin
+            authState = .signedIn(userId: authResult.userId, tenantId: tenantId, isAdmin: isAdmin)
+            updateDisplayName()
+        } catch let error as ASAuthorizationError where error.code == .canceled {
+            // ユーザーキャンセルはエラー表示しない
+        } catch {
+            errorMessage = "サインインに失敗しました: \(error.localizedDescription)"
+        }
+    }
+
+    /// メール/パスワードでサインインする（デモアカウント用）
+    func signInWithEmail(email: String, password: String) async {
+        isLoading = true
+        errorMessage = nil
+        defer { isLoading = false }
+
+        do {
+            let result = try await emailAuthProvider.signIn(email: email, password: password)
 
             guard let tenantId = result.tenantId, !tenantId.isEmpty else {
                 errorMessage = "テナント情報の取得に失敗しました。管理者にお問い合わせください。"

--- a/CareNote/Features/Auth/SignInView.swift
+++ b/CareNote/Features/Auth/SignInView.swift
@@ -1,3 +1,4 @@
+import AuthenticationServices
 import GoogleSignInSwift
 import SwiftUI
 
@@ -5,6 +6,11 @@ import SwiftUI
 
 struct SignInView: View {
     @Bindable var viewModel: AuthViewModel
+    @State private var showEmailLogin = false
+    @State private var email = ""
+    @State private var password = ""
+
+    @Environment(\.colorScheme) private var colorScheme
 
     var body: some View {
         VStack(spacing: 40) {
@@ -33,24 +39,95 @@ struct SignInView: View {
                     .padding(.horizontal)
             }
 
-            // Sign In Button
+            // Sign In Buttons
             if viewModel.isLoading {
                 ProgressView()
                     .controlSize(.large)
             } else {
-                GoogleSignInButton(scheme: .dark, style: .wide) {
-                    Task {
-                        await viewModel.signInWithGoogle()
+                VStack(spacing: 16) {
+                    // Sign in with Apple
+                    SignInWithAppleButton(.signIn) { request in
+                        viewModel.appleSignInCoordinator.configureRequest(request)
+                    } onCompletion: { result in
+                        Task {
+                            await viewModel.handleAppleSignInResult(result)
+                        }
                     }
+                    .signInWithAppleButtonStyle(colorScheme == .dark ? .white : .black)
+                    .frame(height: 50)
+                    .padding(.horizontal, 40)
+
+                    // Google Sign-In
+                    GoogleSignInButton(scheme: .dark, style: .wide) {
+                        Task {
+                            await viewModel.signInWithGoogle()
+                        }
+                    }
+                    .frame(height: 50)
+                    .padding(.horizontal, 40)
+
+                    // Email Login (collapsible)
+                    emailLoginSection
                 }
-                .frame(height: 50)
-                .padding(.horizontal, 40)
             }
 
             Spacer()
                 .frame(height: 60)
         }
         .padding()
+    }
+
+    @ViewBuilder
+    private var emailLoginSection: some View {
+        VStack(spacing: 12) {
+            Button {
+                withAnimation(.easeInOut(duration: 0.2)) {
+                    showEmailLogin.toggle()
+                }
+            } label: {
+                HStack {
+                    Rectangle()
+                        .fill(Color.secondary.opacity(0.3))
+                        .frame(height: 1)
+                    Text("メールでログイン")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                    Rectangle()
+                        .fill(Color.secondary.opacity(0.3))
+                        .frame(height: 1)
+                }
+            }
+            .padding(.horizontal, 40)
+
+            if showEmailLogin {
+                VStack(spacing: 10) {
+                    TextField("メールアドレス", text: $email)
+                        .textContentType(.emailAddress)
+                        .keyboardType(.emailAddress)
+                        .autocorrectionDisabled()
+                        .textInputAutocapitalization(.never)
+                        .textFieldStyle(.roundedBorder)
+
+                    SecureField("パスワード", text: $password)
+                        .textContentType(.password)
+                        .textFieldStyle(.roundedBorder)
+
+                    Button {
+                        Task {
+                            await viewModel.signInWithEmail(email: email, password: password)
+                        }
+                    } label: {
+                        Text("ログイン")
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, 12)
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .disabled(email.isEmpty || password.isEmpty)
+                }
+                .padding(.horizontal, 40)
+                .transition(.opacity.combined(with: .move(edge: .top)))
+            }
+        }
     }
 }
 

--- a/CareNoteTests/AuthViewModelTests.swift
+++ b/CareNoteTests/AuthViewModelTests.swift
@@ -1,4 +1,5 @@
 @testable import CareNote
+import Foundation
 import Testing
 
 // MARK: - MockAuthProvider
@@ -20,6 +21,20 @@ final class MockAuthProvider: @unchecked Sendable, AuthProviding {
         if let error = signOutError {
             throw error
         }
+    }
+}
+
+// MARK: - MockEmailAuthProvider
+
+final class MockEmailAuthProvider: @unchecked Sendable, EmailAuthProviding {
+    var signInResult: (userId: String, tenantId: String?, role: UserRole) = ("user-1", "tenant-1", .member)
+    var signInError: Error?
+
+    func signIn(email: String, password: String) async throws -> (userId: String, tenantId: String?, role: UserRole) {
+        if let error = signInError {
+            throw error
+        }
+        return signInResult
     }
 }
 
@@ -116,6 +131,63 @@ struct AuthViewModelTests {
     }
 }
 
+// MARK: - Email Sign-In Tests
+
+@Suite("Email Sign-In Tests")
+struct EmailSignInTests {
+
+    @Test @MainActor
+    func メールサインイン成功時にsignedInになる() async {
+        let mockAuth = MockAuthProvider()
+        let mockEmail = MockEmailAuthProvider()
+        mockEmail.signInResult = (userId: "user-2", tenantId: "tenant-1", role: .member)
+        let vm = AuthViewModel(authProvider: mockAuth, emailAuthProvider: mockEmail)
+
+        await vm.signInWithEmail(email: "test@example.com", password: "password")
+
+        #expect(vm.authState == .signedIn(userId: "user-2", tenantId: "tenant-1", isAdmin: false))
+        #expect(vm.errorMessage == nil)
+    }
+
+    @Test @MainActor
+    func メールサインインでadminの場合isAdminがtrue() async {
+        let mockAuth = MockAuthProvider()
+        let mockEmail = MockEmailAuthProvider()
+        mockEmail.signInResult = (userId: "user-2", tenantId: "tenant-1", role: .admin)
+        let vm = AuthViewModel(authProvider: mockAuth, emailAuthProvider: mockEmail)
+
+        await vm.signInWithEmail(email: "admin@example.com", password: "password")
+
+        #expect(vm.authState == .signedIn(userId: "user-2", tenantId: "tenant-1", isAdmin: true))
+    }
+
+    @Test @MainActor
+    func メールサインインでtenantIdがない場合エラー() async {
+        let mockAuth = MockAuthProvider()
+        let mockEmail = MockEmailAuthProvider()
+        mockEmail.signInResult = (userId: "user-2", tenantId: nil, role: .member)
+        let vm = AuthViewModel(authProvider: mockAuth, emailAuthProvider: mockEmail)
+
+        await vm.signInWithEmail(email: "test@example.com", password: "password")
+
+        #expect(vm.authState == .signedOut)
+        #expect(vm.errorMessage?.contains("テナント情報") == true)
+    }
+
+    @Test @MainActor
+    func メールサインイン失敗時にerrorMessageが設定される() async {
+        let mockAuth = MockAuthProvider()
+        let mockEmail = MockEmailAuthProvider()
+        mockEmail.signInError = NSError(domain: "test", code: -1, userInfo: [NSLocalizedDescriptionKey: "Invalid credentials"])
+        let vm = AuthViewModel(authProvider: mockAuth, emailAuthProvider: mockEmail)
+
+        await vm.signInWithEmail(email: "test@example.com", password: "wrong")
+
+        #expect(vm.authState == .signedOut)
+        #expect(vm.errorMessage?.contains("サインインに失敗しました") == true)
+    }
+}
+
 // MARK: - UserRole Tests
 
 @Suite("UserRole Tests")
@@ -139,5 +211,21 @@ struct UserRoleTests {
 
     @Test func 空文字列はmemberにフォールバック() {
         #expect(UserRole.from(firestoreValue: "") == .member)
+    }
+}
+
+// MARK: - AuthError Tests
+
+@Suite("AuthError Tests")
+struct AuthErrorTests {
+
+    @Test func appleIdTokenMissingが存在する() {
+        let error = AuthError.appleIdTokenMissing
+        #expect(error == .appleIdTokenMissing)
+    }
+
+    @Test func appleSignInCancelledが存在する() {
+        let error = AuthError.appleSignInCancelled
+        #expect(error == .appleSignInCancelled)
     }
 }


### PR DESCRIPTION
## Summary
- App Store Review Guideline 4.8 対応: Sign in with Apple を Firebase Auth と統合して実装
- App Store Review Guideline 2.1(a) 対応: メール/パスワード認証を追加（レビュアー用デモアカウント提供用）
- ログイン画面に Apple / Google / メール・パスワードの3つのログイン方法を提供

## Changes
- `AppleSignInCoordinator`: CryptoKit nonce 生成 + SignInWithAppleButton 連携 + Firebase Auth 統合
- `AuthViewModel`: `handleAppleSignInResult()`, `signInWithEmail()` メソッド追加
- `EmailAuthProviding` プロトコル導入（DI によるテスタビリティ向上）
- `SignInView`: Apple ボタン（最上位）+ Google ボタン + 折りたたみ式メール/パスワード入力
- `CareNote.entitlements`: Sign in with Apple capability 追加
- テスト: Email Sign-In 4件 + AuthError 2件追加（計18件全PASS）

## 手動作業（マージ後）
- [ ] Apple Developer Portal: App ID に Sign in with Apple capability 有効化
- [ ] Firebase Console: Apple プロバイダー + メール/パスワード認証を有効化
- [ ] Firebase Admin: レビュー用デモアカウント作成（tenantId/role クレーム設定済み）
- [ ] App Store Connect: App Review 情報にデモアカウント認証情報を記載
- [ ] TestFlight 再ビルド → App Store Review 再提出

## Test plan
- [x] ビルド成功（iPhone 17 Pro Simulator）
- [x] Auth関連テスト18件全PASS
- [x] 既存テスト全PASS（回帰なし）
- [ ] 実機テスト: Sign in with Apple フロー動作確認
- [ ] 実機テスト: メール/パスワード認証フロー動作確認
- [ ] 実機テスト: 既存 Google Sign-In の正常動作確認

Closes #43 ではありません（別Issue）

🤖 Generated with [Claude Code](https://claude.com/claude-code)