### PR TITLE
fix: RecordingScene/OutputType の英語rawValue表示バグ

### DIFF
--- a/CareNote/Features/RecordingList/RecordingListView.swift
+++ b/CareNote/Features/RecordingList/RecordingListView.swift
@@ -79,7 +79,7 @@ private struct RecordingListRow: View {
             }
 
             HStack {
-                Text(recording.scene)
+                Text(RecordingScene.displayName(forStoredValue: recording.scene))
                     .font(.caption)
                     .foregroundStyle(.secondary)
 
@@ -168,7 +168,7 @@ struct RecordingDetailView: View {
                 // Info Section
                 VStack(alignment: .leading, spacing: 8) {
                     DetailRow(label: "利用者", value: recording.clientName)
-                    DetailRow(label: "シーン", value: recording.scene)
+                    DetailRow(label: "シーン", value: RecordingScene.displayName(forStoredValue: recording.scene))
                     DetailRow(
                         label: "録音日時",
                         value: recording.recordedAt.formatted(

--- a/CareNote/Features/Settings/TemplateListView.swift
+++ b/CareNote/Features/Settings/TemplateListView.swift
@@ -192,7 +192,7 @@ private struct TemplateRow: View {
 
                 Spacer()
 
-                Text(template.outputType)
+                Text(OutputType.displayName(forStoredValue: template.outputType))
                     .font(.caption)
                     .foregroundStyle(.secondary)
                     .padding(.horizontal, 8)

--- a/CareNote/Models/RecordingScene.swift
+++ b/CareNote/Models/RecordingScene.swift
@@ -46,6 +46,13 @@ enum RecordingScene: String, CaseIterable, Codable, Identifiable, Sendable {
         default: return nil
         }
     }
+
+    /// 保存値（英語rawValue or 旧日本語）から表示名を解決する
+    static func displayName(forStoredValue value: String) -> String {
+        RecordingScene(rawValue: value)?.displayName
+            ?? RecordingScene.fromLegacy(value)?.displayName
+            ?? value
+    }
 }
 
 // MARK: - UploadStatus
@@ -97,5 +104,12 @@ enum OutputType: String, CaseIterable, Codable, Sendable, Identifiable {
         case "カスタム": return .custom
         default: return nil
         }
+    }
+
+    /// 保存値（英語rawValue or 旧日本語）から表示名を解決する
+    static func displayName(forStoredValue value: String) -> String {
+        OutputType(rawValue: value)?.displayName
+            ?? OutputType.fromLegacy(value)?.displayName
+            ?? value
     }
 }


### PR DESCRIPTION
## Summary

PR #58 で rawValue を英語安定識別子に移行した際の表示修正漏れ。録音一覧のシーン欄に「訪問」ではなく `visit` と表示されていた。

## 原因

`RecordingScene.rawValue` を英語化（"visit", "meeting" 等）した際、View 側の \`Text(recording.scene)\` は raw string をそのまま表示していた。

## 修正

`RecordingScene` / `OutputType` に \`displayName(forStoredValue:)\` 静的ヘルパーを追加:
- 新 rawValue（英語）→ \`RecordingScene(rawValue:)?.displayName\`
- 旧 rawValue（日本語、既存データ）→ \`fromLegacy()?.displayName\`
- いずれもマッチしない場合はフォールバックで生文字列

修正箇所:
- RecordingListView.swift L82（一覧カード）
- RecordingListView.swift L171（詳細画面）
- TemplateListView.swift L195（個人テンプレート row）

## Test plan

- [x] iOS Build SUCCEEDED
- [ ] 実機: 録音一覧で「訪問」「担当者会議」等が正しく表示されること
- [ ] 実機: 旧日本語 rawValue のレコードも正しく表示されること（後方互換）
- [ ] 実機: 詳細画面・テンプレート一覧でも同様

## Build 34 対象

Build 33 に含めたかった修正のため、これを取り込んで Build 34 として再アップロード予定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)