### PR TITLE
feat: 録音一覧に Firestore → SwiftData 初回同期を追加

### DIFF
--- a/CareNote/Features/RecordingList/RecordingListViewModel.swift
+++ b/CareNote/Features/RecordingList/RecordingListViewModel.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Observation
+import os.log
 import SwiftData
 
 // MARK: - RecordingListViewModel
@@ -15,6 +16,10 @@ final class RecordingListViewModel {
     private let tenantId: String?
 
     private static let pollingInterval: TimeInterval = 5.0
+    /// テナント切替検知に使う UserDefaults キー（テナント境界を越えたキャッシュ混在を防ぐ）
+    private static let lastSyncedTenantKey = "recordingList.lastSyncedTenantId"
+    private static let logger = Logger(subsystem: "jp.carenote.app", category: "RecordingListVM")
+
     private var pollingTask: Task<Void, Never>?
 
     init(
@@ -28,15 +33,51 @@ final class RecordingListViewModel {
     }
 
     /// 録音一覧を読み込む
+    /// - 前回同期時とテナントが違えば、ローカルキャッシュをクリアしてから再取得（テナント越境防止）
+    /// - まず SwiftData を即時表示（オフライン時のフォールバック）
+    /// - 次に Firestore から同期し SwiftData へ upsert
     func loadRecordings() async {
         isLoading = true
+        defer { isLoading = false }
+
+        // 1. テナント切替を検知してローカルキャッシュをクリア
+        handleTenantSwitchIfNeeded()
+
+        // 2. SwiftData を即座に表示（オフライン時のフォールバック）
         do {
             recordings = try recordingRepository.fetchAll()
         } catch {
             recordings = []
             errorMessage = "録音の読み込みに失敗しました"
+            return
         }
-        isLoading = false
+
+        // 3. Firestore から同期し upsert（失敗時は SwiftData のまま継続）
+        guard let firestoreService,
+              let tenantId,
+              !tenantId.isEmpty else { return }
+        do {
+            let remote = try await firestoreService.fetchRecordings(tenantId: tenantId)
+            try recordingRepository.upsertFromFirestore(remote)
+            recordings = try recordingRepository.fetchAll()
+        } catch {
+            Self.logger.info("Firestore sync failed (using local cache): \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    private func handleTenantSwitchIfNeeded() {
+        guard let currentTenant = tenantId, !currentTenant.isEmpty else { return }
+        let defaults = UserDefaults.standard
+        let lastSynced = defaults.string(forKey: Self.lastSyncedTenantKey)
+        guard lastSynced != currentTenant else { return }
+
+        do {
+            try recordingRepository.deleteAll()
+            Self.logger.info("Cleared local recordings for tenant switch: \(lastSynced ?? "nil", privacy: .public) -> \(currentTenant, privacy: .public)")
+        } catch {
+            Self.logger.error("Failed to clear local recordings on tenant switch: \(error.localizedDescription, privacy: .public)")
+        }
+        defaults.set(currentTenant, forKey: Self.lastSyncedTenantKey)
     }
 
     /// 録音の文字起こしを再試行する

--- a/CareNote/Features/RecordingList/RecordingListViewModel.swift
+++ b/CareNote/Features/RecordingList/RecordingListViewModel.swift
@@ -71,13 +71,20 @@ final class RecordingListViewModel {
         let lastSynced = defaults.string(forKey: Self.lastSyncedTenantKey)
         guard lastSynced != currentTenant else { return }
 
+        // 未アップロードの録音を検知して警告（テナント切替時の意図しないデータ喪失を可視化）
+        if let pending = try? recordingRepository.pendingUploads(), !pending.isEmpty {
+            Self.logger.error("Tenant switch (\(lastSynced ?? "nil", privacy: .public) -> \(currentTenant, privacy: .public)) will discard \(pending.count) pending uploads")
+        }
+
         do {
             try recordingRepository.deleteAll()
             Self.logger.info("Cleared local recordings for tenant switch: \(lastSynced ?? "nil", privacy: .public) -> \(currentTenant, privacy: .public)")
+            // 削除成功時のみ UserDefaults を更新（失敗時は次回再試行して越境を防ぐ）
+            defaults.set(currentTenant, forKey: Self.lastSyncedTenantKey)
         } catch {
             Self.logger.error("Failed to clear local recordings on tenant switch: \(error.localizedDescription, privacy: .public)")
+            // UserDefaults を更新しない → 次回 loadRecordings で再試行される
         }
-        defaults.set(currentTenant, forKey: Self.lastSyncedTenantKey)
     }
 
     /// 録音の文字起こしを再試行する

--- a/CareNote/Repositories/RecordingRepository.swift
+++ b/CareNote/Repositories/RecordingRepository.swift
@@ -93,4 +93,59 @@ final class RecordingRepository: @unchecked Sendable {
         )
         return try modelContext.fetch(descriptor)
     }
+
+    /// 全録音レコードと関連 OutboxItem を削除する（テナント切替時のキャッシュクリア用）
+    func deleteAll() throws {
+        let records = try fetchAll()
+        for record in records {
+            let recordingId = record.id
+            let outboxDescriptor = FetchDescriptor<OutboxItem>(
+                predicate: #Predicate { $0.recordingId == recordingId }
+            )
+            if let items = try? modelContext.fetch(outboxDescriptor) {
+                for item in items { modelContext.delete(item) }
+            }
+            modelContext.delete(record)
+        }
+        try modelContext.save()
+    }
+
+    /// Firestore から取得した録音リストを SwiftData に upsert する
+    /// - firestoreId で既存レコードを検索し、存在すれば更新、なければ新規作成
+    /// - localAudioPath は remote-only レコードでは空文字（再生は不可、メタデータのみ表示）
+    func upsertFromFirestore(_ remoteRecordings: [FirestoreRecording]) throws {
+        for remote in remoteRecordings {
+            guard let remoteId = remote.id else { continue }
+
+            let descriptor = FetchDescriptor<RecordingRecord>(
+                predicate: #Predicate { $0.firestoreId == remoteId }
+            )
+            if let existing = try modelContext.fetch(descriptor).first {
+                existing.clientId = remote.clientId
+                existing.clientName = remote.clientName
+                existing.scene = remote.scene
+                existing.recordedAt = remote.recordedAt
+                existing.durationSeconds = remote.durationSeconds
+                existing.transcription = remote.transcription
+                existing.transcriptionStatus = remote.transcriptionStatus
+                existing.uploadStatus = UploadStatus.done.rawValue
+            } else {
+                let new = RecordingRecord(
+                    id: UUID(),
+                    clientId: remote.clientId,
+                    clientName: remote.clientName,
+                    scene: remote.scene,
+                    recordedAt: remote.recordedAt,
+                    durationSeconds: remote.durationSeconds,
+                    localAudioPath: "",
+                    firestoreId: remoteId,
+                    uploadStatus: UploadStatus.done.rawValue,
+                    transcription: remote.transcription,
+                    transcriptionStatus: remote.transcriptionStatus
+                )
+                modelContext.insert(new)
+            }
+        }
+        try modelContext.save()
+    }
 }


### PR DESCRIPTION
## Summary

機種変更・アプリ再インストール時、既存ユーザーの録音が Firestore には存在するが iOS 側でフェッチしていないため一覧に表示されない既存バグを修正。

**確認事例（2026-04-16）**: tenant 279 admin \`y.honda@279279.net\` が新規端末で Firestore に 8件の録音があるにも関わらず UI 0件表示。

## 変更

### RecordingRepository
- \`upsertFromFirestore(_:)\` — Firestore 録音リストを SwiftData に upsert（firestoreId で重複排除）
- \`deleteAll()\` — テナント切替時のキャッシュクリア用

### RecordingListViewModel.loadRecordings
1. テナント切替検知（UserDefaults に lastSyncedTenantId 保持）→ 切替時は SwiftData 全削除
2. SwiftData を即時表示（オフライン時のフォールバック）
3. Firestore から同期し upsert → 再読込
4. Firestore 失敗時は SwiftData 表示のまま（エラー表示なし）

## 既存挙動への影響

| シナリオ | 挙動 |
|---------|------|
| 審査員（新規端末 → demo-guest） | Firestore 0件 → 動作不変 ✅ |
| 既存ユーザー（y.honda@279279.net）新規端末 | Firestore 8件 → SwiftData に upsert → 表示 ✅ |
| オフライン | SwiftData キャッシュで継続 ✅ |
| テナント切替 | 旧テナントデータ自動クリア → 越境なし ✅ |

## Test plan
- [x] Build SUCCEEDED
- [x] RecordingRepositoryTests / RecordingListViewModelTests: 6/6 PASS
- [ ] 実機: y.honda@279279.net で再インストール → tenant 279 の 8件が表示される
- [ ] 実機: アカウント削除 → demo-guest 再ログイン → 空表示（テナント切替で SwiftData クリア動作確認）
- [ ] 実機: オフライン時に既存 SwiftData 表示継続

## Build 35 対象

Build 34 提出前にこの修正を含めたいユーザー要望に対応（実務での使用可能性を優先）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)