### PR TITLE
fix: 録音の createdBy に認証済み uid を保存 (Phase -1 A1+A2+A4)

### DIFF
--- a/CareNote/Features/RecordingConfirm/RecordingConfirmViewModel.swift
+++ b/CareNote/Features/RecordingConfirm/RecordingConfirmViewModel.swift
@@ -1,3 +1,4 @@
+@preconcurrency import FirebaseAuth
 import Foundation
 import Observation
 import os.log
@@ -56,7 +57,8 @@ final class RecordingConfirmViewModel {
                 projectId: AppConfig.gcpProject,
                 accessTokenProvider: wifService
             ),
-            tenantId: tenantId
+            tenantId: tenantId,
+            currentUidProvider: { Auth.auth().currentUser?.uid }
         )
     }
 
@@ -162,6 +164,8 @@ final class RecordingConfirmViewModel {
                     detail = "Max retries: \(id)"
                 case .modelContainerNotAvailable:
                     detail = "ModelContainer unavailable"
+                case .userNotAuthenticated:
+                    detail = "ログインが必要です"
                 }
             } else {
                 detail = "\(error)"

--- a/CareNote/Services/OutboxSyncService.swift
+++ b/CareNote/Services/OutboxSyncService.swift
@@ -210,6 +210,18 @@ actor OutboxSyncService {
             throw OutboxSyncError.recordingNotFound(item.recordingId)
         }
 
+        // Pre-flight auth check for new recordings: avoid uploading audio to
+        // Cloud Storage when Firestore document creation will fail at uid
+        // validation anyway. Prevents medical audio orphaning in Storage during
+        // auth cold-start edge cases (uid nil/empty). `buildFirestoreRecording`
+        // re-validates as a defense-in-depth for existing firestoreId paths.
+        if recording.firestoreId == nil {
+            guard let uid = currentUidProvider(), !uid.isEmpty else {
+                throw OutboxSyncError.userNotAuthenticated
+            }
+            _ = uid
+        }
+
         // Step 1: Upload audio to Cloud Storage
         let localURL = URL(fileURLWithPath: recording.localAudioPath)
         let gcsUri: String

--- a/CareNote/Services/OutboxSyncService.swift
+++ b/CareNote/Services/OutboxSyncService.swift
@@ -11,6 +11,11 @@ enum OutboxSyncError: Error, Sendable {
     case maxRetriesExceeded(UUID)
     case uploadFailed(Error)
     case transcriptionFailed(Error)
+    /// `currentUidProvider` が nil または空文字を返した状態。
+    /// 既存 retry ラダー（3回 exponential backoff）に乗せて扱う: アプリ cold-start 直後に
+    /// outbox item が enqueue された際、FirebaseAuth のセッション復元と競合して一時的に
+    /// uid 未取得になるケースを吸収するため。恒久的な未ログインは 3 回後に
+    /// `.maxRetriesExceeded` として `uploadStatus = error` で終端する。
     case userNotAuthenticated
 }
 
@@ -219,16 +224,14 @@ actor OutboxSyncService {
         }
 
         // Step 2: Create or update Firestore document
-        var firestoreId = recording.firestoreId
-        if firestoreId == nil {
+        let fid: String
+        if let existing = recording.firestoreId {
+            fid = existing
+        } else {
             let recordingData = try await buildFirestoreRecording(recordingId: item.recordingId, gcsUri: gcsUri)
-            firestoreId = try await firestoreService.createRecording(tenantId: tenantId, recording: recordingData)
-            await updateFirestoreId(recordingId: item.recordingId, firestoreId: firestoreId!)
-        }
-
-        guard let fid = firestoreId else {
-            Self.logger.error("firestoreId is nil after Step 2 for recording \(item.recordingId) — skipping transcription")
-            return
+            let newId = try await firestoreService.createRecording(tenantId: tenantId, recording: recordingData)
+            await updateFirestoreId(recordingId: item.recordingId, firestoreId: newId)
+            fid = newId
         }
 
         try? await firestoreService.updateTranscription(
@@ -325,8 +328,14 @@ actor OutboxSyncService {
         }
     }
 
+    /// internal 可視性は OutboxSyncServiceTests から直接呼ぶためのテストシーム。
+    /// 本番コードパスでは `processItem` からのみ呼び出すこと。
     @MainActor
     func buildFirestoreRecording(recordingId: UUID, gcsUri: String) throws -> FirestoreRecording {
+        // issue #99 の二段防御: currentUidProvider は `String?` だが、Firebase Auth が
+        // token refresh 境界等で非 nil の空文字を返す可能性を排除できない。
+        // 空文字で createdBy を保存すると deleteAccount の
+        // `where createdBy == uid` クエリで永遠に孤立化するため、nil 同等に拒否する。
         guard let uid = currentUidProvider(), !uid.isEmpty else {
             throw OutboxSyncError.userNotAuthenticated
         }
@@ -334,7 +343,14 @@ actor OutboxSyncService {
         let descriptor = FetchDescriptor<RecordingRecord>(
             predicate: #Predicate<RecordingRecord> { $0.id == recordingId }
         )
-        guard let record = try? context.fetch(descriptor).first else {
+        let records: [RecordingRecord]
+        do {
+            records = try context.fetch(descriptor)
+        } catch {
+            Self.logger.error("SwiftData fetch failed for \(recordingId): \(error.localizedDescription)")
+            throw error
+        }
+        guard let record = records.first else {
             throw OutboxSyncError.recordingNotFound(recordingId)
         }
 

--- a/CareNote/Services/OutboxSyncService.swift
+++ b/CareNote/Services/OutboxSyncService.swift
@@ -11,6 +11,7 @@ enum OutboxSyncError: Error, Sendable {
     case maxRetriesExceeded(UUID)
     case uploadFailed(Error)
     case transcriptionFailed(Error)
+    case userNotAuthenticated
 }
 
 // MARK: - OutboxSyncService
@@ -31,6 +32,7 @@ actor OutboxSyncService {
     private let firestoreService: any RecordingStoring
     private let transcriptionService: any Transcribing
     private let tenantId: String
+    private let currentUidProvider: @Sendable () -> String?
 
     private var pathMonitor: NWPathMonitor?
     private var monitorQueue: DispatchQueue?
@@ -46,13 +48,15 @@ actor OutboxSyncService {
         storageService: any AudioUploading,
         firestoreService: any RecordingStoring,
         transcriptionService: any Transcribing,
-        tenantId: String
+        tenantId: String,
+        currentUidProvider: @escaping @Sendable () -> String?
     ) {
         self.modelContainer = modelContainer
         self.storageService = storageService
         self.firestoreService = firestoreService
         self.transcriptionService = transcriptionService
         self.tenantId = tenantId
+        self.currentUidProvider = currentUidProvider
     }
 
     // MARK: - Queue Management
@@ -217,11 +221,9 @@ actor OutboxSyncService {
         // Step 2: Create or update Firestore document
         var firestoreId = recording.firestoreId
         if firestoreId == nil {
-            let recordingData = await buildFirestoreRecording(recordingId: item.recordingId, gcsUri: gcsUri)
-            if let data = recordingData {
-                firestoreId = try await firestoreService.createRecording(tenantId: tenantId, recording: data)
-                await updateFirestoreId(recordingId: item.recordingId, firestoreId: firestoreId!)
-            }
+            let recordingData = try await buildFirestoreRecording(recordingId: item.recordingId, gcsUri: gcsUri)
+            firestoreId = try await firestoreService.createRecording(tenantId: tenantId, recording: recordingData)
+            await updateFirestoreId(recordingId: item.recordingId, firestoreId: firestoreId!)
         }
 
         guard let fid = firestoreId else {
@@ -324,12 +326,17 @@ actor OutboxSyncService {
     }
 
     @MainActor
-    private func buildFirestoreRecording(recordingId: UUID, gcsUri: String) -> FirestoreRecording? {
+    func buildFirestoreRecording(recordingId: UUID, gcsUri: String) throws -> FirestoreRecording {
+        guard let uid = currentUidProvider(), !uid.isEmpty else {
+            throw OutboxSyncError.userNotAuthenticated
+        }
         let context = modelContainer.mainContext
         let descriptor = FetchDescriptor<RecordingRecord>(
             predicate: #Predicate<RecordingRecord> { $0.id == recordingId }
         )
-        guard let record = try? context.fetch(descriptor).first else { return nil }
+        guard let record = try? context.fetch(descriptor).first else {
+            throw OutboxSyncError.recordingNotFound(recordingId)
+        }
 
         return FirestoreRecording(
             clientId: record.clientId,
@@ -340,7 +347,7 @@ actor OutboxSyncService {
             audioStoragePath: gcsUri,
             transcription: nil,
             transcriptionStatus: TranscriptionStatus.processing.rawValue,
-            createdBy: "",
+            createdBy: uid,
             createdAt: record.recordedAt,
             updatedAt: Date()
         )

--- a/CareNoteTests/OutboxSyncServiceTests.swift
+++ b/CareNoteTests/OutboxSyncServiceTests.swift
@@ -24,7 +24,10 @@ struct OutboxSyncServiceTests {
         )
     }
 
-    private static func makeService(container: ModelContainer) -> OutboxSyncService {
+    private static func makeService(
+        container: ModelContainer,
+        currentUidProvider: @escaping @Sendable () -> String? = { "test-uid" }
+    ) -> OutboxSyncService {
         let tokenProvider = StubAccessTokenProvider()
         return OutboxSyncService(
             modelContainer: container,
@@ -37,7 +40,8 @@ struct OutboxSyncServiceTests {
                 projectId: "test-project",
                 accessTokenProvider: tokenProvider
             ),
-            tenantId: "test-tenant"
+            tenantId: "test-tenant",
+            currentUidProvider: currentUidProvider
         )
     }
 
@@ -122,5 +126,101 @@ struct OutboxSyncServiceTests {
 
         #expect(recording.uploadStatus == UploadStatus.error.rawValue)
         #expect(recording.transcriptionStatus == TranscriptionStatus.done.rawValue)
+    }
+
+    // MARK: - createdBy / uid Tests
+
+    @Test @MainActor
+    func buildFirestoreRecordingでcurrentUidProviderが返すuidがcreatedByに入る() async throws {
+        let container = try Self.makeContainer()
+        let context = container.mainContext
+        let service = Self.makeService(
+            container: container,
+            currentUidProvider: { "expected-uid-123" }
+        )
+
+        let recordingId = UUID()
+        let recording = RecordingRecord(
+            id: recordingId,
+            clientId: "client-1",
+            clientName: "テスト利用者",
+            scene: RecordingScene.visit.rawValue,
+            localAudioPath: "/tmp/test.m4a"
+        )
+        context.insert(recording)
+        try context.save()
+
+        let result = try await service.buildFirestoreRecording(
+            recordingId: recordingId,
+            gcsUri: "gs://test-bucket/test.m4a"
+        )
+
+        #expect(result.createdBy == "expected-uid-123")
+        #expect(!result.createdBy.isEmpty)
+    }
+
+    @Test @MainActor
+    func buildFirestoreRecordingでuidが取れない場合はuserNotAuthenticatedエラー() async throws {
+        let container = try Self.makeContainer()
+        let context = container.mainContext
+        let service = Self.makeService(
+            container: container,
+            currentUidProvider: { nil }
+        )
+
+        let recordingId = UUID()
+        let recording = RecordingRecord(
+            id: recordingId,
+            clientId: "client-1",
+            clientName: "テスト利用者",
+            scene: RecordingScene.visit.rawValue,
+            localAudioPath: "/tmp/test.m4a"
+        )
+        context.insert(recording)
+        try context.save()
+
+        await #expect(throws: OutboxSyncError.self) {
+            _ = try await service.buildFirestoreRecording(
+                recordingId: recordingId,
+                gcsUri: "gs://test-bucket/test.m4a"
+            )
+        }
+    }
+
+    @Test @MainActor
+    func buildFirestoreRecordingで更新対象外フィールドは既存値を保持する() async throws {
+        let container = try Self.makeContainer()
+        let context = container.mainContext
+        let service = Self.makeService(
+            container: container,
+            currentUidProvider: { "uid-xyz" }
+        )
+
+        let recordingId = UUID()
+        let recordedAt = Date(timeIntervalSince1970: 1_700_000_000)
+        let recording = RecordingRecord(
+            id: recordingId,
+            clientId: "client-A",
+            clientName: "山田太郎",
+            scene: RecordingScene.assessment.rawValue,
+            recordedAt: recordedAt,
+            durationSeconds: 123.45,
+            localAudioPath: "/tmp/test.m4a"
+        )
+        context.insert(recording)
+        try context.save()
+
+        let result = try await service.buildFirestoreRecording(
+            recordingId: recordingId,
+            gcsUri: "gs://test-bucket/test.m4a"
+        )
+
+        #expect(result.clientId == "client-A")
+        #expect(result.clientName == "山田太郎")
+        #expect(result.scene == RecordingScene.assessment.rawValue)
+        #expect(result.recordedAt == recordedAt)
+        #expect(result.durationSeconds == 123.45)
+        #expect(result.audioStoragePath == "gs://test-bucket/test.m4a")
+        #expect(result.createdBy == "uid-xyz")
     }
 }

--- a/CareNoteTests/OutboxSyncServiceTests.swift
+++ b/CareNoteTests/OutboxSyncServiceTests.swift
@@ -188,6 +188,36 @@ struct OutboxSyncServiceTests {
     }
 
     @Test @MainActor
+    func buildFirestoreRecordingでuidが空文字の場合もuserNotAuthenticatedエラー() async throws {
+        // issue #99 二段防御の境界値テスト: nil と空文字を独立にカバー。
+        // `currentUidProvider` が non-nil な空文字を返しても createdBy は保存されない。
+        let container = try Self.makeContainer()
+        let context = container.mainContext
+        let service = Self.makeService(
+            container: container,
+            currentUidProvider: { "" }
+        )
+
+        let recordingId = UUID()
+        let recording = RecordingRecord(
+            id: recordingId,
+            clientId: "client-1",
+            clientName: "テスト利用者",
+            scene: RecordingScene.visit.rawValue,
+            localAudioPath: "/tmp/test.m4a"
+        )
+        context.insert(recording)
+        try context.save()
+
+        await #expect(throws: OutboxSyncError.self) {
+            _ = try await service.buildFirestoreRecording(
+                recordingId: recordingId,
+                gcsUri: "gs://test-bucket/test.m4a"
+            )
+        }
+    }
+
+    @Test @MainActor
     func buildFirestoreRecordingで更新対象外フィールドは既存値を保持する() async throws {
         let container = try Self.makeContainer()
         let context = container.mainContext

--- a/functions/index.js
+++ b/functions/index.js
@@ -126,12 +126,24 @@ exports.deleteAccount = onCall(
     }
 
     const db = getFirestore();
-    const recordingsSnap = await db
-      .collection("tenants")
-      .doc(tenantId)
-      .collection("recordings")
-      .where("createdBy", "==", uid)
-      .get();
+    let recordingsSnap;
+    try {
+      recordingsSnap = await db
+        .collection("tenants")
+        .doc(tenantId)
+        .collection("recordings")
+        .where("createdBy", "==", uid)
+        .get();
+    } catch (err) {
+      // Query failure (permissions, transient, missing index) must not block
+      // Auth user deletion. App Store 5.1.1(v) requires identity removal even
+      // when data cleanup fails; orphan recordings can be reaped by support
+      // tooling. Proceed with empty snapshot.
+      console.error("[deleteAccount] recordings query failed, proceeding to auth-delete", {
+        uid, tenantId, code: err.code, message: err.message,
+      });
+      recordingsSnap = { docs: [] };
+    }
 
     const cleanupPromises = [];
     for (const doc of recordingsSnap.docs) {

--- a/functions/scripts/audit-createdby.mjs
+++ b/functions/scripts/audit-createdby.mjs
@@ -1,0 +1,118 @@
+#!/usr/bin/env node
+// Usage: node functions/scripts/audit-createdby.mjs [PROJECT_ID]
+//   PROJECT_ID defaults to carenote-dev-279.
+//   Use carenote-prod-279 only after explicit approval (see CLAUDE.md Dev/Prod 分離).
+//
+// Audits the distribution of `createdBy` in every tenant's recordings
+// collection. Motivated by issue #99: existing data was saved with an
+// empty string, breaking deleteAccount and future ownership transfer.
+//
+// Uses Firestore REST API with gcloud user access token (IAM roles/datastore.viewer
+// or higher required). Does not go through Admin SDK to avoid service account key handling.
+// Access token is obtained via execFileSync (no shell) with hardcoded argv.
+
+import { execFileSync } from "node:child_process";
+
+const projectId = process.argv[2] || "carenote-dev-279";
+const base = `https://firestore.googleapis.com/v1/projects/${projectId}/databases/(default)/documents`;
+
+function token() {
+  return execFileSync("gcloud", ["auth", "print-access-token"]).toString().trim();
+}
+
+async function getJson(url) {
+  const res = await fetch(url, {
+    headers: { Authorization: `Bearer ${token()}` },
+  });
+  if (!res.ok) {
+    throw new Error(`HTTP ${res.status} for ${url}: ${await res.text()}`);
+  }
+  return res.json();
+}
+
+async function listAllDocuments(path, pageSize = 300) {
+  const docs = [];
+  let pageToken = null;
+  while (true) {
+    const url = new URL(`${base}/${path}`);
+    url.searchParams.set("pageSize", String(pageSize));
+    if (pageToken) url.searchParams.set("pageToken", pageToken);
+    const data = await getJson(url.toString());
+    if (data.documents) docs.push(...data.documents);
+    if (!data.nextPageToken) break;
+    pageToken = data.nextPageToken;
+  }
+  return docs;
+}
+
+function emptyBucket() {
+  return { empty: 0, missing: 0, nonEmpty: 0, uniqueUids: new Set() };
+}
+
+function summarize(bucket) {
+  const total = bucket.empty + bucket.missing + bucket.nonEmpty;
+  return { total, ...bucket, uniqueUidCount: bucket.uniqueUids.size };
+}
+
+async function audit() {
+  console.log(`\nAuditing createdBy distribution in project: ${projectId}\n`);
+
+  const tenants = await listAllDocuments("tenants");
+  const overall = emptyBucket();
+  const perTenant = [];
+
+  for (const tenantDoc of tenants) {
+    const tenantId = tenantDoc.name.split("/").pop();
+    const recordings = await listAllDocuments(`tenants/${tenantId}/recordings`);
+
+    const bucket = emptyBucket();
+    for (const doc of recordings) {
+      const fields = doc.fields || {};
+      if (!("createdBy" in fields)) {
+        bucket.missing++;
+        overall.missing++;
+      } else {
+        const value = fields.createdBy.stringValue;
+        if (value === undefined || value === null || value === "") {
+          bucket.empty++;
+          overall.empty++;
+        } else {
+          bucket.nonEmpty++;
+          overall.nonEmpty++;
+          bucket.uniqueUids.add(value);
+          overall.uniqueUids.add(value);
+        }
+      }
+    }
+    perTenant.push({ tenantId, ...summarize(bucket) });
+  }
+
+  for (const t of perTenant) {
+    console.log(`Tenant: ${t.tenantId}`);
+    console.log(`  Total recordings : ${t.total}`);
+    console.log(`  Empty string     : ${t.empty}`);
+    console.log(`  Missing field    : ${t.missing}`);
+    console.log(`  Non-empty        : ${t.nonEmpty} (${t.uniqueUidCount} unique uids)`);
+    console.log();
+  }
+
+  const o = summarize(overall);
+  console.log("=== OVERALL ===");
+  console.log(`Total recordings : ${o.total}`);
+  console.log(`Empty string     : ${o.empty}`);
+  console.log(`Missing field    : ${o.missing}`);
+  console.log(`Non-empty        : ${o.nonEmpty} (${o.uniqueUidCount} unique uids)`);
+  console.log();
+
+  const needsBackfill = o.empty + o.missing;
+  if (needsBackfill > 0) {
+    console.log(`⚠️  ${needsBackfill} recordings need backfill (empty or missing createdBy)`);
+    process.exit(2);
+  }
+  console.log("✅ All recordings have non-empty createdBy.");
+}
+
+audit().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/functions/test/delete-account.test.js
+++ b/functions/test/delete-account.test.js
@@ -188,4 +188,38 @@ describe("deleteAccount Callable Function", () => {
       assert.ok(e.message.includes("セッション情報が不完全"), `unexpected: ${e.message}`);
     }
   });
+
+  it("recordings query が失敗しても Auth user 削除は走る (C-Cdx-3)", async () => {
+    // Monkey-patch: where().get() を reject させる
+    const adminFirestore = require("firebase-admin/firestore");
+    const originalGetFirestore = adminFirestore.getFirestore;
+    adminFirestore.getFirestore = () => ({
+      collection: () => ({
+        doc: () => ({
+          collection: () => ({
+            where: () => ({
+              get: async () => {
+                const err = new Error("PERMISSION_DENIED");
+                err.code = 7;
+                throw err;
+              },
+            }),
+          }),
+        }),
+      }),
+    });
+
+    try {
+      const result = await deleteAccount({
+        auth: { uid: "alice", token: { tenantId: "279" } },
+        data: {},
+      });
+      assert.deepStrictEqual(result, { success: true });
+      assert.deepStrictEqual(deletedDocs, [], "query 失敗時は削除対象ゼロ扱い");
+      assert.deepStrictEqual(deletedStorageFiles, []);
+      assert.deepStrictEqual(deletedUids, ["alice"], "Auth user は削除される (App Store 5.1.1(v))");
+    } finally {
+      adminFirestore.getFirestore = originalGetFirestore;
+    }
+  });
 });

--- a/functions/test/delete-account.test.js
+++ b/functions/test/delete-account.test.js
@@ -1,0 +1,191 @@
+const assert = require("assert");
+const functionsTest = require("firebase-functions-test");
+
+const test = functionsTest();
+
+let mockFirestoreData = {};
+let deletedDocs = [];
+let deletedStorageFiles = [];
+let deletedUids = [];
+
+function resetState() {
+  mockFirestoreData = {};
+  deletedDocs = [];
+  deletedStorageFiles = [];
+  deletedUids = [];
+}
+
+before(() => {
+  function createDocRef(path) {
+    return {
+      collection: (subPath) => createCollectionRef(`${path}/${subPath}`),
+      delete: async () => {
+        deletedDocs.push(path);
+        delete mockFirestoreData[path];
+      },
+    };
+  }
+
+  function createCollectionRef(path) {
+    return {
+      doc: (id) => createDocRef(`${path}/${id}`),
+      where: (field, _op, value) => ({
+        get: async () => {
+          const docs = Object.entries(mockFirestoreData)
+            .filter(([key, data]) => key.startsWith(path + "/") && data[field] === value)
+            .map(([key, data]) => ({
+              id: key.split("/").pop(),
+              data: () => data,
+              ref: createDocRef(key),
+            }));
+          return { docs };
+        },
+      }),
+    };
+  }
+
+  const firestoreMock = () => ({
+    collection: (path) => createCollectionRef(path),
+  });
+
+  const adminFirestore = require("firebase-admin/firestore");
+  adminFirestore.getFirestore = firestoreMock;
+
+  const adminStorage = require("firebase-admin/storage");
+  adminStorage.getStorage = () => ({
+    bucket: (name) => ({
+      file: (path) => ({
+        delete: async () => {
+          deletedStorageFiles.push(`${name}/${path}`);
+        },
+      }),
+    }),
+  });
+
+  const adminAuth = require("firebase-admin/auth");
+  adminAuth.getAuth = () => ({
+    deleteUser: async (uid) => {
+      deletedUids.push(uid);
+    },
+  });
+});
+
+afterEach(() => {
+  resetState();
+});
+
+after(() => {
+  test.cleanup();
+});
+
+let deleteAccount;
+before(() => {
+  delete require.cache[require.resolve("../index")];
+  const functions = require("../index");
+  deleteAccount = test.wrap(functions.deleteAccount);
+});
+
+describe("deleteAccount Callable Function", () => {
+  it("caller の createdBy と一致する recording を削除し、Storage audio と Auth user を削除する", async () => {
+    mockFirestoreData["tenants/279/recordings/r1"] = {
+      createdBy: "alice",
+      audioStoragePath: "gs://audio-bucket/279/r1.m4a",
+    };
+    mockFirestoreData["tenants/279/recordings/r2"] = {
+      createdBy: "alice",
+      audioStoragePath: "gs://audio-bucket/279/r2.m4a",
+    };
+    mockFirestoreData["tenants/279/recordings/r3"] = {
+      createdBy: "bob",
+      audioStoragePath: "gs://audio-bucket/279/r3.m4a",
+    };
+
+    const result = await deleteAccount({
+      auth: { uid: "alice", token: { tenantId: "279" } },
+      data: {},
+    });
+
+    assert.deepStrictEqual(result, { success: true });
+    assert.deepStrictEqual(deletedDocs.sort(), [
+      "tenants/279/recordings/r1",
+      "tenants/279/recordings/r2",
+    ]);
+    assert.deepStrictEqual(deletedStorageFiles.sort(), [
+      "audio-bucket/279/r1.m4a",
+      "audio-bucket/279/r2.m4a",
+    ]);
+    assert.deepStrictEqual(deletedUids, ["alice"]);
+    assert.ok("tenants/279/recordings/r3" in mockFirestoreData, "bob の録音は残る");
+  });
+
+  it("createdBy が空文字の既存データは削除されない（issue #99 regression）", async () => {
+    mockFirestoreData["tenants/279/recordings/r1"] = {
+      createdBy: "",
+      audioStoragePath: "gs://audio-bucket/279/r1.m4a",
+    };
+    mockFirestoreData["tenants/279/recordings/r2"] = {
+      createdBy: "",
+      audioStoragePath: "gs://audio-bucket/279/r2.m4a",
+    };
+
+    const result = await deleteAccount({
+      auth: { uid: "alice", token: { tenantId: "279" } },
+      data: {},
+    });
+
+    assert.deepStrictEqual(result, { success: true });
+    assert.deepStrictEqual(deletedDocs, [], "createdBy が空文字の録音は uid='alice' クエリにヒットしない");
+    assert.deepStrictEqual(deletedStorageFiles, []);
+    assert.deepStrictEqual(deletedUids, ["alice"], "Auth user は常に削除される");
+  });
+
+  it("recording 0件でも Auth user 削除は走る", async () => {
+    const result = await deleteAccount({
+      auth: { uid: "carol", token: { tenantId: "279" } },
+      data: {},
+    });
+
+    assert.deepStrictEqual(result, { success: true });
+    assert.deepStrictEqual(deletedDocs, []);
+    assert.deepStrictEqual(deletedStorageFiles, []);
+    assert.deepStrictEqual(deletedUids, ["carol"]);
+  });
+
+  it("audioStoragePath が gs:// でない場合は Storage 削除をスキップして継続", async () => {
+    mockFirestoreData["tenants/279/recordings/r1"] = {
+      createdBy: "alice",
+      audioStoragePath: "https://invalid-url/file.m4a",
+    };
+
+    const result = await deleteAccount({
+      auth: { uid: "alice", token: { tenantId: "279" } },
+      data: {},
+    });
+
+    assert.deepStrictEqual(result, { success: true });
+    assert.deepStrictEqual(deletedDocs, ["tenants/279/recordings/r1"], "Firestore 削除は実行される");
+    assert.deepStrictEqual(deletedStorageFiles, [], "parseできない gs URI は Storage 削除されない");
+    assert.deepStrictEqual(deletedUids, ["alice"]);
+  });
+
+  it("未認証で呼び出されると unauthenticated エラー", async () => {
+    try {
+      await deleteAccount({ auth: null, data: {} });
+      assert.fail("Should have thrown");
+    } catch (e) {
+      assert.ok(e.message.includes("ログイン"), `unexpected: ${e.message}`);
+    }
+  });
+
+  it("tenantId claim がない場合は failed-precondition エラー", async () => {
+    try {
+      await deleteAccount({
+        auth: { uid: "alice", token: {} },
+        data: {},
+      });
+      assert.fail("Should have thrown");
+    } catch (e) {
+      assert.ok(e.message.includes("セッション情報が不完全"), `unexpected: ${e.message}`);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- アカウント移行機能設計中に発見された重大バグ #99 の先行修正
- Codex セカンドオピニオンで仮説を得て、実コード + dev/prod Firestore 監査で **全 29 recordings (dev 21 + prod 8) の `createdBy` が空文字** であることを実証
- 現状 `deleteAccount` Cloud Function の `where("createdBy", "==", uid)` は 0 件ヒットで何も削除していなかった（App Store 5.1.1(v) 要件の実装が実質未達）
- 新規録音で正しい uid を保存する修正、監査スクリプト、deleteAccount 回帰テストを追加

### 変更内容

- **A1** (`7a56b78`) `OutboxSyncService` に `currentUidProvider` を DI、`createdBy: uid` を正しく保存。uid 取得失敗時は `OutboxSyncError.userNotAuthenticated` を throw して既存 retry ロジックに乗せる
- **A2** (`21214da`) `functions/scripts/audit-createdby.mjs`: Firestore REST API で全テナントの `createdBy` 分布を計測する read-only スクリプト
- **A4** (`94fadb2`) `functions/test/delete-account.test.js`: offline mode で Firestore/Storage/Auth をモックした deleteAccount 統合テスト 6 ケース（正常系・空文字 regression・Storage parse 失敗・認証/claim 境界）

### 関連

- Closes: なし（#99 は A3 バックフィル実行後にクローズ予定）
- Refs: #99
- 次 PR: `feature/backfill-createdby`（A3 の運用スクリプト + 実行ログ）
- 監査結果コメント: https://github.com/system-279/carenote-ios/issues/99#issuecomment-4280522204

## Test plan

- [x] `xcodebuild -scheme CareNote -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:CareNoteTests/OutboxSyncServiceTests test` → 6/6 PASS（新規 3 + 既存 3）
- [x] `xcodebuild ... build` 全体 BUILD SUCCEEDED
- [x] `cd functions && npx mocha test/auth-blocking.test.js test/delete-account.test.js` → 20/20 PASS
- [x] `node functions/scripts/audit-createdby.mjs carenote-dev-279` 実行（21件空文字を確認）
- [x] `CLOUDSDK_ACTIVE_CONFIG_NAME=carenote-prod node functions/scripts/audit-createdby.mjs carenote-prod-279` 実行（8件空文字を確認、ユーザー承認済）
- [ ] PR レビュー後、マージ前に再度 iOS + functions ビルドを通す

## マージ後の注意

- 本 PR は新規録音への正しい uid 保存のみ。既存の 29 件は依然として `createdBy: ""` のまま
- 既存データは A3 (別 PR) でバックフィルするまで `deleteAccount` で削除されない
- A3 では紐付け不能なものを `"unknown"` で埋める方針（`/impl-plan` で合意済）

🤖 Generated with [Claude Code](https://claude.com/claude-code)