### PR TITLE
chore: A3 dev バックフィル削除スクリプト + 実行済み (Phase -1 A3)

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -4,7 +4,7 @@
   "description": "CareNote Cloud Functions & Firestore Rules Tests",
   "main": "index.js",
   "scripts": {
-    "test": "mocha --timeout 10000 --exit test/**/*.test.js",
+    "test": "mocha --timeout 10000 --exit \"test/**/*.test.{js,mjs}\"",
     "test:rules": "mocha --timeout 10000 --exit test/firestore-rules.test.js",
     "test:auth": "mocha --timeout 10000 --exit test/auth-blocking.test.js"
   },

--- a/functions/scripts/delete-empty-createdby.mjs
+++ b/functions/scripts/delete-empty-createdby.mjs
@@ -1,0 +1,181 @@
+#!/usr/bin/env node
+// Usage:
+//   node functions/scripts/delete-empty-createdby.mjs <PROJECT_ID>            # dry-run (default)
+//   node functions/scripts/delete-empty-createdby.mjs <PROJECT_ID> --execute  # actually delete
+//
+// Rationale: Issue #99 / Phase -1 A3.
+// Existing recordings were saved with createdBy="" (pre PR #101 bug).
+// `deleteAccount` filters by `createdBy == uid`, so these orphans are never removed.
+// Per ADR-008 / stakeholder decision, they are treated as development/test data and deleted
+// (Firestore doc + Cloud Storage audio object).
+//
+// Safety:
+// - Targets ONLY recordings where `createdBy` is empty string / null / undefined / missing field.
+// - Recordings with non-empty `createdBy` are never touched.
+// - Dry-run is the default; `--execute` must be passed explicitly.
+// - Uses Firestore / Cloud Storage REST with `gcloud auth print-access-token` (no SA key).
+
+import { execFileSync } from "node:child_process";
+
+const projectId = process.argv[2];
+const shouldExecute = process.argv.includes("--execute");
+
+if (!projectId) {
+  console.error("Usage: node delete-empty-createdby.mjs <PROJECT_ID> [--execute]");
+  process.exit(1);
+}
+
+const firestoreBase = `https://firestore.googleapis.com/v1/projects/${projectId}/databases/(default)/documents`;
+
+function token() {
+  return execFileSync("gcloud", ["auth", "print-access-token"]).toString().trim();
+}
+
+async function restGet(url) {
+  const res = await fetch(url, { headers: { Authorization: `Bearer ${token()}` } });
+  if (!res.ok) throw new Error(`GET ${url} -> ${res.status}: ${await res.text()}`);
+  return res.json();
+}
+
+async function restDelete(url) {
+  const res = await fetch(url, {
+    method: "DELETE",
+    headers: { Authorization: `Bearer ${token()}` },
+  });
+  // 404 is acceptable (already deleted); others are errors.
+  if (res.status !== 200 && res.status !== 204 && res.status !== 404) {
+    throw new Error(`DELETE ${url} -> ${res.status}: ${await res.text()}`);
+  }
+  return res.status;
+}
+
+async function listAllDocs(path, pageSize = 300) {
+  const docs = [];
+  let pageToken = null;
+  while (true) {
+    const url = new URL(`${firestoreBase}/${path}`);
+    url.searchParams.set("pageSize", String(pageSize));
+    if (pageToken) url.searchParams.set("pageToken", pageToken);
+    const data = await restGet(url.toString());
+    if (data.documents) docs.push(...data.documents);
+    if (!data.nextPageToken) break;
+    pageToken = data.nextPageToken;
+  }
+  return docs;
+}
+
+function parseGsUri(uri) {
+  if (!uri || typeof uri !== "string" || !uri.startsWith("gs://")) return null;
+  const withoutScheme = uri.slice(5);
+  const slash = withoutScheme.indexOf("/");
+  if (slash === -1) return null;
+  return {
+    bucket: withoutScheme.slice(0, slash),
+    object: withoutScheme.slice(slash + 1),
+  };
+}
+
+async function deleteStorageObject(bucket, object) {
+  const encoded = encodeURIComponent(object);
+  const url = `https://storage.googleapis.com/storage/v1/b/${bucket}/o/${encoded}`;
+  return restDelete(url);
+}
+
+async function deleteFirestoreDoc(docName) {
+  return restDelete(`https://firestore.googleapis.com/v1/${docName}`);
+}
+
+function isEmptyCreatedBy(fields) {
+  if (!("createdBy" in fields)) return true;
+  const v = fields.createdBy.stringValue;
+  return v === undefined || v === null || v === "";
+}
+
+async function main() {
+  console.log(`\nMode     : ${shouldExecute ? "EXECUTE (will delete)" : "DRY-RUN (no changes)"}`);
+  console.log(`Project  : ${projectId}\n`);
+
+  const tenants = await listAllDocs("tenants");
+  const targets = [];
+
+  for (const tenantDoc of tenants) {
+    const tenantId = tenantDoc.name.split("/").pop();
+    const recordings = await listAllDocs(`tenants/${tenantId}/recordings`);
+    for (const rec of recordings) {
+      if (isEmptyCreatedBy(rec.fields || {})) {
+        targets.push({
+          tenantId,
+          id: rec.name.split("/").pop(),
+          docName: rec.name,
+          audioStoragePath: rec.fields?.audioStoragePath?.stringValue,
+          recordedAt: rec.fields?.recordedAt?.timestampValue,
+        });
+      }
+    }
+  }
+
+  console.log(`Targets : ${targets.length}\n`);
+  for (const t of targets) {
+    console.log(
+      `  [${t.tenantId}] ${t.id}  audio=${t.audioStoragePath || "(none)"}  recordedAt=${t.recordedAt || "(none)"}`,
+    );
+  }
+
+  if (!shouldExecute) {
+    console.log(`\nDRY-RUN finished. Re-run with --execute to actually delete.`);
+    return;
+  }
+
+  if (targets.length === 0) {
+    console.log("\nNothing to delete.");
+    return;
+  }
+
+  console.log("\nExecuting deletion...\n");
+  const counters = {
+    storageOk: 0,
+    storageSkip: 0,
+    storageErr: 0,
+    firestoreOk: 0,
+    firestoreErr: 0,
+  };
+
+  for (const t of targets) {
+    const parsed = parseGsUri(t.audioStoragePath);
+    if (parsed) {
+      try {
+        const s = await deleteStorageObject(parsed.bucket, parsed.object);
+        console.log(`  storage   : gs://${parsed.bucket}/${parsed.object} -> ${s}`);
+        counters.storageOk++;
+      } catch (e) {
+        console.error(`  storage ! : gs://${parsed.bucket}/${parsed.object}: ${e.message}`);
+        counters.storageErr++;
+      }
+    } else {
+      console.log(`  storage   : skipped (no parseable gs:// URI)`);
+      counters.storageSkip++;
+    }
+
+    try {
+      const s = await deleteFirestoreDoc(t.docName);
+      console.log(`  firestore : ${t.docName} -> ${s}`);
+      counters.firestoreOk++;
+    } catch (e) {
+      console.error(`  firestore!: ${t.docName}: ${e.message}`);
+      counters.firestoreErr++;
+    }
+  }
+
+  console.log(`\n=== Result ===`);
+  console.log(`Storage  : ok=${counters.storageOk} skip=${counters.storageSkip} err=${counters.storageErr}`);
+  console.log(`Firestore: ok=${counters.firestoreOk} err=${counters.firestoreErr}`);
+
+  if (counters.firestoreErr > 0 || counters.storageErr > 0) {
+    process.exit(2);
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/functions/scripts/delete-empty-createdby.mjs
+++ b/functions/scripts/delete-empty-createdby.mjs
@@ -3,104 +3,193 @@
 //   node functions/scripts/delete-empty-createdby.mjs <PROJECT_ID>            # dry-run (default)
 //   node functions/scripts/delete-empty-createdby.mjs <PROJECT_ID> --execute  # actually delete
 //
-// Rationale: Issue #99 / Phase -1 A3.
+// Prod deletion additionally requires the CONFIRM_PROD=yes environment variable.
+//
+// Rationale: Issue #99.
 // Existing recordings were saved with createdBy="" (pre PR #101 bug).
 // `deleteAccount` filters by `createdBy == uid`, so these orphans are never removed.
-// Per ADR-008 / stakeholder decision, they are treated as development/test data and deleted
-// (Firestore doc + Cloud Storage audio object).
+// Per ADR-008 / stakeholder decision, they are treated as development/test data
+// and deleted (Firestore doc + Cloud Storage audio object).
 //
 // Safety:
-// - Targets ONLY recordings where `createdBy` is empty string / null / undefined / missing field.
-// - Recordings with non-empty `createdBy` are never touched.
-// - Dry-run is the default; `--execute` must be passed explicitly.
-// - Uses Firestore / Cloud Storage REST with `gcloud auth print-access-token` (no SA key).
+// - Dry-run is the default. `--execute` must be passed explicitly, AND prod
+//   additionally requires CONFIRM_PROD=yes (multi-layer guard against the
+//   dev/prod mix-up risk called out in CLAUDE.md Dev/Prod 分離).
+// - Targets ONLY recordings where createdBy is empty string, nullValue, or
+//   missing field. Unknown REST value shapes are treated as populated so we
+//   never delete a record we don't fully understand.
+// - Storage is deleted BEFORE Firestore. On Storage error, the Firestore
+//   delete is skipped to avoid orphaning the audio object (the same class of
+//   bug we're here to clean up).
+// - Before each delete, the document is re-fetched and re-checked (TOCTOU
+//   guard) so a concurrent backfill can't be clobbered.
+// - Firestore DELETE requires 200/204 (404 is treated as a URL/consistency
+//   bug, not silent idempotency). Cloud Storage DELETE accepts 404 because
+//   the GCS API documents that as idempotent.
+// - gcloud user token is used (not a SA key) so the audit trail attributes
+//   deletions to the operator; SA key distribution is also prohibited by
+//   project CLAUDE.md.
 
 import { execFileSync } from "node:child_process";
 
-const projectId = process.argv[2];
-const shouldExecute = process.argv.includes("--execute");
-
-if (!projectId) {
-  console.error("Usage: node delete-empty-createdby.mjs <PROJECT_ID> [--execute]");
-  process.exit(1);
+export function isEmptyCreatedBy(fields) {
+  const f = fields?.createdBy;
+  if (f === undefined) return true;
+  if ("nullValue" in f) return true;
+  if ("stringValue" in f) return f.stringValue === "";
+  return false;
 }
 
-const firestoreBase = `https://firestore.googleapis.com/v1/projects/${projectId}/databases/(default)/documents`;
-
-function token() {
-  return execFileSync("gcloud", ["auth", "print-access-token"]).toString().trim();
+export function parseGsUri(uri) {
+  if (typeof uri !== "string" || !uri.startsWith("gs://")) return null;
+  const rest = uri.slice(5);
+  const slash = rest.indexOf("/");
+  if (slash <= 0) return null;
+  const object = rest.slice(slash + 1);
+  if (object === "") return null;
+  return { bucket: rest.slice(0, slash), object };
 }
 
-async function restGet(url) {
-  const res = await fetch(url, { headers: { Authorization: `Bearer ${token()}` } });
-  if (!res.ok) throw new Error(`GET ${url} -> ${res.status}: ${await res.text()}`);
-  return res.json();
-}
-
-async function restDelete(url) {
-  const res = await fetch(url, {
-    method: "DELETE",
-    headers: { Authorization: `Bearer ${token()}` },
+const isDirectRun = import.meta.url === `file://${process.argv[1]}`;
+if (isDirectRun) {
+  runCli().catch((err) => {
+    console.error(err?.stack || err?.message || err);
+    process.exit(1);
   });
-  // 404 is acceptable (already deleted); others are errors.
-  if (res.status !== 200 && res.status !== 204 && res.status !== 404) {
-    throw new Error(`DELETE ${url} -> ${res.status}: ${await res.text()}`);
+}
+
+async function runCli() {
+  const projectId = process.argv[2];
+  const shouldExecute = process.argv.includes("--execute");
+
+  if (!projectId) {
+    console.error("Usage: node delete-empty-createdby.mjs <PROJECT_ID> [--execute]");
+    console.error("  <PROJECT_ID>: carenote-dev-279 | carenote-prod-279");
+    console.error("  Prod additionally requires CONFIRM_PROD=yes.");
+    process.exit(1);
   }
-  return res.status;
-}
 
-async function listAllDocs(path, pageSize = 300) {
-  const docs = [];
-  let pageToken = null;
-  while (true) {
-    const url = new URL(`${firestoreBase}/${path}`);
-    url.searchParams.set("pageSize", String(pageSize));
-    if (pageToken) url.searchParams.set("pageToken", pageToken);
-    const data = await restGet(url.toString());
-    if (data.documents) docs.push(...data.documents);
-    if (!data.nextPageToken) break;
-    pageToken = data.nextPageToken;
+  const isProd = projectId === "carenote-prod-279";
+  if (isProd && shouldExecute && process.env.CONFIRM_PROD !== "yes") {
+    console.error(`Refusing to --execute against ${projectId} without CONFIRM_PROD=yes.`);
+    console.error(
+      `Run: CONFIRM_PROD=yes node functions/scripts/delete-empty-createdby.mjs ${projectId} --execute`,
+    );
+    process.exit(1);
   }
-  return docs;
-}
 
-function parseGsUri(uri) {
-  if (!uri || typeof uri !== "string" || !uri.startsWith("gs://")) return null;
-  const withoutScheme = uri.slice(5);
-  const slash = withoutScheme.indexOf("/");
-  if (slash === -1) return null;
-  return {
-    bucket: withoutScheme.slice(0, slash),
-    object: withoutScheme.slice(slash + 1),
-  };
-}
+  try {
+    const activeProject = execFileSync("gcloud", ["config", "get-value", "project"])
+      .toString()
+      .trim();
+    if (activeProject && activeProject !== projectId) {
+      console.warn(
+        `Warning: active gcloud project '${activeProject}' differs from target '${projectId}'.`,
+      );
+      console.warn(
+        `  Recommended: CLOUDSDK_ACTIVE_CONFIG_NAME=<matching-config> node ...`,
+      );
+    }
+  } catch {
+    // best-effort; continue
+  }
 
-async function deleteStorageObject(bucket, object) {
-  const encoded = encodeURIComponent(object);
-  const url = `https://storage.googleapis.com/storage/v1/b/${bucket}/o/${encoded}`;
-  return restDelete(url);
-}
+  const token = fetchAccessToken();
+  const rest = makeRestClient(token);
+  const firestoreBase = `https://firestore.googleapis.com/v1/projects/${projectId}/databases/(default)/documents`;
 
-async function deleteFirestoreDoc(docName) {
-  return restDelete(`https://firestore.googleapis.com/v1/${docName}`);
-}
-
-function isEmptyCreatedBy(fields) {
-  if (!("createdBy" in fields)) return true;
-  const v = fields.createdBy.stringValue;
-  return v === undefined || v === null || v === "";
-}
-
-async function main() {
   console.log(`\nMode     : ${shouldExecute ? "EXECUTE (will delete)" : "DRY-RUN (no changes)"}`);
   console.log(`Project  : ${projectId}\n`);
 
-  const tenants = await listAllDocs("tenants");
-  const targets = [];
+  const counters = {
+    targetsFound: 0,
+    storageOk: 0,
+    storageSkip: 0,
+    storageErr: 0,
+    firestoreOk: 0,
+    firestoreSkip: 0,
+    firestoreErr: 0,
+    toctouSkipped: 0,
+  };
 
+  try {
+    const targets = await collectTargets(rest, firestoreBase);
+    counters.targetsFound = targets.length;
+
+    console.log(`Targets : ${targets.length}\n`);
+    for (const t of targets) {
+      console.log(
+        `  [${t.tenantId}] ${t.id}  audio=${t.audioStoragePath || "(none)"}  recordedAt=${t.recordedAt || "(none)"}`,
+      );
+    }
+
+    if (!shouldExecute) {
+      console.log(`\nDRY-RUN finished. Re-run with --execute to actually delete.`);
+      return;
+    }
+    if (targets.length === 0) {
+      console.log("\nNothing to delete.");
+      return;
+    }
+
+    console.log("\nExecuting deletion...\n");
+    for (const t of targets) {
+      const fresh = await rest.get(`https://firestore.googleapis.com/v1/${t.docName}`);
+      if (!isEmptyCreatedBy(fresh.fields || {})) {
+        console.warn(`  skip (TOCTOU): ${t.docName} no longer has empty createdBy`);
+        counters.toctouSkipped++;
+        continue;
+      }
+
+      const parsed = parseGsUri(t.audioStoragePath);
+      if (parsed) {
+        try {
+          await rest.deleteStorageObject(parsed.bucket, parsed.object);
+          console.log(`  storage   : gs://${parsed.bucket}/${parsed.object} -> ok`);
+          counters.storageOk++;
+        } catch (e) {
+          console.error(`  storage ! : gs://${parsed.bucket}/${parsed.object}: ${e.message}`);
+          console.error(`  firestore!: SKIPPED (storage failed; avoiding orphan)`);
+          counters.storageErr++;
+          counters.firestoreSkip++;
+          continue;
+        }
+      } else {
+        counters.storageSkip++;
+      }
+
+      try {
+        await rest.deleteFirestoreDoc(t.docName);
+        console.log(`  firestore : ${t.docName} -> ok`);
+        counters.firestoreOk++;
+      } catch (e) {
+        console.error(`  firestore!: ${t.docName}: ${e.message}`);
+        counters.firestoreErr++;
+      }
+    }
+  } finally {
+    console.log(`\n=== Result ===`);
+    console.log(`Targets  : ${counters.targetsFound}`);
+    console.log(`Storage  : ok=${counters.storageOk} skip=${counters.storageSkip} err=${counters.storageErr}`);
+    console.log(
+      `Firestore: ok=${counters.firestoreOk} skip=${counters.firestoreSkip} err=${counters.firestoreErr}`,
+    );
+    if (counters.toctouSkipped > 0) {
+      console.log(`TOCTOU skipped: ${counters.toctouSkipped}`);
+    }
+  }
+
+  if (counters.firestoreErr > 0 || counters.storageErr > 0) {
+    process.exit(2);
+  }
+}
+
+async function collectTargets(rest, firestoreBase) {
+  const tenants = await listAllDocs(rest, firestoreBase, "tenants");
+  const targets = [];
   for (const tenantDoc of tenants) {
     const tenantId = tenantDoc.name.split("/").pop();
-    const recordings = await listAllDocs(`tenants/${tenantId}/recordings`);
+    const recordings = await listAllDocs(rest, firestoreBase, `tenants/${tenantId}/recordings`);
     for (const rec of recordings) {
       if (isEmptyCreatedBy(rec.fields || {})) {
         targets.push({
@@ -113,69 +202,59 @@ async function main() {
       }
     }
   }
+  return targets;
+}
 
-  console.log(`Targets : ${targets.length}\n`);
-  for (const t of targets) {
-    console.log(
-      `  [${t.tenantId}] ${t.id}  audio=${t.audioStoragePath || "(none)"}  recordedAt=${t.recordedAt || "(none)"}`,
-    );
+async function listAllDocs(rest, firestoreBase, path, pageSize = 300) {
+  const docs = [];
+  let pageToken = null;
+  while (true) {
+    const url = new URL(`${firestoreBase}/${path}`);
+    url.searchParams.set("pageSize", String(pageSize));
+    if (pageToken) url.searchParams.set("pageToken", pageToken);
+    const data = await rest.get(url.toString());
+    if (data.documents) docs.push(...data.documents);
+    if (!data.nextPageToken) break;
+    pageToken = data.nextPageToken;
   }
+  return docs;
+}
 
-  if (!shouldExecute) {
-    console.log(`\nDRY-RUN finished. Re-run with --execute to actually delete.`);
-    return;
-  }
-
-  if (targets.length === 0) {
-    console.log("\nNothing to delete.");
-    return;
-  }
-
-  console.log("\nExecuting deletion...\n");
-  const counters = {
-    storageOk: 0,
-    storageSkip: 0,
-    storageErr: 0,
-    firestoreOk: 0,
-    firestoreErr: 0,
-  };
-
-  for (const t of targets) {
-    const parsed = parseGsUri(t.audioStoragePath);
-    if (parsed) {
-      try {
-        const s = await deleteStorageObject(parsed.bucket, parsed.object);
-        console.log(`  storage   : gs://${parsed.bucket}/${parsed.object} -> ${s}`);
-        counters.storageOk++;
-      } catch (e) {
-        console.error(`  storage ! : gs://${parsed.bucket}/${parsed.object}: ${e.message}`);
-        counters.storageErr++;
-      }
-    } else {
-      console.log(`  storage   : skipped (no parseable gs:// URI)`);
-      counters.storageSkip++;
-    }
-
-    try {
-      const s = await deleteFirestoreDoc(t.docName);
-      console.log(`  firestore : ${t.docName} -> ${s}`);
-      counters.firestoreOk++;
-    } catch (e) {
-      console.error(`  firestore!: ${t.docName}: ${e.message}`);
-      counters.firestoreErr++;
-    }
-  }
-
-  console.log(`\n=== Result ===`);
-  console.log(`Storage  : ok=${counters.storageOk} skip=${counters.storageSkip} err=${counters.storageErr}`);
-  console.log(`Firestore: ok=${counters.firestoreOk} err=${counters.firestoreErr}`);
-
-  if (counters.firestoreErr > 0 || counters.storageErr > 0) {
-    process.exit(2);
+function fetchAccessToken() {
+  try {
+    return execFileSync("gcloud", ["auth", "print-access-token"]).toString().trim();
+  } catch (e) {
+    console.error("Failed to obtain gcloud access token.");
+    console.error("Ensure gcloud is installed and you are logged in:");
+    console.error("  gcloud auth login");
+    throw e;
   }
 }
 
-main().catch((err) => {
-  console.error(err);
-  process.exit(1);
-});
+function makeRestClient(token) {
+  const authHeader = { Authorization: `Bearer ${token}` };
+
+  async function get(url) {
+    const res = await fetch(url, { headers: authHeader });
+    if (!res.ok) throw new Error(`GET ${url} -> ${res.status}: ${await res.text()}`);
+    return res.json();
+  }
+
+  async function deleteFirestoreDoc(docName) {
+    const url = `https://firestore.googleapis.com/v1/${docName}`;
+    const res = await fetch(url, { method: "DELETE", headers: authHeader });
+    if (res.status !== 200 && res.status !== 204) {
+      throw new Error(`DELETE ${docName} -> ${res.status}: ${await res.text()}`);
+    }
+  }
+
+  async function deleteStorageObject(bucket, object) {
+    const url = `https://storage.googleapis.com/storage/v1/b/${bucket}/o/${encodeURIComponent(object)}`;
+    const res = await fetch(url, { method: "DELETE", headers: authHeader });
+    if (res.status !== 200 && res.status !== 204 && res.status !== 404) {
+      throw new Error(`DELETE ${bucket}/${object} -> ${res.status}: ${await res.text()}`);
+    }
+  }
+
+  return { get, deleteFirestoreDoc, deleteStorageObject };
+}

--- a/functions/scripts/delete-empty-createdby.mjs
+++ b/functions/scripts/delete-empty-createdby.mjs
@@ -134,7 +134,17 @@ async function runCli() {
 
     console.log("\nExecuting deletion...\n");
     for (const t of targets) {
-      const fresh = await rest.get(`https://firestore.googleapis.com/v1/${t.docName}`);
+      let fresh;
+      try {
+        fresh = await rest.get(`https://firestore.googleapis.com/v1/${t.docName}`);
+      } catch (e) {
+        if (e.status === 404) {
+          console.warn(`  skip (TOCTOU 404): ${t.docName} no longer exists`);
+          counters.toctouSkipped++;
+          continue;
+        }
+        throw e;
+      }
       if (!isEmptyCreatedBy(fresh.fields || {})) {
         console.warn(`  skip (TOCTOU): ${t.docName} no longer has empty createdBy`);
         counters.toctouSkipped++;
@@ -236,7 +246,11 @@ function makeRestClient(token) {
 
   async function get(url) {
     const res = await fetch(url, { headers: authHeader });
-    if (!res.ok) throw new Error(`GET ${url} -> ${res.status}: ${await res.text()}`);
+    if (!res.ok) {
+      const err = new Error(`GET ${url} -> ${res.status}: ${await res.text()}`);
+      err.status = res.status;
+      throw err;
+    }
     return res.json();
   }
 

--- a/functions/test/delete-empty-createdby.test.mjs
+++ b/functions/test/delete-empty-createdby.test.mjs
@@ -1,0 +1,81 @@
+import { strict as assert } from "node:assert";
+import { isEmptyCreatedBy, parseGsUri } from "../scripts/delete-empty-createdby.mjs";
+
+describe("delete-empty-createdby: isEmptyCreatedBy", () => {
+  it("treats missing createdBy field as empty (legacy data)", () => {
+    assert.equal(isEmptyCreatedBy({}), true);
+  });
+
+  it("treats explicit empty stringValue as empty", () => {
+    assert.equal(isEmptyCreatedBy({ createdBy: { stringValue: "" } }), true);
+  });
+
+  it("treats nullValue as empty", () => {
+    assert.equal(isEmptyCreatedBy({ createdBy: { nullValue: null } }), true);
+  });
+
+  it("treats value object without stringValue/nullValue as populated (safe default)", () => {
+    assert.equal(isEmptyCreatedBy({ createdBy: {} }), false);
+  });
+
+  it("CRITICAL: treats any non-empty stringValue as populated (never delete real uid)", () => {
+    assert.equal(isEmptyCreatedBy({ createdBy: { stringValue: "uid-abc" } }), false);
+    assert.equal(isEmptyCreatedBy({ createdBy: { stringValue: "0" } }), false);
+    assert.equal(isEmptyCreatedBy({ createdBy: { stringValue: "   " } }), false);
+  });
+
+  it("treats unknown value types as populated (refuse to delete)", () => {
+    assert.equal(isEmptyCreatedBy({ createdBy: { integerValue: "42" } }), false);
+    assert.equal(isEmptyCreatedBy({ createdBy: { mapValue: { fields: {} } } }), false);
+    assert.equal(isEmptyCreatedBy({ createdBy: { booleanValue: false } }), false);
+  });
+
+  it("tolerates nullish fields argument", () => {
+    assert.equal(isEmptyCreatedBy(null), true);
+    assert.equal(isEmptyCreatedBy(undefined), true);
+  });
+});
+
+describe("delete-empty-createdby: parseGsUri", () => {
+  it("returns null for non-string inputs", () => {
+    assert.equal(parseGsUri(undefined), null);
+    assert.equal(parseGsUri(null), null);
+    assert.equal(parseGsUri(123), null);
+    assert.equal(parseGsUri({}), null);
+  });
+
+  it("returns null for empty string and non-gs schemes", () => {
+    assert.equal(parseGsUri(""), null);
+    assert.equal(parseGsUri("http://example.com/x.m4a"), null);
+    assert.equal(parseGsUri("https://example.com/x.m4a"), null);
+    assert.equal(parseGsUri("file:///tmp/x.m4a"), null);
+  });
+
+  it("returns null for bucket-only or empty object paths", () => {
+    assert.equal(parseGsUri("gs://"), null);
+    assert.equal(parseGsUri("gs://bucket"), null);
+    assert.equal(parseGsUri("gs://bucket/"), null);
+    assert.equal(parseGsUri("gs:///object"), null);
+  });
+
+  it("parses a standard gs URI", () => {
+    assert.deepEqual(parseGsUri("gs://my-bucket/path/to/file.m4a"), {
+      bucket: "my-bucket",
+      object: "path/to/file.m4a",
+    });
+  });
+
+  it("preserves multi-segment object paths", () => {
+    assert.deepEqual(parseGsUri("gs://carenote-dev-279-audio/279/UUID.m4a"), {
+      bucket: "carenote-dev-279-audio",
+      object: "279/UUID.m4a",
+    });
+  });
+
+  it("preserves non-ASCII object paths", () => {
+    assert.deepEqual(parseGsUri("gs://bucket/テスト/音声.m4a"), {
+      bucket: "bucket",
+      object: "テスト/音声.m4a",
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Issue #99 Phase -1 A3 の **dev 環境分** を完了。

- 新規スクリプト `functions/scripts/delete-empty-createdby.mjs` を追加
- **dev (`carenote-dev-279`) で実行済み**（21 件の orphan 録音を削除、本 PR 内で記録）
- prod (`carenote-prod-279`) は別 PR で同じフローを実施予定

## 背景

PR #101 で新規録音の `createdBy` は正しく保存されるようになったが、それ以前に作成された録音は `createdBy: ""` で保存されていた。`deleteAccount` は `where("createdBy", "==", uid)` で recordings を絞り込むため、これらは永久に削除されない orphan 状態だった。

ADR-008 / stakeholder 判断により、dev 21 件 + prod 8 件（予定）はテスト/開発データとして扱い削除する方針。

## 変更内容

### スクリプト仕様

- **デフォルト dry-run**、`--execute` フラグで実際に削除
- `createdBy` が empty string / null / undefined / missing のみ対象、非空 uid は一切触らない
- Firestore doc + `gs://` audio object の両方を削除
- `gcloud auth print-access-token` で認証（サービスアカウント鍵不要）
- Storage 404 は冪等性のため成功扱い、Firestore 404 は明示的にエラー扱い（意図的な非対称）

### 安全策

- dry-run → ユーザー承認 → `--execute` → 事後監査、の順で実施
- `audit-createdby.mjs` で 0 件になったことを確認
- `carenote-prod-279` + `--execute` には `CONFIRM_PROD=yes` 必須（多層ガード）
- active gcloud config と引数の project が不一致ならば warn
- TOCTOU 対策: 削除直前に再取得し `createdBy` が埋まっていたら skip

### review-pr 対応 (追加コミット `9ec1bbb`)

`silent-failure-hunter` の MEDIUM #4 指摘 (TOCTOU 404 でバッチ中断) を修正:
- `makeRestClient.get` の Error に `err.status` 付与
- 再取得が 404 を返したら `counters.toctouSkipped++` でスキップし他 target を継続

残件 (統合テスト・ログ改善) は follow-up Issue #114 に分離。

## dev 実行結果

### Dry-run で検出された 21 件

| Tenant | Count | 期間 |
|---|---|---|
| 279 | 8 | 2026-03-23 〜 2026-03-25 |
| test-tenant-1 | 13 | 2026-03-03 〜 2026-03-30 |
| demo-guest | 0 | — |

全て開発期間（PR #101 マージ 2026-04-20 より前）のデータ。

### Execute 結果

```
Storage  : ok=21 skip=0 err=0
Firestore: ok=21 err=0
```

Storage 204 / Firestore 200 で全件成功。エラーゼロ。

### 事後監査

```
=== OVERALL ===
Total recordings : 0
Empty string     : 0
Missing field    : 0
Non-empty        : 0 (0 unique uids)

✅ All recordings have non-empty createdBy.
```

全 tenant で recordings 0 件を確認。`createdBy` の orphan は完全に消去。

## Test plan

- [x] dev dry-run で 21 件検出
- [x] dev `--execute` で 21/21 削除成功
- [x] dev audit で empty=0 / missing=0 を確認
- [x] `/review-pr` で 3 エージェント並列レビュー (code-reviewer / silent-failure-hunter / pr-test-analyzer)
- [x] review MEDIUM 指摘 (TOCTOU 404) を fix コミットで修正
- [x] 残件を follow-up Issue #114 に登録
- [x] ユニットテスト 13 件全パス (`isEmptyCreatedBy` / `parseGsUri`)
- [x] CI paths-ignore 適用済み (PR #113) で iOS tests は skip
- [ ] マージ後: prod 用 PR (`chore/phase-1-a3-backfill-prod`) を作成し **ユーザー確認ゲート** を経て実行
- [ ] prod 実施後: Issue #99 を close

## 関連

- Issue #99 (A3 元 Issue)
- Issue #114 (統合テスト・ログ改善 follow-up)
- PR #101 (Phase -1 A1/A2/A4)
- PR #113 (CI paths-ignore)
- ADR-008

🤖 Generated with [Claude Code](https://claude.com/claude-code)