### PR TITLE
chore(ci): iOS テストを iOS コード変更時のみ実行

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,8 +3,20 @@ name: iOS Tests
 on:
   pull_request:
     branches: [main]
+    paths-ignore:
+      - 'functions/**'
+      - 'docs/**'
+      - 'scripts/**'
+      - '**.md'
+      - '.github/**'
   push:
     branches: [main]
+    paths-ignore:
+      - 'functions/**'
+      - 'docs/**'
+      - 'scripts/**'
+      - '**.md'
+      - '.github/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary

- `.github/workflows/test.yml` に `paths-ignore` を追加し、`functions/**` / `docs/**` / `scripts/**` / `**.md` / `.github/**` のみの変更では iOS テストを起動しない
- 効果: JS-only / docs-only PR で iOS Simulator Runtime のインストールが走らず、exit 70 の false-fail が解消

## 背景

PR #112 (A3 dev バックフィル、JS-only) の CI が 2 回連続で「Install iOS Simulator Runtime」ステップで exit 70 (Unable to connect to simulator) 失敗。GitHub Actions macOS ランナー側のインフラ問題で、iOS コード未変更のため本来スキップすべき job。

paths-ignore の対象:

| path | 理由 |
|---|---|
| `functions/**` | Cloud Functions (Node.js) 変更 |
| `docs/**` | ドキュメント変更 |
| `scripts/**` | 非 iOS スクリプト |
| `**.md` | Markdown 全般 |
| `.github/**` | CI/workflow 設定変更 |

`firestore.rules` / `firebase.json` / `.firebaserc` は **意図的に除外しない**（Phase 0.5 で rules-unit-testing 導入までは iOS 側の影響判定ができないため保守的に実行継続）。

## Test plan

- [x] YAML 構文検証 (`python3 -c 'import yaml; yaml.safe_load(...)'` OK)
- [x] `git diff` レビュー
- [ ] マージ後: PR #112 を rebase → iOS tests 起動しないことを確認
- [ ] マージ後: iOS コード変更を含む次の PR で workflow が通常起動することを確認

## 関連

- PR #112 (blocker: A3 dev バックフィル)
- Issue #108 (firebase.json の runtime 重複) — 将来 Firebase 専用 job 分離を検討

🤖 Generated with [Claude Code](https://claude.com/claude-code)