### PR TITLE
feat: Phase 0.5 Firestore Rules 強化 + migrationLogs 新設 (Issue #100)

### DIFF
--- a/.github/workflows/functions-test.yml
+++ b/.github/workflows/functions-test.yml
@@ -1,0 +1,61 @@
+name: Functions & Rules Tests
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'functions/**'
+      - 'firestore.rules'
+      - 'storage.rules'
+      - 'firebase.json'
+      - '.firebaserc'
+      - '.github/workflows/functions-test.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'functions/**'
+      - 'firestore.rules'
+      - 'storage.rules'
+      - 'firebase.json'
+      - '.firebaserc'
+      - '.github/workflows/functions-test.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: functions/package-lock.json
+
+      - name: Setup Java (required by Firestore emulator)
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Install dependencies
+        working-directory: functions
+        run: npm ci
+
+      - name: Install Firebase CLI
+        run: npm install -g firebase-tools
+
+      - name: Run all functions tests (with Firestore emulator for rules tests)
+        working-directory: functions
+        run: |
+          firebase emulators:exec \
+            --only firestore \
+            --project carenote-test \
+            "npm test"

--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,11 @@ generated-images/
 
 # Firebase
 .firebase/
+firebase-debug.log
+firestore-debug.log
+functions/firebase-debug.log
+functions/firestore-debug.log
+functions/node_modules/
 
 # Playwright MCP
 .playwright-mcp/

--- a/docs/handoff/LATEST.md
+++ b/docs/handoff/LATEST.md
@@ -63,9 +63,10 @@ uid 参照箇所の全棚卸し完了。移行 Function の書換対象が確定
 | Phase | 内容 | 状態 |
 |---|---|---|
 | Phase -1 | `createdBy` 正常保存 + 監査 + deleteAccount テスト | ✅ PR #101 マージ済 |
-| Phase -1 A3 | 既存 29 件の `createdBy` バックフィル（別 PR） | ⏳ 未着手、I-Cdx-4/5 注意事項は #99 コメント参照 |
-| Phase 0 | uid 参照棚卸し (ADR-008) | ✅ 本 PR で ADR 草案作成 |
-| Phase 0.5 | Firestore Rules 強化 + `migrationLogs` collection 新設 | ⏳ issue #100 で追跡 |
+| Phase -1 A3 dev | dev 21 件バックフィル削除 | ✅ PR #112 マージ済 (2026-04-20) |
+| Phase -1 A3 prod | prod 8 件バックフィル削除 | ⏳ ユーザー確認後実施（別 PR） |
+| Phase 0 | uid 参照棚卸し (ADR-008) | ✅ PR #109 マージ済 |
+| Phase 0.5 | Firestore Rules 強化 + `migrationLogs` collection 新設 + rules-unit-testing 拡充 + CI 組込 | 🚧 PR 進行中（feat/phase-0-5-rules-strengthen、dev deploy 前） |
 | Phase 0.9 | `allowedDomains: ["279279.net"]` 有効化 | ⏳ Phase 0.5 完了後 |
 | Phase 1 | `transferOwnership` Callable Function 実装 | ⏳ Phase 0.5 完了後 |
 | Phase 2 | 本人主導 UI（移行コード方式） | 🔒 スコープ外（頻度低 × コスト高） |

--- a/firestore.rules
+++ b/firestore.rules
@@ -9,6 +9,7 @@ service cloud.firestore {
     }
 
     // admin ロール判定
+    // 前提: role は Firebase Auth の custom claim (Admin SDK でのみ設定可、JWT 署名で改ざん不可)
     function isAdmin(tenantId) {
       return isTenantMember(tenantId)
         && request.auth.token.role == 'admin';
@@ -39,8 +40,29 @@ service cloud.firestore {
       }
 
       // 録音
+      //   read   : 業務上、同一テナント内の member 間で閲覧共有（既存 UI 仕様）
+      //   create : 自分を createdBy にしたものだけ（他人のなりすまし作成防止）
+      //   update : 作成者本人または admin（transcription 編集・admin 補正のため）
+      //            + createdBy 不変制約（client からオーナーシップを書き換え不可。
+      //              Phase 1 transferOwnership は admin SDK で rules を bypass する）
+      //   delete : 作成者本人または admin（現状 iOS は delete しないが、将来拡張に備えて対称化）
       match /recordings/{recordingId} {
-        allow read, write: if isTenantMember(tenantId);
+        allow read: if isTenantMember(tenantId);
+        allow create: if isTenantMember(tenantId)
+          && request.resource.data.createdBy == request.auth.uid;
+        allow update: if (isAdmin(tenantId)
+            || (isTenantMember(tenantId) && resource.data.createdBy == request.auth.uid))
+          && request.resource.data.createdBy == resource.data.createdBy;
+        allow delete: if isAdmin(tenantId)
+          || (isTenantMember(tenantId) && resource.data.createdBy == request.auth.uid);
+      }
+
+      // 移行ログ（Phase 1 transferOwnership の監査用。admin SDK 経由でのみ書込）
+      //   read   : admin のみ（旧メール等のセンシティブ情報を含むため）
+      //   write  : クライアントからは一切不可（Cloud Function が admin SDK で直書き）
+      match /migrationLogs/{logId} {
+        allow read: if isAdmin(tenantId);
+        allow write: if false;
       }
     }
   }

--- a/firestore.rules
+++ b/firestore.rules
@@ -9,7 +9,8 @@ service cloud.firestore {
     }
 
     // admin ロール判定
-    // 前提: role は Firebase Auth の custom claim (Admin SDK でのみ設定可、JWT 署名で改ざん不可)
+    // 前提: role は Firebase custom claim (サーバー特権経路でのみ設定可、
+    //       JWT 署名検証により client からは改ざん不可)
     function isAdmin(tenantId) {
       return isTenantMember(tenantId)
         && request.auth.token.role == 'admin';
@@ -44,7 +45,7 @@ service cloud.firestore {
       //   create : 自分を createdBy にしたものだけ（他人のなりすまし作成防止）
       //   update : 作成者本人または admin（transcription 編集・admin 補正のため）
       //            + createdBy 不変制約（client からオーナーシップを書き換え不可。
-      //              Phase 1 transferOwnership は admin SDK で rules を bypass する）
+      //              所有権移管は Admin SDK 経由で実施し rules を bypass して createdBy を書換）
       //   delete : 作成者本人または admin（現状 iOS は delete しないが、将来拡張に備えて対称化）
       match /recordings/{recordingId} {
         allow read: if isTenantMember(tenantId);

--- a/functions/test/firestore-rules.test.js
+++ b/functions/test/firestore-rules.test.js
@@ -10,6 +10,11 @@ const PROJECT_ID = "carenote-test";
 const TENANT_ID = "tenant-a";
 const TENANT_ID_B = "tenant-b";
 
+// `firebase emulators:exec` が FIRESTORE_EMULATOR_HOST を自動設定する。
+// ローカルで別ポートを使う場合 (port 8080 競合時) に備えて env を優先する。
+const EMULATOR_HOST_RAW = process.env.FIRESTORE_EMULATOR_HOST || "127.0.0.1:8080";
+const [EMULATOR_HOST, EMULATOR_PORT] = EMULATOR_HOST_RAW.split(":");
+
 function memberAuth(tenantId, role = "member") {
   return {
     uid: `${role}-${tenantId}`,
@@ -30,7 +35,7 @@ before(async () => {
   );
   testEnv = await initializeTestEnvironment({
     projectId: PROJECT_ID,
-    firestore: { rules, host: "127.0.0.1", port: 8080 },
+    firestore: { rules, host: EMULATOR_HOST, port: Number(EMULATOR_PORT) },
   });
 });
 
@@ -427,19 +432,24 @@ describe("メンバー正常系", () => {
     await assertSucceeds(ref.get());
   });
 
-  it("member は自テナントの recordings を read/write できる", async () => {
+  it("member は自テナントの recordings を read できる (createdBy 問わず)", async () => {
+    await testEnv.withSecurityRulesDisabled(async (context) => {
+      await context
+        .firestore()
+        .collection("tenants")
+        .doc(TENANT_ID)
+        .collection("recordings")
+        .doc("r1")
+        .set({ scene: "visit", clientName: "山田太郎", createdBy: "other-uid" });
+    });
+
     const db = testEnv.authenticatedContext(
       "member-a",
       memberAuth(TENANT_ID).token
     ).firestore();
-    const ref = db
-      .collection("tenants")
-      .doc(TENANT_ID)
-      .collection("recordings")
-      .doc("r1");
-
-    await assertSucceeds(ref.set({ scene: "visit", clientName: "山田太郎" }));
-    await assertSucceeds(ref.get());
+    await assertSucceeds(
+      db.collection("tenants").doc(TENANT_ID).collection("recordings").doc("r1").get()
+    );
   });
 
   it("member は自テナントの templates を read できる", async () => {
@@ -481,5 +491,335 @@ describe("メンバー正常系", () => {
       memberAuth(TENANT_ID).token
     ).firestore();
     await assertSucceeds(db.collection("tenants").doc(TENANT_ID).get());
+  });
+});
+
+// ===== recordings 権限境界（Phase 0.5: Issue #100 対応） =====
+
+describe("recordings 権限境界", () => {
+  async function seedRecording(tenantId, recordingId, createdBy, extra = {}) {
+    await testEnv.withSecurityRulesDisabled(async (context) => {
+      await context
+        .firestore()
+        .collection("tenants")
+        .doc(tenantId)
+        .collection("recordings")
+        .doc(recordingId)
+        .set({ scene: "visit", clientName: "山田太郎", createdBy, ...extra });
+    });
+  }
+
+  describe("create", () => {
+    it("member は createdBy に自分の uid をセットすれば create できる", async () => {
+      const db = testEnv.authenticatedContext(
+        "member-a",
+        memberAuth(TENANT_ID).token
+      ).firestore();
+      await assertSucceeds(
+        db
+          .collection("tenants")
+          .doc(TENANT_ID)
+          .collection("recordings")
+          .doc("r-new")
+          .set({ scene: "visit", clientName: "山田太郎", createdBy: "member-a" })
+      );
+    });
+
+    it("member は createdBy に他人の uid を入れた create を拒否される (なりすまし防止)", async () => {
+      const db = testEnv.authenticatedContext(
+        "member-a",
+        memberAuth(TENANT_ID).token
+      ).firestore();
+      await assertFails(
+        db
+          .collection("tenants")
+          .doc(TENANT_ID)
+          .collection("recordings")
+          .doc("r-impersonate")
+          .set({ scene: "visit", clientName: "山田太郎", createdBy: "member-b" })
+      );
+    });
+
+    it("member は createdBy 欠落の create を拒否される", async () => {
+      const db = testEnv.authenticatedContext(
+        "member-a",
+        memberAuth(TENANT_ID).token
+      ).firestore();
+      await assertFails(
+        db
+          .collection("tenants")
+          .doc(TENANT_ID)
+          .collection("recordings")
+          .doc("r-missing")
+          .set({ scene: "visit", clientName: "山田太郎" })
+      );
+    });
+  });
+
+  describe("update", () => {
+    it("member は自分の録音を update できる (transcription 編集想定)", async () => {
+      await seedRecording(TENANT_ID, "r-own", "member-a");
+      const db = testEnv.authenticatedContext(
+        "member-a",
+        memberAuth(TENANT_ID).token
+      ).firestore();
+      await assertSucceeds(
+        db
+          .collection("tenants")
+          .doc(TENANT_ID)
+          .collection("recordings")
+          .doc("r-own")
+          .update({ transcription: "編集済みテキスト" })
+      );
+    });
+
+    it("member は他人の録音を update できない", async () => {
+      await seedRecording(TENANT_ID, "r-other", "member-b");
+      const db = testEnv.authenticatedContext(
+        "member-a",
+        memberAuth(TENANT_ID).token
+      ).firestore();
+      await assertFails(
+        db
+          .collection("tenants")
+          .doc(TENANT_ID)
+          .collection("recordings")
+          .doc("r-other")
+          .update({ transcription: "改ざん" })
+      );
+    });
+
+    it("admin は他人の録音を update できる", async () => {
+      await seedRecording(TENANT_ID, "r-admin-fix", "member-a");
+      const db = testEnv.authenticatedContext(
+        "admin-a",
+        adminAuth(TENANT_ID).token
+      ).firestore();
+      await assertSucceeds(
+        db
+          .collection("tenants")
+          .doc(TENANT_ID)
+          .collection("recordings")
+          .doc("r-admin-fix")
+          .update({ transcription: "admin による補正" })
+      );
+    });
+
+    it("member は自分の録音の createdBy を他人に書き換える update を拒否される", async () => {
+      await seedRecording(TENANT_ID, "r-rewrite", "member-a");
+      const db = testEnv.authenticatedContext(
+        "member-a",
+        memberAuth(TENANT_ID).token
+      ).firestore();
+      await assertFails(
+        db
+          .collection("tenants")
+          .doc(TENANT_ID)
+          .collection("recordings")
+          .doc("r-rewrite")
+          .update({ createdBy: "member-b" })
+      );
+    });
+
+    it("admin も client 経由の createdBy 変更 update は拒否される (admin SDK で bypass する設計)", async () => {
+      await seedRecording(TENANT_ID, "r-admin-rewrite", "member-a");
+      const db = testEnv.authenticatedContext(
+        "admin-a",
+        adminAuth(TENANT_ID).token
+      ).firestore();
+      await assertFails(
+        db
+          .collection("tenants")
+          .doc(TENANT_ID)
+          .collection("recordings")
+          .doc("r-admin-rewrite")
+          .update({ createdBy: "member-b" })
+      );
+    });
+  });
+
+  describe("delete", () => {
+    it("member は自分の録音を delete できる", async () => {
+      await seedRecording(TENANT_ID, "r-own-del", "member-a");
+      const db = testEnv.authenticatedContext(
+        "member-a",
+        memberAuth(TENANT_ID).token
+      ).firestore();
+      await assertSucceeds(
+        db
+          .collection("tenants")
+          .doc(TENANT_ID)
+          .collection("recordings")
+          .doc("r-own-del")
+          .delete()
+      );
+    });
+
+    it("member は他人の録音を delete できない", async () => {
+      await seedRecording(TENANT_ID, "r-other-del", "member-b");
+      const db = testEnv.authenticatedContext(
+        "member-a",
+        memberAuth(TENANT_ID).token
+      ).firestore();
+      await assertFails(
+        db
+          .collection("tenants")
+          .doc(TENANT_ID)
+          .collection("recordings")
+          .doc("r-other-del")
+          .delete()
+      );
+    });
+
+    it("admin は他人の録音を delete できる", async () => {
+      await seedRecording(TENANT_ID, "r-admin-del", "member-a");
+      const db = testEnv.authenticatedContext(
+        "admin-a",
+        adminAuth(TENANT_ID).token
+      ).firestore();
+      await assertSucceeds(
+        db
+          .collection("tenants")
+          .doc(TENANT_ID)
+          .collection("recordings")
+          .doc("r-admin-del")
+          .delete()
+      );
+    });
+  });
+});
+
+// ===== migrationLogs: Phase 1 transferOwnership の監査ログ =====
+
+describe("migrationLogs 権限境界", () => {
+  async function seedMigrationLog(tenantId, logId) {
+    await testEnv.withSecurityRulesDisabled(async (context) => {
+      await context
+        .firestore()
+        .collection("tenants")
+        .doc(tenantId)
+        .collection("migrationLogs")
+        .doc(logId)
+        .set({
+          executedAt: new Date(),
+          actor: "admin-sdk",
+          oldEmail: "old@279279.net",
+          newEmail: "new@279279.net",
+          affectedDocs: 42,
+        });
+    });
+  }
+
+  it("admin は migrationLogs を read できる", async () => {
+    await seedMigrationLog(TENANT_ID, "log-1");
+    const db = testEnv.authenticatedContext(
+      "admin-a",
+      adminAuth(TENANT_ID).token
+    ).firestore();
+    await assertSucceeds(
+      db
+        .collection("tenants")
+        .doc(TENANT_ID)
+        .collection("migrationLogs")
+        .doc("log-1")
+        .get()
+    );
+  });
+
+  it("member は migrationLogs を read できない (旧メール等機微情報)", async () => {
+    await seedMigrationLog(TENANT_ID, "log-2");
+    const db = testEnv.authenticatedContext(
+      "member-a",
+      memberAuth(TENANT_ID).token
+    ).firestore();
+    await assertFails(
+      db
+        .collection("tenants")
+        .doc(TENANT_ID)
+        .collection("migrationLogs")
+        .doc("log-2")
+        .get()
+    );
+  });
+
+  it("admin でもクライアントからは write できない (admin SDK 専用)", async () => {
+    const db = testEnv.authenticatedContext(
+      "admin-a",
+      adminAuth(TENANT_ID).token
+    ).firestore();
+    await assertFails(
+      db
+        .collection("tenants")
+        .doc(TENANT_ID)
+        .collection("migrationLogs")
+        .doc("log-new")
+        .set({ actor: "admin-a" })
+    );
+  });
+
+  it("member も当然 write できない", async () => {
+    const db = testEnv.authenticatedContext(
+      "member-a",
+      memberAuth(TENANT_ID).token
+    ).firestore();
+    await assertFails(
+      db
+        .collection("tenants")
+        .doc(TENANT_ID)
+        .collection("migrationLogs")
+        .doc("log-new")
+        .set({ actor: "member-a" })
+    );
+  });
+
+  it("他テナント admin は自テナント外の migrationLogs を read できない", async () => {
+    await seedMigrationLog(TENANT_ID, "log-cross");
+    const db = testEnv.authenticatedContext(
+      "admin-b",
+      adminAuth(TENANT_ID_B).token
+    ).firestore();
+    await assertFails(
+      db
+        .collection("tenants")
+        .doc(TENANT_ID)
+        .collection("migrationLogs")
+        .doc("log-cross")
+        .get()
+    );
+  });
+
+  // AC-10 網羅: write: false が create 以外にも効いていることを保証
+  // (将来 rules を allow create/update/delete に分解した場合の回帰検知)
+
+  it("admin でも migrationLogs を update できない", async () => {
+    await seedMigrationLog(TENANT_ID, "log-update");
+    const db = testEnv.authenticatedContext(
+      "admin-a",
+      adminAuth(TENANT_ID).token
+    ).firestore();
+    await assertFails(
+      db
+        .collection("tenants")
+        .doc(TENANT_ID)
+        .collection("migrationLogs")
+        .doc("log-update")
+        .update({ affectedDocs: 999 })
+    );
+  });
+
+  it("admin でも migrationLogs を delete できない", async () => {
+    await seedMigrationLog(TENANT_ID, "log-delete");
+    const db = testEnv.authenticatedContext(
+      "admin-a",
+      adminAuth(TENANT_ID).token
+    ).firestore();
+    await assertFails(
+      db
+        .collection("tenants")
+        .doc(TENANT_ID)
+        .collection("migrationLogs")
+        .doc("log-delete")
+        .delete()
+    );
   });
 });

--- a/functions/test/firestore-rules.test.js
+++ b/functions/test/firestore-rules.test.js
@@ -10,8 +10,8 @@ const PROJECT_ID = "carenote-test";
 const TENANT_ID = "tenant-a";
 const TENANT_ID_B = "tenant-b";
 
-// `firebase emulators:exec` が FIRESTORE_EMULATOR_HOST を自動設定する。
-// ローカルで別ポートを使う場合 (port 8080 競合時) に備えて env を優先する。
+// CI と local で `firebase emulators:exec` が FIRESTORE_EMULATOR_HOST を注入するため、
+// ハードコード値よりも env を優先する（ローカルでポート変更した場合の可搬性も確保）。
 const EMULATOR_HOST_RAW = process.env.FIRESTORE_EMULATOR_HOST || "127.0.0.1:8080";
 const [EMULATOR_HOST, EMULATOR_PORT] = EMULATOR_HOST_RAW.split(":");
 


### PR DESCRIPTION
## Summary

Issue #100 (P0) の対応。`recordings` 権限を最小化し、`migrationLogs` collection を新設、rules-unit-testing を拡充、CI を組込む。Phase 0.9 `allowedDomains` 有効化の前提条件を満たす。

## 背景

既存の `allow read, write: if isTenantMember(tenantId)` は、テナント member 全員が他人の録音を read/write/delete できる状態で、介護記録としては過剰権限。`allowedDomains = ["279279.net"]` を有効化すると @279279.net ユーザー全員（退職者含み得る）が自動的に member 化される設計のため、有効化前に rules 強化が必須。

## 変更内容

### `firestore.rules`

| 操作 | 旧 | 新 |
|---|---|---|
| recordings read | tenant member | 変更なし (tenant member) |
| recordings create | tenant member | tenant member + `createdBy == auth.uid` |
| recordings update | tenant member | (作成者本人 or admin) かつ `createdBy` 不変 |
| recordings delete | tenant member | 作成者本人 or admin |
| migrationLogs read | (未定義) | admin のみ |
| migrationLogs write | (未定義) | 全拒否 (admin SDK 経由のみ) |

`isAdmin` に Firebase Auth custom claim 依拠の前提コメント追加。

### `functions/test/firestore-rules.test.js` (+346 行、計 78 tests)

- **recordings 権限境界** describe 新設:
  - create: 自 uid / 他 uid / 欠落
  - update: 自分 / 他人 / admin / **createdBy 書き換え拒否 (member + admin 両方)**
  - delete: 自分 / 他人 / admin
- **migrationLogs 権限境界** describe 新設:
  - read: admin OK / member NG / cross-tenant admin NG
  - write: admin set / member set / **admin update / admin delete** 全 NG
- 既存 "member は recordings を read/write できる" を read 専用に改訂
- `FIRESTORE_EMULATOR_HOST` env var 優先化（ローカルポート競合時の柔軟性）

### CI: `.github/workflows/functions-test.yml` (新規)

- trigger: `functions/**`, `firestore.rules`, `storage.rules`, `firebase.json`, `.firebaserc`
- Ubuntu + Node.js 20 + Java 17 (Firestore emulator 要件)
- `firebase emulators:exec --only firestore "npm test"` で全 functions テストを一括実行

### `.gitignore`
- emulator debug log / functions/node_modules を追加

### `docs/handoff/LATEST.md`
- Phase 表の A3 dev ✅ / prod ⏳ と Phase 0.5 進行中を反映

## 品質ゲート実施履歴

| ゲート | 結果 |
|---|---|
| `/impl-plan` (承認済) | Acceptance Criteria 12 項目策定 |
| iOS 整合性調査 (C-0) | recordings update 呼出は自分の録音のみ、delete は Firestore 送信なし → iOS コード変更不要 |
| `/safe-refactor` | HIGH/MEDIUM 0 件、LOW 1 件（既存スタイル準拠のため不採用） |
| Evaluator 分離 (`evaluator` agent) | HIGH 2 件指摘 → 本 PR で全修正 |
| ローカル emulator test | 78/78 PASS |

### Evaluator が検出し修正した 2 点

1. **createdBy の可変性** — update rule が `createdBy` 書き換えを許容していた（member が自録音の createdBy を他人に書換 → 権限消失するが誤操作リスク）。`request.resource.data.createdBy == resource.data.createdBy` を追加 + 回帰テスト 2 件追加。
2. **migrationLogs の update/delete テスト不在** — `allow write: if false` は create/update/delete を包含するが、テストは create のみカバー。将来 rules を分解した際の回帰検知のため update/delete テスト追加。

## Test plan

- [x] ローカル Firestore emulator で全 78 テスト PASS
- [x] `/safe-refactor` 分析
- [x] Evaluator 分離 (evaluator agent)
- [x] iOS 側の recordings CRUD 呼出を調査し、新 rules で従来動作を壊さないことを確認
- [ ] CI で functions-test workflow が緑
- [ ] `/review-pr` (6 エージェント並列のうち関連のみ)
- [ ] dev deploy (`firebase deploy --only firestore:rules -P dev`)
- [ ] dev 環境で iOS 実機 / シミュレーターで録音作成・transcription 編集が通常通り動くことを確認
- [ ] prod deploy (**ユーザー確認後**、A3 prod バックフィル完了を推奨前提)

## 依存

- **Sprint B-2 (A3 prod バックフィル) を先に完了させることを推奨**: prod に createdBy 空の録音が残っていると、本 rules 導入後は admin でないと update/delete できない edge case が発生する。A3 で全て削除してから Rules deploy が最もクリーン。

## 関連

- Issue #100 (本件、P0)
- Issue #111 (Phase 0.9 allowedDomains 有効化、本 PR 完了後の後続)
- Issue #110 (Phase 1 transferOwnership、migrationLogs の書込側 Cloud Function を実装)
- ADR-008 (アカウント移行方式)
- PR #112 (Phase -1 A3 dev バックフィル)

🤖 Generated with [Claude Code](https://claude.com/claude-code)