### PR TITLE
chore: A3 prod バックフィル実施 (Phase -1 A3 prod, closes #99)

### DIFF
--- a/docs/handoff/LATEST.md
+++ b/docs/handoff/LATEST.md
@@ -64,19 +64,21 @@ uid 参照箇所の全棚卸し完了。移行 Function の書換対象が確定
 |---|---|---|
 | Phase -1 | `createdBy` 正常保存 + 監査 + deleteAccount テスト | ✅ PR #101 マージ済 |
 | Phase -1 A3 dev | dev 21 件バックフィル削除 | ✅ PR #112 マージ済 (2026-04-20) |
-| Phase -1 A3 prod | prod 8 件バックフィル削除 | ⏳ ユーザー確認後実施（別 PR） |
+| Phase -1 A3 prod | prod 8 件バックフィル削除 | ✅ 実施済 (2026-04-21, 8/8 成功, audit empty=0) |
 | Phase 0 | uid 参照棚卸し (ADR-008) | ✅ PR #109 マージ済 |
-| Phase 0.5 | Firestore Rules 強化 + `migrationLogs` collection 新設 + rules-unit-testing 拡充 + CI 組込 | 🚧 PR 進行中（feat/phase-0-5-rules-strengthen、dev deploy 前） |
-| Phase 0.9 | `allowedDomains: ["279279.net"]` 有効化 | ⏳ Phase 0.5 完了後 |
-| Phase 1 | `transferOwnership` Callable Function 実装 | ⏳ Phase 0.5 完了後 |
+| Phase 0.5 | Firestore Rules 強化 + `migrationLogs` collection 新設 + rules-unit-testing 拡充 + CI 組込 | ✅ PR #115 マージ済 + dev deploy 完了 (2026-04-21, iOS 実機検証は別途) |
+| Phase 0.9 | `allowedDomains: ["279279.net"]` 有効化 | ⏳ Phase 0.5 prod deploy + iOS 実機検証後 |
+| Phase 1 | `transferOwnership` Callable Function 実装 | ⏳ 並行着手可 |
 | Phase 2 | 本人主導 UI（移行コード方式） | 🔒 スコープ外（頻度低 × コスト高） |
 
 ## オープン Issue（アカウント移行機能関連）
 
 | # | タイトル | ラベル | 優先度 |
 |---|---------|--------|-------|
-| #99 | 録音の `createdBy` が空文字で保存されている | bug, P0 | A3 バックフィル後にクローズ |
-| #100 | Firestore Rules の recordings 権限が過剰 | bug, P0 | Phase 0.5 着手時 |
+| #99 | 録音の `createdBy` が空文字で保存されている | bug, P0 | **A3 prod 完了により本 PR でクローズ** |
+| #100 | Firestore Rules の recordings 権限が過剰 | bug, P0 | **PR #115 マージ済 (dev deploy 完了、prod deploy 残)** |
+| #114 | delete-empty-createdby: 統合テスト・ログ強化 | enhancement, P2 | PR #112 follow-up |
+| #116 | Firestore Rules 追加エッジケーステスト | enhancement, P2 | PR #115 follow-up (Phase 1 前対処) |
 | #102 | deleteAccount テスト拡張（partial failure / auth error codes） | enhancement, P2 | - |
 | #103 | audit-createdby 堅牢性（token cache / pagination 保護） | enhancement, P2 | - |
 | #104 | delete-account test mock の深さ制限 | enhancement, P2 | - |


### PR DESCRIPTION
## Summary

Issue #99 Phase -1 A3 の **prod 環境分** を完了。dev (PR #112) と同じスクリプト・同じフローで実施し、`docs/handoff/LATEST.md` を更新する docs-only PR。

## 背景

PR #101 以前に作成された録音は `createdBy: ""` の orphan で、`deleteAccount` の `where("createdBy", "==", uid)` クエリで絞り込めず実質的に削除不能だった。dev 21 件 + prod 8 件が該当。dev は PR #112 で削除済、本 PR で prod 8 件を実施済として記録。

## 実施フロー (2026-04-21)

### 1. Dry-run (読取のみ)

```
CLOUDSDK_ACTIVE_CONFIG_NAME=carenote-prod \
  node functions/scripts/delete-empty-createdby.mjs carenote-prod-279
```

**結果**: Targets=8、全て tenant `279`、期間 2026-03-30 〜 2026-04-03

| docId | audioStoragePath | recordedAt |
|---|---|---|
| 7N9eG1fCAui6zTNPqVph | gs://.../95ECB0EB-...m4a | 2026-03-30T05:14:06Z |
| A2gXQA9As2niFV81wXOx | gs://.../08804E07-...m4a | 2026-03-30T05:19:55Z |
| ARk8NlqO6H3b0B6NWjmi | gs://.../3BA0F4F1-...m4a | 2026-03-30T05:19:00Z |
| IPAfgwX194262MaThK8v | gs://.../DF6747EA-...m4a | 2026-04-03T11:27:51Z |
| MtOttpa3TIQT7mzMPqco | gs://.../0824C724-...m4a | 2026-03-30T05:14:00Z |
| VSPc2KdoEyOqDwpDuzBu | gs://.../7806825D-...m4a | 2026-03-30T21:04:20Z |
| YbP7F6QMIyU8Gs10cpz7 | gs://.../BEF76B75-...m4a | 2026-04-03T12:05:07Z |
| l5QLI0LteX7fvVdRNww3 | gs://.../0C2333B9-...m4a | 2026-03-30T21:04:56Z |

### 2. ユーザー承認 → Execute

```
CONFIRM_PROD=yes CLOUDSDK_ACTIVE_CONFIG_NAME=carenote-prod \
  node functions/scripts/delete-empty-createdby.mjs carenote-prod-279 --execute
```

**結果**:
```
=== Result ===
Targets  : 8
Storage  : ok=8 skip=0 err=0
Firestore: ok=8 skip=0 err=0
```

全 16 delete (Storage 8 + Firestore 8) が 200/204 で成功、エラーゼロ、TOCTOU skip ゼロ。

### 3. Audit (事後確認)

```
CLOUDSDK_ACTIVE_CONFIG_NAME=carenote-prod \
  node functions/scripts/audit-createdby.mjs carenote-prod-279
```

**結果**:
```
Tenant: 279       → Total=0, Empty=0, Missing=0
Tenant: demo-guest → Total=0, Empty=0, Missing=0

=== OVERALL ===
Total recordings : 0
Empty string     : 0
Missing field    : 0
Non-empty        : 0 (0 unique uids)

✅ All recordings have non-empty createdBy.
```

prod の recordings は全 tenant で 0 件、orphan 完全消去を確認。

## 影響

- `deleteAccount` Cloud Function が prod 実データに対して正常動作する状態を確立
- Phase 0.5 Firestore Rules (PR #115) の prod deploy 前提 (`createdBy == auth.uid` 制約が既存データと矛盾しない) を満たす
- App Store 5.1.1(v) アカウント削除要件の実挙動を prod で担保

## 使用スクリプト

PR #112 マージ済の `functions/scripts/delete-empty-createdby.mjs`。多層 prod ガード:
- `CONFIRM_PROD=yes` env 必須（`!== "yes"` 厳格比較）
- active gcloud config と引数 project の不一致を warn
- TOCTOU 再取得 + 404 skip で batch 中断回避 (PR #112 で fix コミット追加済)

## Test plan

- [x] dev dry-run / execute / audit（PR #112 で実施済）
- [x] prod dry-run で 8 件検出
- [x] prod `CONFIRM_PROD=yes --execute` で 8/8 削除成功、エラーゼロ
- [x] prod audit で empty=0 / missing=0 / Total=0 を確認
- [ ] マージ後: Issue #99 クローズ (closes キーワードで自動)

## 関連

- **Closes #99**
- PR #101 (Phase -1 A1/A2/A4)
- PR #112 (Phase -1 A3 dev + スクリプト)
- PR #115 (Phase 0.5 Rules 強化、本 PR マージにより prod deploy 可能)
- Issue #114 (A3 スクリプト follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)