### PR TITLE
fix(ci): functions-test workflow の Java を 21 に更新

### DIFF
--- a/.github/workflows/functions-test.yml
+++ b/.github/workflows/functions-test.yml
@@ -39,11 +39,11 @@ jobs:
           cache: 'npm'
           cache-dependency-path: functions/package-lock.json
 
-      - name: Setup Java (required by Firestore emulator)
+      - name: Setup Java (required by firebase-tools / Firestore emulator)
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '21'
 
       - name: Install dependencies
         working-directory: functions


### PR DESCRIPTION
## Summary

PR #115 で追加した `.github/workflows/functions-test.yml` の main 初回実行で以下のエラーで失敗:

\`\`\`
Error: firebase-tools no longer supports Java version before 21.
Please install a JDK at version 21 or above to get a compatible runtime.
\`\`\`

actions/setup-java の `java-version` を 17 → 21 に更新。

## 変更

- `.github/workflows/functions-test.yml`: `java-version: '17'` → `'21'`（1 行変更）
- workflow 実行内容、テスト、trigger 条件は変更なし

## Test plan

- [x] YAML 構文検証（diff 確認）
- [ ] マージ後: main で functions-test workflow が green であること

## 関連

- PR #115 (workflow 追加)
- run 24674927965 (失敗 run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)