### PR TITLE
docs: LATEST.md を Sprint B/C/D 完了状態に更新（handoff 用）

### DIFF
--- a/docs/handoff/LATEST.md
+++ b/docs/handoff/LATEST.md
@@ -161,7 +161,7 @@ _Issue #99 / #100 / #110 は本セッションで全て解決_
 
 Issue #110 本体は transferOwnership のみ。旧 Auth user 削除は別 Function として残してあるため、将来独立 Issue 化して実装する（ロールバック余地を Phase 1 完了後に評価）。
 
-## Aliyah / 既知の警告
+## 既知の警告
 
 ### Cloud Functions Node.js 20 deprecation
 

--- a/docs/handoff/LATEST.md
+++ b/docs/handoff/LATEST.md
@@ -1,148 +1,190 @@
-# Handoff — アカウント所有権移行機能 設計着手 + Phase -1 重大バグ修正完了 (2026-04-20)
+# Handoff — アカウント移行機能 Phase -1/0/0.5/1 完了、Phase 0.9 待機 (2026-04-21)
 
 ## セッション成果サマリ
 
-ユーザーからの要望「テナント単位ドメイン全許可 + 改姓時のアカウント完全移行」の検討中、Codex セカンドオピニオンで **既存 `deleteAccount` Cloud Function が機能不全だった重大バグ** (issue #99) と **Firestore Rules の過剰権限** (issue #100) を発見。設計計画 (Phase -1 → Phase 0 → Phase 0.5 → Phase 1 → Phase 0.9) に基づき Phase -1 の先行修正を完了。
+アカウント所有権移行機能の Phase -1 から Phase 1 まで完了。Phase 0.9 (`allowedDomains` 有効化) の前提となる rules 強化 + 権限移管機能が揃い、ユーザー側の smoke test + prod deploy 承認を待つ状態。
 
-| PR | 内容 | 状態 |
-|----|------|------|
-| #101 | Phase -1: `createdBy` 正常保存 + 監査スクリプト + deleteAccount 統合テスト + Codex Critical 対応 | ✅ main |
+### マージ済み PR（2026-04-21 セッション）
 
-## Phase -1 の重要発見と修正
+| PR | 内容 | Issue |
+|----|------|-------|
+| #113 | CI paths-ignore（iOS 軽量化） | — |
+| #112 | Phase -1 A3 dev バックフィル + 削除スクリプト | #99 |
+| #115 | Phase 0.5 Firestore Rules 強化 + migrationLogs collection | #100 |
+| #117 | Phase -1 A3 prod バックフィル実施記録 | **#99 closed** |
+| #118 | CI Java 17→21 (firebase-tools 要件) | — |
+| #119 | Phase 1 transferOwnership Callable Function | **#110 closed** |
 
-### 発見された重大バグ（issue #99）
+### 実施済み prod/dev operation（履歴）
 
-**dev/prod の全 recordings で `createdBy: ""` が保存されていた**:
+| 環境 | 操作 | 結果 |
+|---|---|---|
+| dev | A3 バックフィル execute | 21 件削除、audit empty=0 |
+| prod | A3 バックフィル execute (`CONFIRM_PROD=yes`) | 8/8 削除成功、audit empty=0 |
+| dev | Firestore Rules deploy | `firebase deploy --only firestore:rules` ✅ |
+| dev | transferOwnership Cloud Function deploy | Node.js 20 2nd Gen、asia-northeast1 ✅ |
 
-| 環境 | Total | Empty | Non-empty |
-|---|---|---|---|
-| dev (carenote-dev-279) | 21 | 21 | 0 |
-| prod (carenote-prod-279) | 8 | 8 | 0 |
+### 解消した Critical Issue
 
-影響:
-- 本番稼働中の `deleteAccount` は `where("createdBy", "==", uid)` クエリで **常に 0 件ヒット** → recordings / Storage audio が削除されていなかった
-- **App Store 5.1.1(v) アカウント削除要件の実装が実質未達**の可能性が高い
-- 今後のアカウント移行機能も機能しない状態だった
-
-### PR #101 の修正内容
-
-- **A1**: `OutboxSyncService` に `currentUidProvider` を DI、`createdBy: uid` を正しく保存。uid 取得失敗時は `OutboxSyncError.userNotAuthenticated` を throw し既存 retry ラダーに乗せる
-- **A2**: `functions/scripts/audit-createdby.mjs` で Firestore REST API による `createdBy` 分布計測
-- **A4**: `functions/test/delete-account.test.js` に offline mock 統合テスト 7 ケース（空文字 regression + Codex C-Cdx-3 query 失敗時挙動含む）
-- **Codex Critical**: `processItem` 冒頭で GCS orphan 防止の uid pre-flight check + deleteAccount の recordings query を try-catch で包み Auth 削除優先方針を実挙動に反映
-
-### テスト結果
-
-- iOS: 7/7 PASS（境界値 nil / "" / valid 網羅）
-- functions (auth-blocking + delete-account): 21/21 PASS
-
-## Phase 0 調査結果（ADR-008 に詳細）
-
-uid 参照箇所の全棚卸し完了。移行 Function の書換対象が確定:
-
-| コレクション | フィールド | 書換 | 備考 |
-|---|---|---|---|
-| `recordings.createdBy` | string | **必要** | PR #101 で uid 保存は正常化済み |
-| `templates.createdBy` | string | **必要** | 新規発見 |
-| `templates.createdByName` | string | 不変 | 意図的スナップショット |
-| `whitelist.addedBy` | string | **必要** | 監査追跡のため |
-| `clients/*` | - | 不要 | uid 参照なし |
-| Cloud Storage path | - | 不要 | `{tenantId}/{recordingId}.m4a`、uid 非依存 |
-
-詳細は [ADR-008](../adr/ADR-008-account-ownership-transfer.md) 参照。
+- **#99** createdBy 空文字バグ → PR #101/#112/#117 で完全解決
+- **#100** Firestore Rules 過剰権限 → PR #115 で解決（dev deploy 済、prod deploy 残）
+- **#110** transferOwnership 実装 → PR #119 で解決（dev deploy 済、prod deploy 残）
 
 ## 現在の状態
 
-- **ブランチ**: main
+- **ブランチ**: main（clean、CI green）
 - **ビルド**: Build 35（App Store Connect 審査中、2026-04-16 提出）
-- **審査通過見込み**: 90%+（リジェクト時の playbook は本セクション末尾参照）
-- **アカウント移行機能**: Phase -1 完了、Phase 0 ADR 草案作成、Phase 0.5〜1 は未着手
+- **審査通過見込み**: 90%+（deleteAccount が実データで機能する状態を確立済み）
+- **アカウント移行機能**: **Phase -1 / 0 / 0.5 / 1 完了**、Phase 0.9 は smoke test + prod deploy 後
 
 ## アカウント移行機能の Phase 構成
 
 | Phase | 内容 | 状態 |
 |---|---|---|
 | Phase -1 | `createdBy` 正常保存 + 監査 + deleteAccount テスト | ✅ PR #101 マージ済 |
-| Phase -1 A3 dev | dev 21 件バックフィル削除 | ✅ PR #112 マージ済 (2026-04-20) |
-| Phase -1 A3 prod | prod 8 件バックフィル削除 | ✅ 実施済 (2026-04-21, 8/8 成功, audit empty=0) |
-| Phase 0 | uid 参照棚卸し (ADR-008) | ✅ PR #109 マージ済 |
-| Phase 0.5 | Firestore Rules 強化 + `migrationLogs` collection 新設 + rules-unit-testing 拡充 + CI 組込 | ✅ PR #115 マージ済 + dev deploy 完了 (2026-04-21, iOS 実機検証は別途) |
-| Phase 0.9 | `allowedDomains: ["279279.net"]` 有効化 | ⏳ Phase 0.5 prod deploy + iOS 実機検証後 |
-| Phase 1 | `transferOwnership` Callable Function 実装 | 🚧 PR 進行中（feat/phase-1-transfer-ownership、dev deploy 前） |
+| Phase -1 A3 dev | dev 21 件バックフィル削除 | ✅ PR #112 (2026-04-20) |
+| Phase -1 A3 prod | prod 8 件バックフィル削除 | ✅ 実施済 + PR #117 (2026-04-21) |
+| Phase 0 | uid 参照棚卸し (ADR-008) | ✅ PR #109 |
+| Phase 0.5 | Firestore Rules 強化 + migrationLogs + rules-unit-testing + CI 組込 | ✅ PR #115 merged + dev deploy 完了 (2026-04-21) |
+| Phase 0.9 | `allowedDomains: ["279279.net"]` 有効化 | ⏳ **ユーザー作業待ち**（smoke test + prod deploy 後） |
+| Phase 1 | `transferOwnership` Callable Function 実装 | ✅ PR #119 merged + dev deploy 完了 (2026-04-21) |
 | Phase 2 | 本人主導 UI（移行コード方式） | 🔒 スコープ外（頻度低 × コスト高） |
 
-## オープン Issue（アカウント移行機能関連）
+## ユーザー作業依頼（次セッション再開に関わる重要項目）
 
-| # | タイトル | ラベル | 優先度 |
-|---|---------|--------|-------|
-| #99 | 録音の `createdBy` が空文字で保存されている | bug, P0 | **A3 prod 完了により本 PR でクローズ** |
-| #100 | Firestore Rules の recordings 権限が過剰 | bug, P0 | **PR #115 マージ済 (dev deploy 完了、prod deploy 残)** |
-| #114 | delete-empty-createdby: 統合テスト・ログ強化 | enhancement, P2 | PR #112 follow-up |
-| #116 | Firestore Rules 追加エッジケーステスト | enhancement, P2 | PR #115 follow-up (Phase 1 前対処) |
-| #102 | deleteAccount テスト拡張（partial failure / auth error codes） | enhancement, P2 | - |
-| #103 | audit-createdby 堅牢性（token cache / pagination 保護） | enhancement, P2 | - |
-| #104 | delete-account test mock の深さ制限 | enhancement, P2 | - |
-| #105 | deleteAccount E2E を Firebase Emulator Suite で実装 | enhancement, P2 | Phase 1 着手時に吸収予定 |
-| #106 | `@preconcurrency` FirebaseAuth Sendable 制約明示化 | enhancement, P2 | - |
-| #107 | `processItem` 主経路テスト追加 | enhancement, P2 | - |
-| #108 | `firebase.json` runtime 重複解消 | bug, P2 | - |
+### 1. iOS 実機 smoke test（Phase 0.5 dev → prod 移行ゲート）
 
-## 既存オープン Issue
+**目的**: Firestore Rules 強化後の iOS 動作確認。dev 環境で下記が通常通り動くこと:
 
-| # | タイトル | ラベル | 優先度 |
-|---|---------|--------|-------|
-| #71 | upload-testflight.sh に entitlements 検証ステップを追加 | P1, bug | 既存 |
-| #65 | Apple ID アカウントリンク | enhancement | 将来対応 |
-| #90 | Guest Tenant のスパム対策: TTL / レート制限 | enhancement | P2 |
-| #91 | アカウント削除後のローカル SwiftData / Outbox クリーンアップ | bug | **P1**（セキュリティリスク） |
-| #92 | Guest Tenant 利用者向けの「本番ログイン不可」案内UI | enhancement | P2 |
-| #93 | deleteAccount Cloud Function の単体テスト追加 | enhancement | **PR #101 で完了**（クローズ候補） |
+- 新規録音作成 → Firestore に `createdBy=自分のuid` で保存
+- 自分の録音の transcription 編集 → 成功
+- RecordingList 表示 → 他人の録音も（read 可）従来通り表示
+- 他人の録音編集を試みる操作があれば → 拒否されること（現在 UI に該当なし、実質 admin SDK 経由のみ update）
 
-## 次セッション推奨アクション
+**失敗時の rollback**:
+```
+# Firestore Console → Rules → 以前のバージョンにリリース
+# または
+firebase deploy --only firestore:rules --project carenote-dev-279  # 旧コミットの rules
+```
 
-### アカウント移行機能の続行（優先度順）
+### 2. transferOwnership dev smoke test（Phase 1 dev → prod 移行ゲート）
 
-1. **A3: 既存 recordings の `createdBy` バックフィル PR**
-   - 29 件（dev 21 + prod 8）の対応
-   - Issue #99 I-Cdx-4/5 の注意事項（`"unknown"` 扱いは deleteAccount で消えない / 推定バックフィルは false attribution リスク）を踏まえ、stakeholder 合意後に方針決定
-   - 候補: 全削除（テストデータ主体と思われるため）/ 隔離コレクション移動 / lifecycle rule 自動削除
+**目的**: Callable Function の動作確認。`firebase functions:shell` で呼出:
 
-2. **Phase 0.5: Firestore Rules 強化 (#100)**
-   - `recordings` を owner (`createdBy == uid`) + admin に絞る
-   - `migrationLogs` collection 新設（admin のみ read、Cloud Function のみ write）
-   - `@firebase/rules-unit-testing` をセット、CI 組込み
+```
+firebase functions:shell --project carenote-dev-279
+> transferOwnership({ fromUid: "test-from", toUid: "test-to", dryRun: true }, { auth: { uid: "admin-x", token: { tenantId: "279", role: "admin" } } })
+# → { dryRunId, counts: {...} }
+> transferOwnership({ dryRunId: "<上の id>" }, { auth: adminの auth })
+# → { ok: true, updated: {...} }
+```
 
-3. **Phase 1: `transferOwnership` Cloud Function 実装**
-   - ADR-008 の書換対象（recordings + templates + whitelist）
-   - 二段階 confirm (dryRun → dryRunId 指定 confirm)
-   - chunked batch write + `migrationState.lastDocId` で中断再開可
-   - `migrationLogs/{id}` に監査ログ記録
-   - 初期実装で `deleteOldAuthUser` は外す（別 Function に分離）
+もしくは本番相当の admin アカウントでテストデータを用意し、end-to-end 確認。
 
-4. **Phase 0.9: allowedDomains 有効化**
-   - prod `tenants/279.allowedDomains = ["279279.net"]` を Firestore 直接更新
-   - 運用手順書化
+**ロールバック**: Cloud Function 削除で即無効化。データ更新は migrationLogs に残るため監査可能。
 
-### App Store 審査関連
+### 3. Phase 0.5 prod deploy 承認 (smoke test 通過後)
 
-**審査通過時:**
-1. Issue #91（Outbox 誤送信セキュリティリスク）を最優先
-2. Issue #93 は PR #101 でカバー → クローズ検討
-3. #90 / #92 順次対応
+```
+firebase deploy --only firestore:rules --project carenote-prod-279
+```
 
-**リジェクト時:**
-1. リジェクト理由精読 + ADR-007 照合
-2. Guideline 別 playbook（2.1(a) / 5.1.1(v) / 4.8）
-3. `/codex review` でセカンドオピニオン
+prod 操作のため CLAUDE.md に従いユーザー確認ゲートあり。
 
-## CI / 既知問題
+### 4. Phase 1 prod deploy 承認 (smoke test 通過後)
 
-- PR #101 の CI: test PASS (32m17s)
-- 過去の CI #96 失敗は GitHub Actions の iOS Simulator Runtime 接続失敗（exit 70）、コード起因ではない
+```
+firebase deploy --only functions:transferOwnership --project carenote-prod-279
+```
+
+prod 操作のため ユーザー確認必須。
+
+### 5. Sprint E: Phase 0.9 `allowedDomains` 有効化 (Phase 0.5/1 prod 完了後)
+
+- Issue #111 で追跡
+- prod `tenants/279.allowedDomains = ["279279.net"]` を Firestore に設定
+- RUNBOOK 作成 + `beforeSignIn` で allowedDomains が参照されることの動作確認
+
+## Open Issue（優先度順）
+
+### P0（ブロッカーなし、現時点で CLOSED）
+
+_Issue #99 / #100 / #110 は本セッションで全て解決_
+
+### P1
+
+| # | タイトル | 状態 |
+|---|---------|------|
+| #71 | upload-testflight.sh に entitlements 検証ステップを追加 | 既存、要対応 |
+| #91 | アカウント削除後のローカル SwiftData / Outbox クリーンアップ | セキュリティリスク、要対応 |
+
+### P2（本セッション follow-up）
+
+| # | タイトル |
+|---|---------|
+| #114 | delete-empty-createdby: 統合テスト・ログ強化 |
+| #116 | Firestore Rules 追加エッジケーステスト |
+| #120 | transferOwnership: /review-pr 指摘の残課題 (logging / CLI / boundary tests) |
+
+### P2（既存）
+
+| # | タイトル |
+|---|---------|
+| #90 | Guest Tenant スパム対策: TTL / レート制限 |
+| #92 | Guest Tenant 利用者向けの「本番ログイン不可」案内UI |
+| #102 | deleteAccount テスト拡張（partial failure / auth error codes） |
+| #103 | audit-createdby 堅牢性（token cache / pagination 保護） |
+| #104 | delete-account test mock の深さ制限 |
+| #105 | deleteAccount E2E を Firebase Emulator Suite で実装 |
+| #106 | `@preconcurrency` FirebaseAuth Sendable 制約明示化 |
+| #107 | `processItem` 主経路テスト追加 |
+| #108 | `firebase.json` runtime 重複 + Node.js 20 deprecation (2026-10-30) |
+| #111 | Phase 0.9: prod allowedDomains 有効化（Phase 0.5/1 prod deploy 後） |
+
+### 将来対応
+
+| # | タイトル |
+|---|---------|
+| #65 | Apple ID アカウントリンク |
+
+## 次セッション推奨アクション（優先度順）
+
+1. **Phase 0.5 iOS smoke test を済ませる**（上記「ユーザー作業依頼 §1」）
+2. **Phase 1 dev smoke test を済ませる**（上記「ユーザー作業依頼 §2」）
+3. **Phase 0.5 prod deploy**（ユーザー承認 → Rules apply）
+4. **Phase 1 prod deploy**（ユーザー承認 → Cloud Function deploy）
+5. **Sprint E: Phase 0.9 RUNBOOK 作成 + prod allowedDomains 設定**（Issue #111）
+6. App Store 審査結果次第で Issue #91/#71 に優先対応
+
+### deleteOldAuthUser 分離 Function（Phase 1 残件）
+
+Issue #110 本体は transferOwnership のみ。旧 Auth user 削除は別 Function として残してあるため、将来独立 Issue 化して実装する（ロールバック余地を Phase 1 完了後に評価）。
+
+## Aliyah / 既知の警告
+
+### Cloud Functions Node.js 20 deprecation
+
+- dev deploy 時に警告: 「Runtime Node.js 20 will be deprecated on 2026-04-30 and will be decommissioned on 2026-10-30」
+- Issue #108 に firebase.json runtime 重複解消とあわせて記載。`nodejs20` → `nodejs22` へ upgrade 必要
+- firebase-functions パッケージも outdated 警告
+
+### CI Workflow
+
+- `.github/workflows/test.yml` (iOS Tests) は paths-ignore で `firestore.rules` / `functions/**` / `docs/**` / `.github/**` 等を除外
+- `.github/workflows/functions-test.yml` (Functions & Rules Tests) が Firestore + Auth emulator で 109 tests を実行
+- GitHub Actions iOS Simulator install の infra 失敗 (exit 70) は paths-ignore で回避済み
+
+## ADR
+
+- [ADR-008](../adr/ADR-008-account-ownership-transfer.md) — アカウント所有権移行方式。Phase 0 棚卸し + Phase 1 実装詳細（状態遷移図、エラーマッピング、チェックポイント、監査ログスキーマ、Partial Update 不変性、入力検証、運用呼出フロー、count drift 仕様）まで記載。Status: Accepted。
 
 ## 参考資料
 
-- [PR #101 Phase -1 修正](https://github.com/system-279/carenote-ios/pull/101)
+- [PR #101 Phase -1](https://github.com/system-279/carenote-ios/pull/101)
+- [PR #112 A3 dev バックフィル](https://github.com/system-279/carenote-ios/pull/112)
+- [PR #115 Phase 0.5 Rules](https://github.com/system-279/carenote-ios/pull/115)
+- [PR #117 A3 prod バックフィル](https://github.com/system-279/carenote-ios/pull/117)
+- [PR #119 Phase 1 transferOwnership](https://github.com/system-279/carenote-ios/pull/119)
 - [ADR-008 アカウント所有権移行方式](../adr/ADR-008-account-ownership-transfer.md)
 - [ADR-007 Guest Tenant 設計判断](../adr/ADR-007-guest-tenant-for-apple-signin.md)
-- [Issue #99 createdBy 空文字バグ](https://github.com/system-279/carenote-ios/issues/99)（監査結果コメント + A3 設計注意事項あり）


### PR DESCRIPTION
## Summary

2026-04-21 セッション終了前の handoff 用。`docs/handoff/LATEST.md` を本セッションの全成果（Phase -1 A3 dev+prod / Phase 0.5 / Phase 1）を反映した状態に更新し、次セッション AI が再開できる状態を確立する。docs-only PR。

## 変更

### Phase 表 (§アカウント移行機能の Phase 構成)
- Phase -1 A3 prod ✅ 実施済 (PR #117)
- Phase 0.5 ✅ PR #115 merged + dev deploy 完了
- Phase 1 ✅ PR #119 merged + dev deploy 完了
- Phase 0.9 ⏳ ユーザー作業待ち（smoke test + prod deploy）

### Open Issue 表
- 削除: #99 / #100 / #110（closed）
- 追加: #114 / #116 / #120（本セッション follow-up）、#108 に Node 20 deprecation 警告注記

### 新設セクション: ユーザー作業依頼
次セッション再開に必要な 5 ステップを明示:
1. iOS 実機 smoke test (Phase 0.5)
2. transferOwnership dev smoke test (Phase 1)
3. Phase 0.5 prod deploy 承認
4. Phase 1 prod deploy 承認
5. Sprint E: Phase 0.9 allowedDomains 有効化

### 既知の警告セクション
- Cloud Functions Node.js 20 deprecation (2026-10-30)
- firebase-functions パッケージ outdated
- CI Workflow の paths-ignore 状況

## Handoff 再開性チェック

- [x] main: clean、CI green (Functions & Rules Tests pass 1m12s)
- [x] 残留プロセス: なし
- [x] 主要 ADR: [ADR-008](../adr/ADR-008-account-ownership-transfer.md) が Accepted + Phase 1 実装詳細記載済
- [x] LATEST.md 190 行（500 行上限以下）
- [x] 解消した P0 Issue (#99/#100/#110) 全て CLOSED 確認済

## Test plan

- [x] diff 確認
- [x] `wc -l` で 190 行確認（上限内）
- [ ] マージ後: 次セッション開始時に `cat docs/handoff/LATEST.md` で現状把握可能

🤖 Generated with [Claude Code](https://claude.com/claude-code)