### PR TITLE
test: delete-account mock の深いサブコレクション偽陽性修正 (Closes #104)

### DIFF
--- a/functions/test/delete-account.test.js
+++ b/functions/test/delete-account.test.js
@@ -31,8 +31,17 @@ before(() => {
       doc: (id) => createDocRef(`${path}/${id}`),
       where: (field, _op, value) => ({
         get: async () => {
+          const prefix = path + "/";
           const docs = Object.entries(mockFirestoreData)
-            .filter(([key, data]) => key.startsWith(path + "/") && data[field] === value)
+            .filter(([key, data]) => {
+              if (!key.startsWith(prefix)) return false;
+              const rel = key.slice(prefix.length);
+              // Only direct children: reject deeper subcollection paths
+              // (e.g. "recordings/r1/comments/c1" must not match a query on
+              // "tenants/279/recordings"). See Issue #104.
+              if (rel.includes("/")) return false;
+              return data[field] === value;
+            })
             .map(([key, data]) => ({
               id: key.split("/").pop(),
               data: () => data,
@@ -165,6 +174,41 @@ describe("deleteAccount Callable Function", () => {
     assert.deepStrictEqual(result, { success: true });
     assert.deepStrictEqual(deletedDocs, ["tenants/279/recordings/r1"], "Firestore 削除は実行される");
     assert.deepStrictEqual(deletedStorageFiles, [], "parseできない gs URI は Storage 削除されない");
+    assert.deepStrictEqual(deletedUids, ["alice"]);
+  });
+
+  it("サブコレクション配下のドキュメントは recordings クエリで拾われない (Issue #104 regression)", async () => {
+    mockFirestoreData["tenants/279/recordings/r1"] = {
+      createdBy: "alice",
+      audioStoragePath: "gs://audio-bucket/279/r1.m4a",
+    };
+    // 深いサブコレクションに alice の createdBy を持つ別ドキュメント。
+    // 直下 recordings のクエリで拾ってはならない。
+    mockFirestoreData["tenants/279/recordings/r1/comments/c1"] = {
+      createdBy: "alice",
+      audioStoragePath: "gs://audio-bucket/279/r1-c1.m4a",
+    };
+
+    const result = await deleteAccount({
+      auth: { uid: "alice", token: { tenantId: "279" } },
+      data: {},
+    });
+
+    assert.deepStrictEqual(result, { success: true });
+    assert.deepStrictEqual(
+      deletedDocs,
+      ["tenants/279/recordings/r1"],
+      "直下の r1 のみ削除。サブコレクション配下の c1 は対象外"
+    );
+    assert.deepStrictEqual(
+      deletedStorageFiles,
+      ["audio-bucket/279/r1.m4a"],
+      "Storage も直下 r1 の audio のみ削除"
+    );
+    assert.ok(
+      "tenants/279/recordings/r1/comments/c1" in mockFirestoreData,
+      "サブコレクション配下のドキュメントは残存"
+    );
     assert.deepStrictEqual(deletedUids, ["alice"]);
   });
 


### PR DESCRIPTION
## Summary

PR #101 の code-reviewer 指摘 (I-4) を修正。`functions/test/delete-account.test.js` の `createCollectionRef` mock が `where().get()` で `key.startsWith(path + "/")` のみフィルタしており、**将来サブコレクションを追加した瞬間に偽陽性で拾う**潜在リスクがあった。

## 修正内容

- `createCollectionRef` の `where().get()`: prefix 除去後の相対パスに `/` が含まれる場合を除外
- 偽陽性の回帰防止テストを 1 件追加: `tenants/279/recordings/r1` と `tenants/279/recordings/r1/comments/c1` を同時 seed、削除対象が直下の r1 のみであることを確認

## Test plan

- [x] `npx mocha test/delete-account.test.js` 全 8 テスト PASS（既存 7 + 新規 1）
- [x] 既存テストの挙動変化なし（直下のみ seed している既存テストでは filter 条件が保守的になるだけで結果は不変）

## 受入基準 (Issue #104)

- [x] mock の `createCollectionRef` が直下 segment のみをフィルタする
- [x] 既存 6 テスト全 PASS を維持（実際は 7 テスト、全 PASS）
- [x] サブコレクションを混入させたテストケースを 1 つ追加（偽陽性の回帰防止）

## 関連

- Closes #104
- PR #101 code-reviewer I-4

🤖 Generated with [Claude Code](https://claude.com/claude-code)