### PR TITLE
feat: admin ID token 発行 helper + RUNBOOK (Issue #120 part 1)

### DIFF
--- a/docs/runbook/phase-1-admin-id-token.md
+++ b/docs/runbook/phase-1-admin-id-token.md
@@ -37,12 +37,18 @@
 
 ### 2. ID token の発行
 
+**token は必ず shell 変数経由で受け取る**（terminal に裸表示させると scrollback / copy-paste で漏洩する）。ログ用途で stderr を保存したい場合は `2>/tmp/get-token.log` を付加（stderr を `/dev/null` に捨てると user 作成・claims 設定の診断情報が消えるので非推奨）。
+
 ```bash
-node functions/scripts/get-admin-id-token.mjs \
+ID_TOKEN=$(node functions/scripts/get-admin-id-token.mjs \
   --project carenote-dev-279 \
   --uid transferOp-yh-20260421 \
   --tenant-id 279 \
-  --role admin
+  --role admin \
+  2>/tmp/get-token.log)
+
+# 確認: JWT の構造 (xxx.yyy.zzz) を持つこと
+echo "${ID_TOKEN:0:20}..."  # 先頭 20 文字だけ確認（全体を echo しない）
 ```
 
 処理内容:
@@ -56,12 +62,6 @@ stdout に ID token（JWT）のみが出力される。stderr には診断情報
 ### 3. Callable 呼出
 
 ```bash
-# 1 行で使う場合
-ID_TOKEN=$(node functions/scripts/get-admin-id-token.mjs \
-  --project carenote-dev-279 \
-  --uid transferOp-yh-20260421 \
-  --tenant-id 279 --role admin)
-
 node functions/scripts/call-transfer-ownership.mjs \
   --project carenote-dev-279 \
   --from-uid <old-uid> --to-uid <new-uid> \
@@ -99,27 +99,25 @@ node /tmp/cleanup-admin-uid.mjs
 - `migrationLogs` / `migrationState` 書込許可のある Rules が deploy 済（Phase 0.5 PR #115 prod 反映後）
 - low-traffic 時間帯
 
-### 2. ID token 発行
+### 2. ID token 発行（shell 変数経由で取得、terminal に裸表示させない）
+
+**重要**: `CONFIRM_PROD` の値は project id を指定する。`CONFIRM_PROD=yes` ではない。これは `export CONFIRM_PROD=yes` を一度した shell で後続コマンドが全て無警告で prod に流れるリスクを避けるため。helper script は `CONFIRM_PROD === args.project` を厳密チェックする。
+
+さらに `export` ではなく **invocation scoped な前置き** (`CONFIRM_PROD=... CLOUDSDK_... node ...`) を必ず使う。
 
 ```bash
-CONFIRM_PROD=yes \
-CLOUDSDK_ACTIVE_CONFIG_NAME=carenote-prod \
+ID_TOKEN=$(CONFIRM_PROD=carenote-prod-279 \
+  CLOUDSDK_ACTIVE_CONFIG_NAME=carenote-prod \
   node functions/scripts/get-admin-id-token.mjs \
     --project carenote-prod-279 \
     --uid transferOp-yh-20260421 \
-    --tenant-id 279 --role admin
+    --tenant-id 279 --role admin \
+    2>/tmp/get-token-prod.log)
 ```
-
-`CONFIRM_PROD=yes` が無いと helper script が exit 2 で即拒否する。
 
 ### 3. transferOwnership 呼出
 
 ```bash
-ID_TOKEN=$(CONFIRM_PROD=yes CLOUDSDK_ACTIVE_CONFIG_NAME=carenote-prod \
-  node functions/scripts/get-admin-id-token.mjs \
-    --project carenote-prod-279 --uid transferOp-yh-20260421 \
-    --tenant-id 279 --role admin)
-
 CONFIRM_PROD=yes \
   node functions/scripts/call-transfer-ownership.mjs \
     --project carenote-prod-279 \
@@ -135,6 +133,8 @@ CONFIRM_PROD=yes \
     --id-token "$ID_TOKEN"
 ```
 
+**NOTE**: `call-transfer-ownership.mjs` 側の `CONFIRM_PROD` は現状 `=yes` 固定（#120 part 2 で本 helper と同じ nonce 方式に揃える予定）。
+
 ### 4. 一時 uid の削除（必ず実施）
 
 dev 手順 A § 4 の cleanup スクリプトを `projectId: "carenote-prod-279"` と `CONFIRM_PROD=yes` + `CLOUDSDK_ACTIVE_CONFIG_NAME=carenote-prod` で実行。
@@ -148,8 +148,10 @@ dev 手順 A § 4 の cleanup スクリプトを `projectId: "carenote-prod-279"
 | 項目 | 対応 |
 |---|---|
 | API_KEY の扱い | 公開 identifier（iOS バイナリに埋込済）なので helper script への引数 / ログ出力は許容 |
-| ID token の扱い | **機密**。shell history に残さないよう `ID_TOKEN=$(...)` で変数経由、`--id-token "$ID_TOKEN"` で渡す |
+| ID token の扱い | **機密**。`ID_TOKEN=$(...)` で変数経由、`--id-token "$ID_TOKEN"` で渡す。echo する場合は `${ID_TOKEN:0:20}...` で先頭のみ |
+| shell history | `node ... --uid transferOp-yh-20260421` の `--uid` 引数は history に残る。機密情報ではないが、一時 uid であることを命名で明示する理由にもなる |
 | 一時 admin uid | 作業終了後に必ず delete。放置すると永続的 admin 権限が残る |
+| prod ガード | `CONFIRM_PROD=<project-id>` を **invocation 前置き**で指定（`export` 非推奨）。helper は値を project id と厳密比較 |
 | prod 実行履歴 | `migrationLogs/<dryRunId>` に caller uid + 操作内容が自動記録される |
 | GOOGLE_APPLICATION_CREDENTIALS | **使わない**。`gcloud auth application-default login` の ADC を利用 |
 

--- a/docs/runbook/phase-1-admin-id-token.md
+++ b/docs/runbook/phase-1-admin-id-token.md
@@ -1,0 +1,184 @@
+# RUNBOOK: `transferOwnership` 用 admin ID token の取得
+
+**ステータス**: 運用可能
+**対象**: `call-transfer-ownership.mjs` 方式B / 他の Callable Function を admin 権限で叩く必要がある one-off 運用
+**関連**: Issue #120、`docs/runbook/phase-1-transfer-ownership-smoke-test.md` 方式B、`functions/scripts/get-admin-id-token.mjs`
+
+---
+
+## いつ使うか
+
+- Phase 1 `transferOwnership` dev smoke test **方式B**（prod 相当経路での動作確認）
+- 緊急の one-off 所有権移行運用
+- その他、Firebase Auth の admin custom claim を要する Callable を CLI から叩く場合
+
+**iOS 側にデバッグコードを追加して ID token をログ出力する方式は禁止**（revert 忘れで debug コードが merge されるリスクが高い）。本 RUNBOOK の helper script を使うこと。
+
+---
+
+## 前提
+
+- `gcloud auth application-default login` で ADC 設定済（`system@279279.net` アカウント）
+- Firebase Admin SDK が `node_modules` に存在（`functions/` で `npm ci` 済）
+- 作業 shell が repository root にある（`GoogleService-Info.plist` 自動解決用）
+
+---
+
+## 手順 A: dev 環境
+
+### 1. 一時 admin uid の決定
+
+本 ID token は既存ユーザーの identity を借りる形式。以下のいずれか:
+
+- **推奨: 一時 uid パターン** — `transferOp-<initials>-<YYYYMMDD>`（例: `transferOp-yh-20260421`）
+  - 運用後に `auth.deleteUser()` で確実に削除できる
+  - admin 権限付与が一時的であることが uid 名から明らか
+- 既存 admin ユーザーの uid（監査ログに自分の実 uid が残るメリット）
+
+### 2. ID token の発行
+
+```bash
+node functions/scripts/get-admin-id-token.mjs \
+  --project carenote-dev-279 \
+  --uid transferOp-yh-20260421 \
+  --tenant-id 279 \
+  --role admin
+```
+
+処理内容:
+1. Admin SDK (ADC) で該当 uid を Auth に upsert
+2. `custom claims: { tenantId, role: "admin" }` を set
+3. custom token を発行
+4. Identity Toolkit `signInWithCustomToken` REST で ID token に交換（~1 時間有効）
+
+stdout に ID token（JWT）のみが出力される。stderr には診断情報（user 作成有無 / claims 設定）が出る。
+
+### 3. Callable 呼出
+
+```bash
+# 1 行で使う場合
+ID_TOKEN=$(node functions/scripts/get-admin-id-token.mjs \
+  --project carenote-dev-279 \
+  --uid transferOp-yh-20260421 \
+  --tenant-id 279 --role admin)
+
+node functions/scripts/call-transfer-ownership.mjs \
+  --project carenote-dev-279 \
+  --from-uid <old-uid> --to-uid <new-uid> \
+  --dry-run \
+  --id-token "$ID_TOKEN"
+```
+
+ID token は ~1 時間有効。dryRun → confirm の操作は同一 token で十分間に合う。
+
+### 4. cleanup
+
+```bash
+cat > /tmp/cleanup-admin-uid.mjs <<'EOF'
+import { initializeApp, applicationDefault } from "firebase-admin/app";
+import { getAuth } from "firebase-admin/auth";
+initializeApp({ credential: applicationDefault(), projectId: "carenote-dev-279" });
+await getAuth().deleteUser("transferOp-yh-20260421");
+console.log("deleted");
+process.exit(0);
+EOF
+node /tmp/cleanup-admin-uid.mjs
+```
+
+一時 uid 方式を採用した場合は必ず実行。既存 admin uid を流用した場合はこの手順をスキップし、claims だけ元に戻すか、role を変えずに放置（元から admin の場合）。
+
+---
+
+## 手順 B: prod 環境
+
+**CLAUDE.md MUST**: prod 操作前にユーザー承認取得。以下コマンドをエージェントが自動実行することは禁止。
+
+### 1. 事前確認
+
+- prod の `transferOwnership` function が deploy 済（`firebase functions:list --project=carenote-prod-279` で `ACTIVE` 確認）
+- `migrationLogs` / `migrationState` 書込許可のある Rules が deploy 済（Phase 0.5 PR #115 prod 反映後）
+- low-traffic 時間帯
+
+### 2. ID token 発行
+
+```bash
+CONFIRM_PROD=yes \
+CLOUDSDK_ACTIVE_CONFIG_NAME=carenote-prod \
+  node functions/scripts/get-admin-id-token.mjs \
+    --project carenote-prod-279 \
+    --uid transferOp-yh-20260421 \
+    --tenant-id 279 --role admin
+```
+
+`CONFIRM_PROD=yes` が無いと helper script が exit 2 で即拒否する。
+
+### 3. transferOwnership 呼出
+
+```bash
+ID_TOKEN=$(CONFIRM_PROD=yes CLOUDSDK_ACTIVE_CONFIG_NAME=carenote-prod \
+  node functions/scripts/get-admin-id-token.mjs \
+    --project carenote-prod-279 --uid transferOp-yh-20260421 \
+    --tenant-id 279 --role admin)
+
+CONFIRM_PROD=yes \
+  node functions/scripts/call-transfer-ownership.mjs \
+    --project carenote-prod-279 \
+    --from-uid <old-uid> --to-uid <new-uid> \
+    --dry-run \
+    --id-token "$ID_TOKEN"
+
+# 問題なければ confirm
+CONFIRM_PROD=yes \
+  node functions/scripts/call-transfer-ownership.mjs \
+    --project carenote-prod-279 \
+    --dry-run-id <uuid> --confirm \
+    --id-token "$ID_TOKEN"
+```
+
+### 4. 一時 uid の削除（必ず実施）
+
+dev 手順 A § 4 の cleanup スクリプトを `projectId: "carenote-prod-279"` と `CONFIRM_PROD=yes` + `CLOUDSDK_ACTIVE_CONFIG_NAME=carenote-prod` で実行。
+
+`migrationLogs` に記録された caller uid は削除されない（監査ログは保持）。
+
+---
+
+## セキュリティ注意事項
+
+| 項目 | 対応 |
+|---|---|
+| API_KEY の扱い | 公開 identifier（iOS バイナリに埋込済）なので helper script への引数 / ログ出力は許容 |
+| ID token の扱い | **機密**。shell history に残さないよう `ID_TOKEN=$(...)` で変数経由、`--id-token "$ID_TOKEN"` で渡す |
+| 一時 admin uid | 作業終了後に必ず delete。放置すると永続的 admin 権限が残る |
+| prod 実行履歴 | `migrationLogs/<dryRunId>` に caller uid + 操作内容が自動記録される |
+| GOOGLE_APPLICATION_CREDENTIALS | **使わない**。`gcloud auth application-default login` の ADC を利用 |
+
+---
+
+## トラブルシューティング
+
+### `signInWithCustomToken HTTP 400: INVALID_CUSTOM_TOKEN`
+
+- 時刻ずれ (`gcloud auth application-default login` を再実行して ADC を refresh)
+- API key と project id が不一致 (`--api-key` を明示的に指定)
+
+### `Error: permission-denied: 管理者のみ実行可能です`
+
+- `transferOwnership` は `request.auth.token.role === "admin"` を要求
+- helper script が set した claims が ID token に反映されているか確認: ID token を [jwt.io](https://jwt.io) にペースト → payload に `role: "admin"` が入っていること
+- helper script 内で claims を set してから custom token を発行しているので、通常ここで失敗しない。失敗した場合は helper script の logs (stderr) を確認
+
+### `--id-token is required` (call-transfer-ownership.mjs)
+
+- ID token 発行コマンドの stderr 出力が stdout に混ざって JWT 以外の文字列が取れている可能性
+- `node get-admin-id-token.mjs ... 2>/dev/null` で stderr を捨てて stdout のみ取るか、`command substitution` で最終行だけ抽出
+
+---
+
+## 関連
+
+- [Phase 1 transferOwnership smoke test](./phase-1-transfer-ownership-smoke-test.md)
+- [ADR-008 アカウント所有権移行方式](../adr/ADR-008-account-ownership-transfer.md)
+- Issue #120 (本 RUNBOOK の整備トリガー)
+- `functions/scripts/get-admin-id-token.mjs` (本 RUNBOOK の主役)
+- `functions/scripts/call-transfer-ownership.mjs` (ID token の消費者)

--- a/functions/scripts/get-admin-id-token.mjs
+++ b/functions/scripts/get-admin-id-token.mjs
@@ -1,0 +1,182 @@
+#!/usr/bin/env node
+// Usage: node functions/scripts/get-admin-id-token.mjs \
+//          --project <id> --uid <admin-uid> --tenant-id <tenantId> [--role admin] [--api-key <key>]
+//
+// Emits a Firebase Auth ID token carrying the admin claims required by the
+// `transferOwnership` Callable Function. Intended for dev/prod RUNBOOK use
+// (方式B smoke test / one-off prod ops). Not for application use.
+//
+// Pipeline:
+//   1. Use Firebase Admin SDK (ADC) to upsert the target user and set
+//      custom claims { tenantId, role }.
+//   2. Mint a Firebase custom token for that uid.
+//   3. Exchange the custom token at Identity Toolkit
+//      `accounts:signInWithCustomToken` using the project's public Web API
+//      Key. The returned `idToken` is valid for ~1 hour.
+//
+// Authentication:
+//   - Admin SDK credentials: `gcloud auth application-default login` (ADC).
+//     No service account key file is mounted.
+//   - API Key: the Firebase Web API Key is public (embedded in mobile app
+//     binaries). It can be supplied via --api-key or auto-resolved from
+//     CareNote/Firebase/<env>/GoogleService-Info.plist.
+//
+// Safety:
+//   - On prod projects, CONFIRM_PROD=yes is required (guardrail against
+//     accidental prod-targeted token issuance).
+//   - Ephemeral admin uid pattern is encouraged: pass a uid like
+//     "transferOp-<initials>-<YYYYMMDD>" and delete it after the op.
+//
+// Exit codes:
+//   0 — idToken printed on stdout
+//   1 — argument / config error
+//   2 — prod target without CONFIRM_PROD=yes
+//   3 — Admin SDK or Identity Toolkit call failed
+
+import { initializeApp, applicationDefault } from "firebase-admin/app";
+import { getAuth } from "firebase-admin/auth";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import process from "node:process";
+
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 2; i < argv.length; i++) {
+    const a = argv[i];
+    switch (a) {
+      case "--project": args.project = argv[++i]; break;
+      case "--uid": args.uid = argv[++i]; break;
+      case "--tenant-id": args.tenantId = argv[++i]; break;
+      case "--role": args.role = argv[++i]; break;
+      case "--api-key": args.apiKey = argv[++i]; break;
+      case "--help":
+      case "-h": args.help = true; break;
+      default: throw new Error(`Unknown argument: ${a}`);
+    }
+  }
+  return args;
+}
+
+function usageAndExit(code) {
+  console.error(
+    "Usage: node get-admin-id-token.mjs \\\n" +
+      "         --project <id> --uid <admin-uid> --tenant-id <tenantId> \\\n" +
+      "         [--role admin] [--api-key <public-api-key>]\n\n" +
+      "Env:\n" +
+      "  CONFIRM_PROD=yes  required when --project matches 'prod'\n" +
+      "  GOOGLE_APPLICATION_CREDENTIALS  optional; ADC preferred"
+  );
+  process.exit(code);
+}
+
+function validate(args) {
+  if (args.help) usageAndExit(0);
+  if (!args.project || !args.uid || !args.tenantId) {
+    console.error("Error: --project, --uid, --tenant-id are required");
+    usageAndExit(1);
+  }
+  if (args.project.includes("prod") && process.env.CONFIRM_PROD !== "yes") {
+    console.error(
+      "Error: prod project targeted but CONFIRM_PROD=yes not set. Refusing."
+    );
+    process.exit(2);
+  }
+  args.role = args.role || "admin";
+}
+
+function resolveApiKey(args) {
+  if (args.apiKey) return args.apiKey;
+  // Auto-resolve from the appropriate GoogleService-Info.plist by project id.
+  // Dev and prod plists live under CareNote/Firebase/{Dev,Prod}.
+  const env = args.project.includes("prod") ? "Prod" : "Dev";
+  const plistPath = path.resolve(
+    process.cwd(),
+    `CareNote/Firebase/${env}/GoogleService-Info.plist`
+  );
+  let plist;
+  try {
+    plist = readFileSync(plistPath, "utf8");
+  } catch (err) {
+    throw new Error(
+      `--api-key omitted and ${plistPath} is not readable (${err.message}). ` +
+        `Pass --api-key explicitly or run from repo root.`
+    );
+  }
+  const match = plist.match(/<key>API_KEY<\/key>\s*<string>([^<]+)<\/string>/);
+  if (!match) {
+    throw new Error(
+      `Could not find API_KEY in ${plistPath}. Pass --api-key explicitly.`
+    );
+  }
+  return match[1];
+}
+
+async function mintIdToken(args) {
+  initializeApp({ credential: applicationDefault(), projectId: args.project });
+  const auth = getAuth();
+
+  try {
+    await auth.getUser(args.uid);
+  } catch (err) {
+    if (err.code === "auth/user-not-found") {
+      console.error(`  creating Auth user: ${args.uid}`);
+      await auth.createUser({ uid: args.uid });
+    } else {
+      throw err;
+    }
+  }
+
+  await auth.setCustomUserClaims(args.uid, {
+    tenantId: args.tenantId,
+    role: args.role,
+  });
+  console.error(
+    `  set claims { tenantId: "${args.tenantId}", role: "${args.role}" } on ${args.uid}`
+  );
+
+  const customToken = await auth.createCustomToken(args.uid, {
+    tenantId: args.tenantId,
+    role: args.role,
+  });
+
+  const apiKey = resolveApiKey(args);
+  const res = await fetch(
+    `https://identitytoolkit.googleapis.com/v1/accounts:signInWithCustomToken?key=${apiKey}`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ token: customToken, returnSecureToken: true }),
+    }
+  );
+  const text = await res.text();
+  if (!res.ok) {
+    throw new Error(`signInWithCustomToken HTTP ${res.status}: ${text}`);
+  }
+  let json;
+  try {
+    json = JSON.parse(text);
+  } catch {
+    throw new Error(`signInWithCustomToken returned non-JSON: ${text.slice(0, 200)}`);
+  }
+  if (!json.idToken) {
+    throw new Error(`signInWithCustomToken response missing idToken: ${text.slice(0, 200)}`);
+  }
+  return json.idToken;
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+  validate(args);
+  try {
+    const idToken = await mintIdToken(args);
+    // Write a trailing newline so `$(...)` substitution in shells works
+    // without producing warnings.
+    process.stdout.write(idToken + "\n");
+  } catch (err) {
+    console.error(`Error: ${err.message}`);
+    if (err.stack && process.env.DEBUG) console.error(err.stack);
+    process.exit(3);
+  }
+}
+
+main();

--- a/functions/scripts/get-admin-id-token.mjs
+++ b/functions/scripts/get-admin-id-token.mjs
@@ -39,6 +39,17 @@ import { readFileSync } from "node:fs";
 import path from "node:path";
 import process from "node:process";
 
+// Explicit allowlist beats substring matching for the prod guard.
+// A substring check like `includes("prod")` would miss future prod names
+// that don't contain "prod" (e.g. "carenote-live-279") and falsely flag
+// pre-prod sandboxes (e.g. "carenote-preprod-test").
+const PROD_PROJECTS = new Set(["carenote-prod-279"]);
+const DEV_PROJECTS = new Set(["carenote-dev-279"]);
+
+function isProdProject(project) {
+  return PROD_PROJECTS.has(project);
+}
+
 function parseArgs(argv) {
   const args = {};
   for (let i = 2; i < argv.length; i++) {
@@ -75,11 +86,23 @@ function validate(args) {
     console.error("Error: --project, --uid, --tenant-id are required");
     usageAndExit(1);
   }
-  if (args.project.includes("prod") && process.env.CONFIRM_PROD !== "yes") {
+  if (isProdProject(args.project)) {
+    // Require the project id as the confirmation value to prevent
+    // accidental `export CONFIRM_PROD=yes` in a long-lived shell from
+    // bypassing every subsequent prod-targeted invocation.
+    if (process.env.CONFIRM_PROD !== args.project) {
+      console.error(
+        `Error: prod project ${args.project} targeted. Set CONFIRM_PROD=${args.project} ` +
+          `for the invocation (not via persistent \`export\`).`
+      );
+      process.exit(2);
+    }
+  } else if (!DEV_PROJECTS.has(args.project)) {
     console.error(
-      "Error: prod project targeted but CONFIRM_PROD=yes not set. Refusing."
+      `Error: project "${args.project}" is neither dev nor prod allowlisted. ` +
+        `If this is a new project, update PROD_PROJECTS / DEV_PROJECTS in this script.`
     );
-    process.exit(2);
+    process.exit(1);
   }
   args.role = args.role || "admin";
 }
@@ -88,7 +111,7 @@ function resolveApiKey(args) {
   if (args.apiKey) return args.apiKey;
   // Auto-resolve from the appropriate GoogleService-Info.plist by project id.
   // Dev and prod plists live under CareNote/Firebase/{Dev,Prod}.
-  const env = args.project.includes("prod") ? "Prod" : "Dev";
+  const env = isProdProject(args.project) ? "Prod" : "Dev";
   const plistPath = path.resolve(
     process.cwd(),
     `CareNote/Firebase/${env}/GoogleService-Info.plist`
@@ -149,17 +172,35 @@ async function mintIdToken(args) {
     }
   );
   const text = await res.text();
+  // Never echo raw response bodies into error messages — on 200 the body
+  // carries the live idToken, and even partial/truncated bodies may contain
+  // JWT fragments. Only surface structured error codes/messages.
   if (!res.ok) {
-    throw new Error(`signInWithCustomToken HTTP ${res.status}: ${text}`);
+    let code = "";
+    let message = "";
+    try {
+      const parsed = JSON.parse(text);
+      code = parsed?.error?.status || parsed?.error?.code || "";
+      message = parsed?.error?.message || "";
+    } catch {
+      // body was not JSON; do not echo it (could still contain secrets)
+    }
+    const safeSuffix = code || message
+      ? `${code}${code && message ? ": " : ""}${message}`
+      : "(response body withheld)";
+    throw new Error(`signInWithCustomToken HTTP ${res.status}: ${safeSuffix}`);
   }
   let json;
   try {
     json = JSON.parse(text);
   } catch {
-    throw new Error(`signInWithCustomToken returned non-JSON: ${text.slice(0, 200)}`);
+    // Do not include any portion of the body; on 200 it contains the idToken.
+    throw new Error("signInWithCustomToken returned non-JSON on 200 status");
   }
   if (!json.idToken) {
-    throw new Error(`signInWithCustomToken response missing idToken: ${text.slice(0, 200)}`);
+    // Only surface structure, never raw payload.
+    const keys = Object.keys(json || {}).join(",");
+    throw new Error(`signInWithCustomToken response missing idToken (keys: ${keys})`);
   }
   return json.idToken;
 }
@@ -173,8 +214,12 @@ async function main() {
     // without producing warnings.
     process.stdout.write(idToken + "\n");
   } catch (err) {
+    // Deliberately do NOT print err.stack — firebase-admin error messages
+    // and stack traces have historically surfaced custom tokens, and this
+    // script is the one place that generates credentials. Users needing
+    // deeper traces should modify the script locally rather than enable a
+    // DEBUG env flag that could leak secrets into terminals/CI logs.
     console.error(`Error: ${err.message}`);
-    if (err.stack && process.env.DEBUG) console.error(err.stack);
     process.exit(3);
   }
 }


### PR DESCRIPTION
## Summary

Phase 1 `transferOwnership` 方式B smoke test と one-off prod 運用で必要な Firebase Auth admin ID token を、iOS debug ログに依存せず安全に取得できる仕組みを整備。

## 何を解決するか

- 従来: iOS AuthViewModel に一時的に `getIDToken { ... }` ログを追加し、出力を copy → 後で revert という運用 ⇒ **revert 忘れリスク / PR 混入リスク**
- 本 PR: Admin SDK + Identity Toolkit REST で CLI のみで完結、一時 admin uid パターンで cleanup も明示化

## 新規ファイル

| ファイル | 役割 |
|---|---|
| `functions/scripts/get-admin-id-token.mjs` | ADC で uid upsert → custom claims set → custom token → signInWithCustomToken で ID token exchange |
| `docs/runbook/phase-1-admin-id-token.md` | dev / prod 手順 + セキュリティ注意事項 + トラブルシューティング |

## セキュリティ (review 指摘反映済)

- prod ガード: `PROD_PROJECTS = Set(["carenote-prod-279"])` allowlist + `CONFIRM_PROD=<project-id>` nonce 方式（`export` で bypass される risk 排除）
- 未知 project: dev/prod allowlist に無ければ exit 1 で拒否
- ID token 漏洩防止: signInWithCustomToken error から raw body を除去、JSON parse 経由で error code/message のみ surface、idToken 欠落時は keys 一覧のみ
- createCustomToken err.stack 出力を停止（firebase-admin stack trace で custom token が出る歴史的 risk）
- API_KEY: 公開 identifier (iOS binary 埋込済) のため RUNBOOK / script への露出は許容
- SA key 不使用: `gcloud auth application-default login` の ADC のみ

## Test plan

- [x] `node --check` syntax valid
- [x] `node get-admin-id-token.mjs --help` 正しい usage 表示
- [x] 未知 project (`bogus-project-name`) → exit 1
- [x] prod project `CONFIRM_PROD` 無し → exit 2
- [x] prod project `CONFIRM_PROD=yes` → exit 2 (project-id 不一致で拒否)
- [x] prod project `CONFIRM_PROD=carenote-prod-279` → ADC 操作に進入
- [ ] 次セッションでユーザー側が dev で実地検証:
  - `node get-admin-id-token.mjs --project carenote-dev-279 --uid transferOp-test-20260421 --tenant-id 279 --role admin 2>/tmp/log`
  - 出力された ID token を [jwt.io](https://jwt.io) で decode、payload に `tenantId: "279"`, `role: "admin"` を確認
  - ID token を使って `call-transfer-ownership.mjs --dry-run` が成功することを確認
  - 一時 admin uid を cleanup

## Issue #120 AC 進捗

- [x] `--id-token` 取得 RUNBOOK を整備
- [ ] call-transfer-ownership.mjs の fetch / JSON.parse 強化 → **part 2**
- [ ] transferOwnership server-side の err.stack / errorId → **part 2**
- [ ] テスト追加 (BATCH_SIZE 境界 / checkpoint atomicity) → **part 3**

## Review 結果

- code-reviewer: Critical 0 / Important 2 → 1 件対応 (§2 runbook形式)、1 件対応 (prod allowlist)
- silent-failure-hunter: Critical 3 → **全件対応** (token leak redaction / prod guard bypass / CONFIRM_PROD nonce)
- 残 Important/Suggestion は Issue #129 で follow-up

## follow-up

- **Issue #129**: getUser エラー分岐 / retry / 自動 cleanup / ADC project mismatch warning / call-transfer-ownership.mjs CONFIRM_PROD 方式統一
- PR #122 の `phase-1-transfer-ownership-smoke-test.md` 方式B 節に本 RUNBOOK 参照を追加する follow-up コミットが必要 (PR #122 merge 後)

## 関連

- Issue #120 (本 PR で AC 1 項目消化)
- Follow-up: Issue #129
- PR #122 (smoke-test RUNBOOK、方式B セクションの参照更新が必要)
- ADR-008

🤖 Generated with [Claude Code](https://claude.com/claude-code)