### PR TITLE
feat: Node.js 20→22 runtime upgrade + firebase.json 重複キー整理 (Issue #124, #108)

### DIFF
--- a/.github/workflows/functions-test.yml
+++ b/.github/workflows/functions-test.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
           cache-dependency-path: functions/package-lock.json
 

--- a/docs/handoff/LATEST.md
+++ b/docs/handoff/LATEST.md
@@ -163,11 +163,11 @@ Issue #110 本体は transferOwnership のみ。旧 Auth user 削除は別 Funct
 
 ## 既知の警告
 
-### Cloud Functions Node.js 20 deprecation
+### Cloud Functions Node.js 22 runtime（Issue #124 で対応）
 
-- dev deploy 時に警告: 「Runtime Node.js 20 will be deprecated on 2026-04-30 and will be decommissioned on 2026-10-30」
-- Issue #108 に firebase.json runtime 重複解消とあわせて記載。`nodejs20` → `nodejs22` へ upgrade 必要
-- firebase-functions パッケージも outdated 警告
+- 以前の deprecation 警告（Node.js 20 decommission 2026-10-30）は Issue #124 で解消予定
+- firebase.json の `functions` 重複キーも同 PR で統合（Issue #108 も同時解決）
+- firebase-functions 7.2.5 / firebase-admin 13.8.0 に更新
 
 ### CI Workflow
 

--- a/firebase.json
+++ b/firebase.json
@@ -8,23 +8,19 @@
       "**/*.md"
     ]
   },
-  "functions": {
-    "source": "functions",
-    "runtime": "nodejs22"
-  },
+  "functions": [
+    {
+      "source": "functions",
+      "codebase": "default",
+      "runtime": "nodejs22"
+    }
+  ],
   "firestore": {
     "rules": "firestore.rules"
   },
   "storage": {
     "rules": "storage.rules"
   },
-  "functions": [
-    {
-      "source": "functions",
-      "codebase": "default",
-      "runtime": "nodejs20"
-    }
-  ],
   "hosting": {
     "public": "hosting/public",
     "ignore": [

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -9,8 +9,8 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "firebase-admin": "^13.7.0",
-        "firebase-functions": "^7.2.2"
+        "firebase-admin": "^13.8.0",
+        "firebase-functions": "^7.2.5"
       },
       "devDependencies": {
         "@firebase/rules-unit-testing": "^5.0.0",
@@ -19,7 +19,7 @@
         "mocha": "^11.1.0"
       },
       "engines": {
-        "node": "20"
+        "node": "22"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -3917,9 +3917,9 @@
       }
     },
     "node_modules/firebase-admin": {
-      "version": "13.7.0",
-      "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-13.7.0.tgz",
-      "integrity": "sha512-o3qS8zCJbApe7aKzkO2Pa380t9cHISqeSd3blqYTtOuUUUua3qZTLwNWgGUOss3td6wbzrZhiHIj3c8+fC046Q==",
+      "version": "13.8.0",
+      "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-13.8.0.tgz",
+      "integrity": "sha512-iawoQkmZbsA+2DY5UEuB8f6jSlskzzySoye0D2F6e3zlDZX9DUcXf0HhZqLUn/P6WhLGvTf6ZtCmshZvhAgTYg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@fastify/busboy": "^3.0.0",
@@ -3930,7 +3930,7 @@
         "google-auth-library": "^10.6.1",
         "jsonwebtoken": "^9.0.0",
         "jwks-rsa": "^3.1.0",
-        "node-forge": "^1.3.1",
+        "node-forge": "^1.4.0",
         "uuid": "^11.0.2"
       },
       "engines": {
@@ -3942,9 +3942,9 @@
       }
     },
     "node_modules/firebase-functions": {
-      "version": "7.2.2",
-      "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-7.2.2.tgz",
-      "integrity": "sha512-fWFVI+4weuaat+Fp+4xYY1T+omiTvya8fW79+edgLWCOaDEBSBNlfhstnt+K1esblscZlJf8v+IA0LsCG8Uf1Q==",
+      "version": "7.2.5",
+      "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-7.2.5.tgz",
+      "integrity": "sha512-K+pP0AknluAguLRbD96hibyXbnOgwnvd4hkExWdGrxnNCLoj8LBFj08uvJYxyvhsCgYzQumrUaHBW4lsXKSiRg==",
       "license": "MIT",
       "dependencies": {
         "@types/cors": "^2.8.5",

--- a/functions/package.json
+++ b/functions/package.json
@@ -13,11 +13,11 @@
   "license": "ISC",
   "type": "commonjs",
   "engines": {
-    "node": "20"
+    "node": "22"
   },
   "dependencies": {
-    "firebase-admin": "^13.7.0",
-    "firebase-functions": "^7.2.2"
+    "firebase-admin": "^13.8.0",
+    "firebase-functions": "^7.2.5"
   },
   "devDependencies": {
     "@firebase/rules-unit-testing": "^5.0.0",


### PR DESCRIPTION
## Summary

- Firebase Functions runtime を **Node.js 20 → 22** へ upgrade（2026-04-30 deprecation 対応）
- firebase.json の `functions` 重複キーを統合（Issue #108 同時解決）
- firebase-functions 7.2.2→7.2.5, firebase-admin 13.7.0→13.8.0（どちらも互換 bump）

## 背景

- **2026-04-30**: Node.js 20 runtime が Cloud Functions で deprecated（残り9日）
- **2026-10-30**: 同 decommission（deploy 不可）
- `firebase deploy` 時の deprecation warning が今 PR で消滅する想定

## 変更ファイル（5）

| File | Change |
|------|--------|
| `functions/package.json` | engines.node 20→22、firebase-functions/admin bump |
| `functions/package-lock.json` | 依存更新（npm install 自動） |
| `firebase.json` | 重複 `functions` キー統合 → `nodejs22` 1箇所に |
| `.github/workflows/functions-test.yml` | node-version '20' → '22' |
| `docs/handoff/LATEST.md` | Node 20 deprecation セクション更新 |

**Scope外（別 Issue 推奨）**: `firebase.json` の `hosting` 重複キー（`public: docs` vs `public: hosting/public`）。latent bug だが Issue #124 とは独立のため本 PR では触らない。

## Quality Gate 実施済み

- `/simplify` 3並列（reuse/quality/efficiency） → 指摘は handoff 更新のみ（反映済）
- `/safe-refactor` → HIGH/MEDIUM/LOW いずれも0件、config-only 変更で breaking change なし
- 109 tests PASS（`firebase emulators:exec --only firestore,auth`）

## Test plan

- [x] functions/ で `npm test` via emulator が 109 tests PASS
- [x] CI `Functions & Rules Tests` が Node 22 で PASS
- [ ] dev deploy → `firebase functions:list --project=carenote-dev-279` で 3 関数 (`beforeSignIn`/`deleteAccount`/`transferOwnership`) がすべて `nodejs22` ACTIVE 確認
- [ ] dev smoke test: iOS 実機から Sign-In → 録音 → delete → transfer の主要動線
- [ ] **prod deploy（ユーザー明示承認必須 / CLAUDE.md MUST）** — 低トラフィック時間帯、deploy 直後の Cloud Logging エラー確認
- [ ] prod で deprecation warning が消滅していることを確認

## Rollback

- dev deploy 失敗: `git revert` → 再 deploy（Node 20 に戻る）
- prod deploy 失敗: `gcloud functions deploy --source=<old revision>` or Cloud Functions Console で "Rollback to previous revision"

Closes #124
Closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)