### PR TITLE
test(delete-account): mock の深いサブコレクション偽陽性を修正 (#104)

### DIFF
--- a/functions/test/delete-account.test.js
+++ b/functions/test/delete-account.test.js
@@ -32,7 +32,12 @@ before(() => {
       where: (field, _op, value) => ({
         get: async () => {
           const docs = Object.entries(mockFirestoreData)
-            .filter(([key, data]) => key.startsWith(path + "/") && data[field] === value)
+            .filter(([key, data]) => {
+              if (!key.startsWith(path + "/")) return false;
+              const rel = key.slice(path.length + 1);
+              if (rel.includes("/")) return false;
+              return data[field] === value;
+            })
             .map(([key, data]) => ({
               id: key.split("/").pop(),
               data: () => data,
@@ -166,6 +171,41 @@ describe("deleteAccount Callable Function", () => {
     assert.deepStrictEqual(deletedDocs, ["tenants/279/recordings/r1"], "Firestore 削除は実行される");
     assert.deepStrictEqual(deletedStorageFiles, [], "parseできない gs URI は Storage 削除されない");
     assert.deepStrictEqual(deletedUids, ["alice"]);
+  });
+
+  it("深いサブコレクションを where でヒットさせない（issue #104 regression）", async () => {
+    mockFirestoreData["tenants/279/recordings/r1"] = {
+      createdBy: "alice",
+      audioStoragePath: "gs://audio-bucket/279/r1.m4a",
+    };
+    mockFirestoreData["tenants/279/recordings/r1/comments/c1"] = {
+      createdBy: "alice",
+      text: "nested doc — must NOT be returned by where()",
+    };
+    mockFirestoreData["tenants/279/recordings/r1/attachments/a1"] = {
+      createdBy: "alice",
+      url: "gs://audio-bucket/279/r1/a1.txt",
+    };
+
+    const result = await deleteAccount({
+      auth: { uid: "alice", token: { tenantId: "279" } },
+      data: {},
+    });
+
+    assert.deepStrictEqual(result, { success: true });
+    assert.deepStrictEqual(
+      deletedDocs,
+      ["tenants/279/recordings/r1"],
+      "直下 recording のみ削除対象（サブコレクションは where 結果に含めない）"
+    );
+    assert.ok(
+      "tenants/279/recordings/r1/comments/c1" in mockFirestoreData,
+      "サブコレクション docs は削除対象に含まれない"
+    );
+    assert.ok(
+      "tenants/279/recordings/r1/attachments/a1" in mockFirestoreData,
+      "サブコレクション docs は削除対象に含まれない"
+    );
   });
 
   it("未認証で呼び出されると unauthenticated エラー", async () => {


### PR DESCRIPTION
## Summary
- `where().get()` mock を「直下 segment のみ」にフィルタ制限し、将来サブコレクション追加時の偽陽性を予防
- 回帰防止テストを 1 件追加（サブコレクション docs が削除対象に含まれないことを検証）

## 背景
PR #101 レビュー (code-reviewer I-4) で指摘された潜在リスク。現在のコード範囲では顕在化しないが、`recordings/{id}/comments` 等のサブコレクションを追加した瞬間にテストが偽陽性で通るため、mock の正確性を先行して確保する。

## 受入基準
- [x] mock の `createCollectionRef` が直下 segment のみをフィルタする
- [x] 既存 7 テスト全 PASS を維持（新規 1 件含め 8 passing）
- [x] サブコレクションを混入させたテストケースを 1 つ追加（偽陽性の回帰防止）

## Test plan
- [x] `npx mocha --timeout 10000 --exit test/delete-account.test.js` → **8 passing**
- [x] 既存 7 テスト全て PASS 維持を確認

Closes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)