### PR TITLE
refactor(sync): currentUidProvider の @MainActor 越境を型で明示 (#106)

### DIFF
--- a/CareNote/Features/RecordingConfirm/RecordingConfirmViewModel.swift
+++ b/CareNote/Features/RecordingConfirm/RecordingConfirmViewModel.swift
@@ -1,4 +1,4 @@
-@preconcurrency import FirebaseAuth
+import FirebaseAuth
 import Foundation
 import Observation
 import os.log
@@ -58,7 +58,7 @@ final class RecordingConfirmViewModel {
                 accessTokenProvider: wifService
             ),
             tenantId: tenantId,
-            currentUidProvider: { Auth.auth().currentUser?.uid }
+            currentUidProvider: { @MainActor in Auth.auth().currentUser?.uid }
         )
     }
 

--- a/CareNote/Services/OutboxSyncService.swift
+++ b/CareNote/Services/OutboxSyncService.swift
@@ -37,7 +37,10 @@ actor OutboxSyncService {
     private let firestoreService: any RecordingStoring
     private let transcriptionService: any Transcribing
     private let tenantId: String
-    private let currentUidProvider: @Sendable () -> String?
+    // `@MainActor` 境界越えを型で表明。Firebase Auth singleton は MainActor 前提で
+    // アクセスし、actor 内からは `await` で呼ぶことで data race 可能性を排除する
+    // (issue #106)。
+    private let currentUidProvider: @Sendable @MainActor () -> String?
 
     private var pathMonitor: NWPathMonitor?
     private var monitorQueue: DispatchQueue?
@@ -54,7 +57,7 @@ actor OutboxSyncService {
         firestoreService: any RecordingStoring,
         transcriptionService: any Transcribing,
         tenantId: String,
-        currentUidProvider: @escaping @Sendable () -> String?
+        currentUidProvider: @escaping @Sendable @MainActor () -> String?
     ) {
         self.modelContainer = modelContainer
         self.storageService = storageService
@@ -216,7 +219,7 @@ actor OutboxSyncService {
         // auth cold-start edge cases (uid nil/empty). `buildFirestoreRecording`
         // re-validates as a defense-in-depth for existing firestoreId paths.
         if recording.firestoreId == nil {
-            guard let uid = currentUidProvider(), !uid.isEmpty else {
+            guard let uid = await currentUidProvider(), !uid.isEmpty else {
                 throw OutboxSyncError.userNotAuthenticated
             }
             _ = uid

--- a/CareNoteTests/OutboxSyncServiceTests.swift
+++ b/CareNoteTests/OutboxSyncServiceTests.swift
@@ -26,7 +26,7 @@ struct OutboxSyncServiceTests {
 
     private static func makeService(
         container: ModelContainer,
-        currentUidProvider: @escaping @Sendable () -> String? = { "test-uid" }
+        currentUidProvider: @escaping @Sendable @MainActor () -> String? = { "test-uid" }
     ) -> OutboxSyncService {
         let tokenProvider = StubAccessTokenProvider()
         return OutboxSyncService(


### PR DESCRIPTION
## Summary
- PR #101 Codex review (I-Cdx-2) で指摘された \`@preconcurrency\` による data race 検出の silencing を解消
- \`currentUidProvider\` 型に \`@MainActor\` を追加し、actor 境界越えを型で明示

## 背景
\`RecordingConfirmViewModel.swift\` が \`@preconcurrency import FirebaseAuth\` で Sendable 違反を silence していたため、\`Auth.auth().currentUser?.uid\` を actor 内から呼ぶ data race 可能性をコンパイラが検出できなかった。

## 変更内容

### OutboxSyncService.swift
- \`currentUidProvider: @Sendable () -> String?\` → \`@Sendable @MainActor () -> String?\`
- actor-isolated な \`processItem\` (L222) では \`await currentUidProvider()\` で呼び出し
- \`buildFirestoreRecording\` は既に \`@MainActor\` のため同期呼び出し継続 (L354)

### RecordingConfirmViewModel.swift
- \`@preconcurrency import FirebaseAuth\` → \`import FirebaseAuth\`（\`@preconcurrency\` を削除）
- default factory 内の provider closure に \`{ @MainActor in Auth.auth().currentUser?.uid }\` と明示

## 設計判断
Issue #106 の 3 つの改善案のうち **Option 2（provider 自体を \`@MainActor @Sendable\` に）** を採用。
- Option 1（MainActor 側で uid 取得して渡す）は retry loop 設計（cold-start セッション復元待ち 3 回 backoff）を壊す
- Option 3（\`@preconcurrency\` narrow）は import レベルでは実現不可能
- Option 2 は retry loop 維持しつつ data race を型で排除。MainActor hop コストは 2s+ backoff に対して無視できる

## 受入基準
- [x] Option 2 を採用
- [x] Swift 6 strict concurrency で concurrency/Sendable 警告ゼロ
- [x] data race 可能性が型で排除される（\`@preconcurrency\` 不要化）

## Test plan
- [x] \`xcodebuild -only-testing:CareNoteTests/OutboxSyncServiceTests test\` → **7 passing (0.152s)**
- [x] \`xcodebuild -only-testing:CareNoteTests/RecordingConfirmViewModelTests test\` → **5 passing (0.113s)**
- [x] \`xcodebuild build\` → **BUILD SUCCEEDED**, concurrency 警告ゼロ
- [x] 全体テストの ClientRepositoryTests 巻き込みクラッシュは既存問題（main でも再現）→ **Issue #141 として切り出し**

Closes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)