### PR TITLE
fix: firebase.json の重複 hosting キーを削除 (#131)

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -1,13 +1,4 @@
 {
-  "hosting": {
-    "public": "docs",
-    "ignore": [
-      "firebase.json",
-      "**/.*",
-      "**/node_modules/**",
-      "**/*.md"
-    ]
-  },
   "functions": [
     {
       "source": "functions",


### PR DESCRIPTION
## Summary
- JSON 仕様で重複キーは後者が勝つため、現状既に \`hosting/public\` が配信中
- 最初の \`hosting\` (public: \`docs\`) は silent に無効化されていた dead config → 削除
- **実行時動作は変わらない**（dead config の清掃のみ）

## 削除判断
| 対象 | 用途 | Firebase Hosting で配信すべきか |
|------|------|------|
| \`docs/\` | Architecture Docs (ADR, runbook, handoff) — 開発者向け | × 内部ドキュメント |
| \`hosting/public/\` | App Store 公開ランディング + privacy.html | ✅ 審査要件 |

最初の \`hosting\` キーは \`"public": "docs"\` で、JSON 後勝ちにより無効化済み。\`docs/\` は GitHub Pages / Firebase Hosting いずれでも配信されておらず、削除して dead config を片付けるのが正しい。

## 受入基準
- [x] \`docs/\` vs \`hosting/public/\` のどちらを配信するか決定 → **hosting/public** 維持
- [x] firebase.json の重複 \`hosting\` キーを 1 箇所に統合
- [x] 不要なディレクトリは削除または README で役割を明記 → **削除不要**（\`docs/\` は開発者向け内部ドキュメントとして保持）

## Test plan
- [x] JSON 構文検証: \`node -e 'JSON.parse(require("fs").readFileSync("firebase.json","utf8"))'\` → JSON valid
- [x] 残った \`hosting\` キーの public / ignore 設定は変更なし
- [ ] \`firebase hosting:channel:deploy preview\` は prod deploy 時にユーザーが実施

Closes #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)