### PR TITLE
fix: upload-testflight.sh に entitlements 検証ステップを追加 (#71)

### DIFF
--- a/scripts/upload-testflight.sh
+++ b/scripts/upload-testflight.sh
@@ -18,6 +18,16 @@ sed -i '' "s/CURRENT_PROJECT_VERSION: \"[0-9]*\"/CURRENT_PROJECT_VERSION: \"$BUI
 echo "== XcodeGen =="
 xcodegen generate
 
+# entitlements 検証 (Issue #71): XcodeGen が project.yml の properties 未定義で
+# entitlements を空上書きするバグの再発防止。Sign in with Apple など必須
+# entitlement が失われた状態で archive されると App Store 審査で reject される。
+echo "== Entitlements verification =="
+if ! grep -q "com.apple.developer.applesignin" CareNote/CareNote.entitlements; then
+  echo "ERROR: Sign in with Apple entitlement missing from CareNote/CareNote.entitlements" >&2
+  echo "       project.yml の targets.CareNote.entitlements.properties を確認してください" >&2
+  exit 1
+fi
+
 echo "== Archive (v$(grep 'MARKETING_VERSION:' project.yml | head -1 | sed 's/.*: *"\(.*\)"/\1/'), build: $BUILD_NUMBER) =="
 xcodebuild archive \
   -project CareNote.xcodeproj \


### PR DESCRIPTION
## Summary
- Build 23 で XcodeGen が \`CareNote.entitlements\` から \`com.apple.developer.applesignin\` を消去した状態で archive した事故の再発防止
- archive 前に \`grep -q\` で entitlement 存在を検証、欠落時は stderr にエラーと exit 1

## 背景
\`project.yml\` に entitlements の \`properties\` が未定義だと、XcodeGen が空の entitlements で上書きする。Build 24 で \`properties\` 追加による恒久対策済みだが、他の entitlement 追加時に同様の見落としが起きうるためスクリプト側でも検証する。

## 変更位置
\`scripts/upload-testflight.sh\` の \`xcodegen generate\` 直後、\`xcodebuild archive\` 直前。

\`\`\`bash
echo "== Entitlements verification =="
if ! grep -q "com.apple.developer.applesignin" CareNote/CareNote.entitlements; then
  echo "ERROR: Sign in with Apple entitlement missing from CareNote/CareNote.entitlements" >&2
  echo "       project.yml の targets.CareNote.entitlements.properties を確認してください" >&2
  exit 1
fi
\`\`\`

## Test plan
- [x] \`bash -n scripts/upload-testflight.sh\` (構文検証) → OK
- [x] 現状の \`CareNote.entitlements\` を \`grep -q\` → exit 0 (entitlement present)
- [ ] 次回 TestFlight upload 時に script 通過確認 → ユーザー作業

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)