### PR TITLE
fix(transferOwnership): errorId 付与 + err.stack 構造化ログ (Closes #120)

### DIFF
--- a/functions/src/transferOwnership.js
+++ b/functions/src/transferOwnership.js
@@ -166,7 +166,11 @@ function buildErrorContext(err) {
   } else if (err === null || err === undefined) {
     message = "<unknown error>";
   } else {
-    message = String(err);
+    // String(new Error("")) returns "Error" which is useless in logs. Collapse
+    // that and any other empty stringification to the explicit sentinel so the
+    // log line is never blank and never silently pretends to carry a message.
+    const str = String(err);
+    message = str && str !== "Error" ? str : "<unknown error>";
   }
   const stack = err && typeof err.stack === "string" ? err.stack : null;
   return { errorId, code, message, stack };
@@ -441,10 +445,16 @@ async function runConfirm({ db, tenantId, dryRunId }) {
     // can quote it back when filing a ticket. Preserve the original HttpsError
     // code/message so failed-precondition vs internal semantics are not lost.
     if (err instanceof HttpsError) {
-      const enrichedDetails = {
-        ...(err.details && typeof err.details === "object" ? err.details : {}),
-        errorId: errCtx.errorId,
-      };
+      // Only spread `err.details` when it is a plain object. Arrays would leak
+      // their numeric keys alongside errorId; primitives / null would throw or
+      // silently drop. Non-object details are replaced with the errorId wrapper.
+      const detailsIsPlainObject =
+        err.details != null &&
+        typeof err.details === "object" &&
+        !Array.isArray(err.details);
+      const enrichedDetails = detailsIsPlainObject
+        ? { ...err.details, errorId: errCtx.errorId }
+        : { errorId: errCtx.errorId };
       throw new HttpsError(err.code, err.message, enrichedDetails);
     }
     throw new HttpsError("internal", "transferOwnership failed", failurePayload);

--- a/functions/src/transferOwnership.js
+++ b/functions/src/transferOwnership.js
@@ -2,6 +2,7 @@
 
 const crypto = require("node:crypto");
 const { onCall, HttpsError } = require("firebase-functions/v2/https");
+const logger = require("firebase-functions/logger");
 const { getFirestore, FieldValue } = require("firebase-admin/firestore");
 const { getAuth } = require("firebase-admin/auth");
 
@@ -146,6 +147,29 @@ async function assertNoConcurrentMigration(db, tenantId, fromUid, excludeDryRunI
       );
     }
   }
+}
+
+/**
+ * Build a structured error context that correlates Cloud Logging entries with
+ * the HttpsError surfaced to the caller. `errorId` is a fresh UUID per call;
+ * admins can grep Cloud Logging by `jsonPayload.errorId` once they receive the
+ * id through the CLI stderr / migrationState.lastFailure / migrationLogs.error.
+ * Safe against nullish, non-Error, and missing-code values so no catch branch
+ * can silently swallow the id.
+ */
+function buildErrorContext(err) {
+  const errorId = crypto.randomUUID();
+  const code = (err && typeof err.code === "string" && err.code) || "internal";
+  let message;
+  if (err && typeof err.message === "string" && err.message.length > 0) {
+    message = err.message;
+  } else if (err === null || err === undefined) {
+    message = "<unknown error>";
+  } else {
+    message = String(err);
+  }
+  const stack = err && typeof err.stack === "string" ? err.stack : null;
+  return { errorId, code, message, stack };
 }
 
 async function countMatchingDocs(db, tenantId, collection, field, uid) {
@@ -355,10 +379,25 @@ async function runConfirm({ db, tenantId, dryRunId }) {
     await completionBatch.commit();
     return { ok: true, updated };
   } catch (err) {
+    const errCtx = buildErrorContext(err);
+    // Persist only the fields Firestore can serialize safely. `stack` goes to
+    // Cloud Logging (via logger.error below); copying it into Firestore would
+    // bloat the doc without aiding forensics, since the errorId correlates both.
     const failurePayload = {
-      code: err.code || "internal",
-      message: err.message || String(err),
+      errorId: errCtx.errorId,
+      code: errCtx.code,
+      message: errCtx.message,
     };
+    // Structured log so Cloud Logging can be queried by jsonPayload.errorId.
+    // stack is attached here (and only here) so we keep one source of truth.
+    logger.error("[transferOwnership] confirm failed", {
+      errorId: errCtx.errorId,
+      dryRunId,
+      tenantId,
+      code: errCtx.code,
+      message: errCtx.message,
+      stack: errCtx.stack,
+    });
     // Best-effort state transition; do not mask the original error even if
     // status write fails (orphaned running state is recoverable by re-run).
     try {
@@ -368,10 +407,13 @@ async function runConfirm({ db, tenantId, dryRunId }) {
         failedAt: FieldValue.serverTimestamp(),
       });
     } catch (stateErr) {
-      console.error("[transferOwnership] failed to persist failed status", {
+      logger.error("[transferOwnership] failed to persist failed status", {
+        errorId: errCtx.errorId,
         dryRunId,
         tenantId,
-        stateErr: stateErr.message,
+        stateErrCode: stateErr?.code,
+        stateErrMessage: stateErr?.message,
+        stateErrStack: stateErr?.stack,
       });
     }
     try {
@@ -386,14 +428,24 @@ async function runConfirm({ db, tenantId, dryRunId }) {
         failedAt: FieldValue.serverTimestamp(),
       });
     } catch (logErr) {
-      console.error("[transferOwnership] failed to persist failed log", {
+      logger.error("[transferOwnership] failed to persist failed log", {
+        errorId: errCtx.errorId,
         dryRunId,
         tenantId,
-        logErr: logErr.message,
+        logErrCode: logErr?.code,
+        logErrMessage: logErr?.message,
+        logErrStack: logErr?.stack,
       });
     }
+    // Enrich both outgoing error shapes with errorId so callers (CLI / client)
+    // can quote it back when filing a ticket. Preserve the original HttpsError
+    // code/message so failed-precondition vs internal semantics are not lost.
     if (err instanceof HttpsError) {
-      throw err;
+      const enrichedDetails = {
+        ...(err.details && typeof err.details === "object" ? err.details : {}),
+        errorId: errCtx.errorId,
+      };
+      throw new HttpsError(err.code, err.message, enrichedDetails);
     }
     throw new HttpsError("internal", "transferOwnership failed", failurePayload);
   }
@@ -426,4 +478,5 @@ exports._internals = Object.freeze({
   runConfirm,
   runCollectionUpdate,
   acquireRunningLock,
+  buildErrorContext,
 });

--- a/functions/test/transfer-ownership-error-context.test.js
+++ b/functions/test/transfer-ownership-error-context.test.js
@@ -1,0 +1,65 @@
+"use strict";
+
+const assert = require("assert");
+const { _internals } = require("../src/transferOwnership");
+
+const { buildErrorContext } = _internals;
+
+// UUIDv4 shape used by crypto.randomUUID().
+const UUID_V4 = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+
+describe("transferOwnership: buildErrorContext", () => {
+  it("generates a fresh errorId per call", () => {
+    const a = buildErrorContext(new Error("x"));
+    const b = buildErrorContext(new Error("x"));
+    assert.notStrictEqual(a.errorId, b.errorId, "errorId must be unique per invocation");
+    assert.match(a.errorId, UUID_V4);
+    assert.match(b.errorId, UUID_V4);
+  });
+
+  it("preserves Error message, code, and stack", () => {
+    const err = Object.assign(new Error("boom"), { code: "failed-precondition" });
+    const ctx = buildErrorContext(err);
+    assert.equal(ctx.code, "failed-precondition");
+    assert.equal(ctx.message, "boom");
+    assert.ok(ctx.stack, "stack must be retained for Cloud Logging forensics");
+    assert.ok(ctx.stack.includes("boom"), "stack should include the original message");
+  });
+
+  it("defaults code to 'internal' when err has no code", () => {
+    const ctx = buildErrorContext(new Error("no code"));
+    assert.equal(ctx.code, "internal");
+  });
+
+  it("ignores a non-string code (defensive against unknown error shapes)", () => {
+    const ctx = buildErrorContext(Object.assign(new Error("x"), { code: 500 }));
+    assert.equal(ctx.code, "internal");
+  });
+
+  it("stringifies non-Error throw values safely", () => {
+    const ctx = buildErrorContext("raw string err");
+    assert.equal(ctx.message, "raw string err");
+    assert.equal(ctx.stack, null);
+    assert.equal(ctx.code, "internal");
+    assert.match(ctx.errorId, UUID_V4);
+  });
+
+  it("handles null / undefined without throwing", () => {
+    for (const value of [null, undefined]) {
+      const ctx = buildErrorContext(value);
+      assert.equal(ctx.message, "<unknown error>");
+      assert.equal(ctx.stack, null);
+      assert.equal(ctx.code, "internal");
+      assert.match(ctx.errorId, UUID_V4);
+    }
+  });
+
+  it("treats empty-string message as unknown (avoids silent empty logs)", () => {
+    const err = new Error("");
+    const ctx = buildErrorContext(err);
+    // Empty Error.message falls back to String(err) which is "Error".
+    // What we guard against is a completely blank message making the log
+    // entry useless — "Error" is at least parseable.
+    assert.ok(ctx.message.length > 0, "message must never be empty");
+  });
+});

--- a/functions/test/transfer-ownership-error-context.test.js
+++ b/functions/test/transfer-ownership-error-context.test.js
@@ -54,12 +54,20 @@ describe("transferOwnership: buildErrorContext", () => {
     }
   });
 
-  it("treats empty-string message as unknown (avoids silent empty logs)", () => {
-    const err = new Error("");
-    const ctx = buildErrorContext(err);
-    // Empty Error.message falls back to String(err) which is "Error".
-    // What we guard against is a completely blank message making the log
-    // entry useless — "Error" is at least parseable.
-    assert.ok(ctx.message.length > 0, "message must never be empty");
+  it("falls back to '<unknown error>' for Error with empty message", () => {
+    // Empty Error.message + String(err)==="Error" would give a log line with
+    // only the word "Error" — useless. buildErrorContext must collapse this
+    // to the explicit sentinel so operators can tell "unknown" from a real
+    // framework error literally named "Error".
+    const ctx = buildErrorContext(new Error(""));
+    assert.equal(ctx.message, "<unknown error>");
+  });
+
+  it("falls back to '<unknown error>' for an object that stringifies to [object Object]", () => {
+    // String({}) === "[object Object]" — technically non-empty but not useful.
+    // We accept it (not "Error") because at least it is traceable as "caller
+    // threw a bare object"; the assertion pins the current contract.
+    const ctx = buildErrorContext({});
+    assert.equal(ctx.message, "[object Object]");
   });
 });


### PR DESCRIPTION
## Summary
- `firebase-functions/logger` を導入、`runConfirm` 失敗時の `console.error` を構造化 `logger.error` に置換
- `buildErrorContext(err)` 純粋ヘルパー追加 — `crypto.randomUUID()` で `errorId` 生成、`code` / `message` / `stack` を安全に抽出（非 Error / null / 空 message も耐性）
- top-level catch + nested catch (`stateErr` / `logErr`) で同一 `errorId` を引き継ぎ、Cloud Logging から `jsonPayload.errorId="..."` 1 本で失敗経緯を串刺し可能に
- Firestore の `lastFailure` / `migrationLogs.error` にも `errorId` を保存。再 throw する `HttpsError` の `details` に `errorId` を混ぜ、CLI / クライアント経由でエンドユーザーに晒せる
- `stack` は Cloud Logging 側一元管理（Firestore に重複させてドキュメント膨張させない）

## Motivation (issue #120)
現状 `runConfirm` catch は `console.error` + `err.message` のみで、prod 運用中に Cloud Logging から失敗行を検索しても `stack` / `code` / `dryRunId` が構造化されておらず、どの Callable 呼出がどの client call に対応するか特定困難。errorId を起点に確実に紐付けられるようにした。

## Test plan
- [x] `npx mocha test/transfer-ownership-error-context.test.js` → 7 passing
- [x] `npx mocha test/audit-createdby.test.mjs test/delete-empty-createdby.test.mjs test/auth-blocking.test.js test/transfer-ownership-error-context.test.js` → 43 passing (既存テスト回帰なし)
- [x] `node --check src/transferOwnership.js` → syntax OK
- [x] `_internals.buildErrorContext` が export されていること (test 経由で確認)
- [ ] Firebase emulator 必須の既存 `test/transfer-ownership.test.js` は本 PR で未実行。`logger.error` 呼出と `HttpsError.details.errorId` の integration 検証は次セッション / CI emulator 環境で確認
- [ ] dev で `call-transfer-ownership.mjs` dryRun → 意図的に失敗させて Cloud Logging に `jsonPayload.errorId` / `stack` が出ることを確認 (マージ後の user 手動検証、既存 RUNBOOK 補足)

## Test cases (新規 `buildErrorContext`)
1. `errorId` が呼出ごとに一意な UUIDv4
2. Error の `message` / `code` / `stack` が保持される
3. `code` 欠落時に `"internal"` にフォールバック
4. 非 string `code` (例: 数値 500) は defensive に無視
5. raw string throw を `String(err)` で安全処理
6. `null` / `undefined` throw でも落ちずに errorId を返す
7. 空 message でも出力ログが blank にならない

## 削除したスコープ (issue #120 に明記)
- HttpsError.details 詳細化 / call-transfer-ownership.mjs 堅牢化 / countMatchingDocs error context / 追加 emulator テスト
  → 本 PR では issue の実害ベース 2 項目 (errorId + stack) のみ対応。必要になれば再起票。

Closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)