### PR TITLE
test(outbox): upload 失敗時に createRecording が呼ばれないこと検証 (Closes #145)

### DIFF
--- a/CareNoteTests/OutboxSyncServiceTests.swift
+++ b/CareNoteTests/OutboxSyncServiceTests.swift
@@ -17,13 +17,21 @@ private actor StubAccessTokenProvider: AccessTokenProviding {
 private actor StubAudioUploader: AudioUploading {
     private(set) var uploadCalls: [(localURL: URL, tenantId: String, recordingId: String)] = []
     var gcsUriToReturn: String = "gs://test-bucket/default.m4a"
+    var errorToThrow: Error?
 
     func uploadAudio(localURL: URL, tenantId: String, recordingId: String) async throws -> String {
         uploadCalls.append((localURL, tenantId, recordingId))
+        if let err = errorToThrow { throw err }
         return gcsUriToReturn
     }
 
     func setGcsUri(_ uri: String) { gcsUriToReturn = uri }
+    func setError(_ error: Error) { errorToThrow = error }
+}
+
+/// 汎用テスト用エラー（stub injection 用）。
+private struct TestInjectedError: Error, Equatable {
+    let label: String
 }
 
 /// 呼び出し履歴を記録する RecordingStoring stub。
@@ -435,6 +443,55 @@ struct OutboxSyncServiceTests {
         let createCalls = await stubStore.createCalls
         #expect(uploadCalls.isEmpty, "uid=='' 時も pre-flight check で throw され uploadAudio は呼ばれない")
         #expect(createCalls.isEmpty)
+    }
+
+    /// 回帰防止 (#145): Step 1 (uploadAudio) が throw した場合、
+    /// createRecording / transcribe は呼ばれない。
+    /// 将来「Firestore doc 先行作成 → URI 後埋め」構造への変更で Storage 失敗時に
+    /// orphan Firestore doc が残る regression を早期に検知する。
+    @Test @MainActor
+    func processQueueImmediately_upload失敗時_createRecordingが呼ばれない_145() async throws {
+        let (container, audioPath) = try Self.setupContainerWithAudioFile()
+        defer { try? FileManager.default.removeItem(atPath: audioPath) }
+
+        let stubUploader = StubAudioUploader()
+        await stubUploader.setError(TestInjectedError(label: "upload-failed"))
+        let stubStore = StubRecordingStore()
+        let stubTranscriber = StubTranscriber()
+
+        let service = OutboxSyncService(
+            modelContainer: container,
+            storageService: stubUploader,
+            firestoreService: stubStore,
+            transcriptionService: stubTranscriber,
+            tenantId: "test-tenant",
+            currentUidProvider: { "test-uid-upload-failed" }
+        )
+
+        let recordingId = UUID()
+        let context = container.mainContext
+        context.insert(RecordingRecord(
+            id: recordingId,
+            clientId: "client-1",
+            clientName: "テスト利用者",
+            scene: RecordingScene.visit.rawValue,
+            localAudioPath: audioPath
+        ))
+        context.insert(OutboxItem(recordingId: recordingId))
+        try context.save()
+
+        // OutboxSyncService は原因 error を `OutboxSyncError.uploadFailed(_)` で wrap して throw する。
+        await #expect(throws: OutboxSyncError.self) {
+            try await service.processQueueImmediately()
+        }
+
+        let uploadCalls = await stubUploader.uploadCalls
+        let createCalls = await stubStore.createCalls
+        let transcribeCalls = await stubTranscriber.transcribeCalls
+
+        #expect(uploadCalls.count == 1, "upload は試行される（pre-flight を通過した後 Step 1 で throw）")
+        #expect(createCalls.isEmpty, "upload 失敗時に Firestore doc が先行作成されないこと (orphan 防止)")
+        #expect(transcribeCalls.isEmpty, "upload 失敗時は後続 Step の transcribe も実行されないこと")
     }
 
     // MARK: - Helpers for processItem 主経路テスト


### PR DESCRIPTION
## Summary
- PR #144 pr-test-analyzer レビューで挙がった rating 7 の I-1 のみ実装（他 I-2/I-3/I-4 は過剰起票整理で scope 縮小、#145 で明示）
- `OutboxSyncService.processQueueImmediately` の Step 1 (uploadAudio) が throw した場合、後続の `createRecording` / `transcribe` が呼ばれないことを明示的に検証
- Regression gate: 将来「Firestore doc 先行作成 → URI 後埋め」構造への変更時に Storage 失敗で orphan Firestore doc が残る変更を事前に捕捉

## Changes
- `StubAudioUploader` に `errorToThrow` / `setError(_:)` を追加（既存 stub の最小拡張）
- 新規テスト `processQueueImmediately_upload失敗時_createRecordingが呼ばれない_145()` を追加
- `OutboxSyncError.uploadFailed(_)` ラップ前提で `#expect(throws: OutboxSyncError.self)` は型レベルで検証

## Test plan
- [x] `xcodebuild -only-testing:CareNoteTests/OutboxSyncServiceTests test` で 11 tests (新規1含む) PASS を確認
- [x] 新規テスト単体で、uploadCalls.count==1 / createCalls.isEmpty / transcribeCalls.isEmpty の3条件を assertion で検証

## Related
- Closes #145
- 参考: PR #144 (Issue #107 / I-Cdx-3)
- 方針: Codex セカンドオピニオン (2026-04-21) に従い rating 7 のみ Issue 化、rating 5-6 は scope 外

## 注記
- Issue #141（全体テスト実行時クラッシュ）の影響により `-only-testing` での個別実行で検証。全体テスト実行は Issue #141 の根本解決待ち
- CLAUDE.md の「Partial Update テストで更新対象外フィールド保持」規範に直接該当しないため該当チェックなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)