### PR TITLE
fix(ci): retry iOS simulator runtime install to reduce flaky failures (Closes #159)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,6 +48,7 @@ jobs:
           MAX_ATTEMPTS: '3'
           RETRY_INTERVAL: '30'
         run: |
+          set -euo pipefail
           attempt=1
           while [ "$attempt" -le "$MAX_ATTEMPTS" ]; do
             echo "Attempt $attempt of $MAX_ATTEMPTS: xcodebuild -downloadPlatform iOS"
@@ -61,16 +62,7 @@ jobs:
             fi
             attempt=$((attempt + 1))
           done
-          if xcrun simctl list runtimes --json | python3 -c "
-          import json, sys
-          d = json.load(sys.stdin)
-          ok = any('iOS' in r.get('identifier', '') and r.get('isAvailable') for r in d.get('runtimes', []))
-          sys.exit(0 if ok else 1)
-          "; then
-            echo "::warning::Download failed after $MAX_ATTEMPTS attempts, but iOS simulator runtime is already available - continuing"
-            exit 0
-          fi
-          echo "::error::Failed to install iOS simulator runtime after $MAX_ATTEMPTS attempts and no fallback runtime available"
+          echo "::error::Failed to install iOS simulator runtime after $MAX_ATTEMPTS attempts"
           exit 1
 
       - name: Install XcodeGen

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,34 @@ jobs:
           xcode-version: '16.3'
 
       - name: Install iOS Simulator Runtime
-        run: xcodebuild -downloadPlatform iOS
+        env:
+          MAX_ATTEMPTS: '3'
+          RETRY_INTERVAL: '30'
+        run: |
+          attempt=1
+          while [ "$attempt" -le "$MAX_ATTEMPTS" ]; do
+            echo "Attempt $attempt of $MAX_ATTEMPTS: xcodebuild -downloadPlatform iOS"
+            if xcodebuild -downloadPlatform iOS; then
+              echo "Simulator runtime installed successfully"
+              exit 0
+            fi
+            if [ "$attempt" -lt "$MAX_ATTEMPTS" ]; then
+              echo "Attempt $attempt failed, retrying in ${RETRY_INTERVAL}s..."
+              sleep "$RETRY_INTERVAL"
+            fi
+            attempt=$((attempt + 1))
+          done
+          if xcrun simctl list runtimes --json | python3 -c "
+          import json, sys
+          d = json.load(sys.stdin)
+          ok = any('iOS' in r.get('identifier', '') and r.get('isAvailable') for r in d.get('runtimes', []))
+          sys.exit(0 if ok else 1)
+          "; then
+            echo "::warning::Download failed after $MAX_ATTEMPTS attempts, but iOS simulator runtime is already available - continuing"
+            exit 0
+          fi
+          echo "::error::Failed to install iOS simulator runtime after $MAX_ATTEMPTS attempts and no fallback runtime available"
+          exit 1
 
       - name: Install XcodeGen
         run: brew install xcodegen


### PR DESCRIPTION
## Summary
- `xcodebuild -downloadPlatform iOS` が main push 時に intermittently 失敗し、iOS Tests ワークフローが 3 連続失敗していた問題への対応 (Issue #159)
- 最大 3 回リトライ (30s 間隔) を追加
- `MAX_ATTEMPTS` / `RETRY_INTERVAL` は `env:` 経由で注入 (workflow injection 対策)
- `set -euo pipefail` で厳格エラーハンドリング

## 変更内容
- `.github/workflows/test.yml` のみ、コード変更なし (+20/-1)

## 背景
Issue #159 の通り、以下の 3 run が main push で全て "Install iOS Simulator Runtime" step 失敗:
| Run ID | Commit | 結果 |
|---|---|---|
| 24760085320 | 506f4e8 (#158) | ❌ 41s |
| 24758496043 | 5adfa2e (#156) | ❌ 39s |
| 24754398062 | (#153) | ❌ 38s |

PR 側の同じ job は pass することが多く、intermittent flaky と判断。

## Review 反映 (5cf7307)
初版にあった「既存 iOS runtime が利用可能なら warning で継続」の fallback path を削除:
- 理由: `'iOS' in identifier` は substring match で古い iOS 16 runtime でも通過 → 後続 Boot Simulator (line 86-103) が `iPhone 16 Pro` を見つけられず silent skip → 分かりにくいエラーになるリスク
- #159 の根本症状は download flake なので、fallback は scope 外。retry のみに集中

## Test plan
- [ ] このPR自体では iOS Tests workflow は **起動しない** (`paths-ignore` に `.github/**` 含まれるため)
  - 検証方法: マージ後の次の substantive PR / main push で確認
- [ ] マージ後の main push 時 workflow が pass する (main CI green 復帰確認)
- [ ] `xcodebuild -downloadPlatform iOS` が 1 回目で成功した場合は追加時間が発生しないこと (既存挙動維持)
- [x] YAML 構文検証: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/test.yml'))"` が通ること (ローカルで確認済)

## Notes
- Issue #159 の修正候補リストのうち「retry 追加」を採用。`actions/cache` 案は別途検討対象 (今回は最小変更を優先)
- `set -e` でリトライ loop が壊れない理由: `if xcodebuild ...; then` の if 条件節内は `-e` が一時無効化されるため、失敗時も次の iteration に進める

🤖 Generated with [Claude Code](https://claude.com/claude-code)