### PR TITLE
fix(tests): unify CareNoteTests on shared ModelContainer (#141)

### DIFF
--- a/CareNoteTests/ClientCacheServiceTests.swift
+++ b/CareNoteTests/ClientCacheServiceTests.swift
@@ -36,7 +36,7 @@ struct ClientCacheServiceTests {
 
     @Test @MainActor
     func キャッシュ空の場合needsRefreshはtrue() throws {
-        let container = try makeClientOnlyTestModelContainer()
+        let container = try makeTestModelContainer()
         let manager = MockClientManager()
         let service = ClientCacheService(clientManager: manager, modelContainer: container)
 
@@ -45,7 +45,7 @@ struct ClientCacheServiceTests {
 
     @Test @MainActor
     func キャッシュ新鮮な場合needsRefreshはfalse() async throws {
-        let container = try makeClientOnlyTestModelContainer()
+        let container = try makeTestModelContainer()
         let manager = MockClientManager()
         await manager.setClients([
             FirestoreClient(id: "c1", name: "山田太郎", furigana: "やまだたろう"),
@@ -59,7 +59,7 @@ struct ClientCacheServiceTests {
 
     @Test @MainActor
     func forceRefreshでFirestoreデータがキャッシュされる() async throws {
-        let container = try makeClientOnlyTestModelContainer()
+        let container = try makeTestModelContainer()
         let manager = MockClientManager()
         await manager.setClients([
             FirestoreClient(id: "c1", name: "山田太郎", furigana: "やまだたろう"),
@@ -75,7 +75,7 @@ struct ClientCacheServiceTests {
 
     @Test @MainActor
     func getCachedClientsはふりがな順にソートされる() async throws {
-        let container = try makeClientOnlyTestModelContainer()
+        let container = try makeTestModelContainer()
         let manager = MockClientManager()
         await manager.setClients([
             FirestoreClient(id: "c1", name: "山田太郎", furigana: "やまだたろう"),
@@ -93,7 +93,7 @@ struct ClientCacheServiceTests {
 
     @Test @MainActor
     func forceRefreshで既存キャッシュが置き換わる() async throws {
-        let container = try makeClientOnlyTestModelContainer()
+        let container = try makeTestModelContainer()
         let manager = MockClientManager()
 
         await manager.setClients([
@@ -116,7 +116,7 @@ struct ClientCacheServiceTests {
 
     @Test @MainActor
     func Firestoreエラー時にrefreshFailedエラー() async throws {
-        let container = try makeClientOnlyTestModelContainer()
+        let container = try makeTestModelContainer()
         let manager = MockClientManager()
         await manager.setError(NSError(domain: "Test", code: 1))
 
@@ -129,7 +129,7 @@ struct ClientCacheServiceTests {
 
     @Test @MainActor
     func refreshIfNeededはキャッシュ新鮮時にスキップ() async throws {
-        let container = try makeClientOnlyTestModelContainer()
+        let container = try makeTestModelContainer()
         let manager = MockClientManager()
         await manager.setClients([
             FirestoreClient(id: "c1", name: "テスト", furigana: "てすと"),

--- a/CareNoteTests/ClientRepositoryTests.swift
+++ b/CareNoteTests/ClientRepositoryTests.swift
@@ -10,7 +10,7 @@ struct ClientRepositoryTests {
 
     @MainActor
     private func makeRepository() throws -> (ClientRepository, ModelContainer) {
-        let container = try makeClientOnlyTestModelContainer()
+        let container = try makeTestModelContainer()
         let repo = ClientRepository(modelContext: container.mainContext)
         return (repo, container)
     }

--- a/CareNoteTests/ClientSelectViewModelTests.swift
+++ b/CareNoteTests/ClientSelectViewModelTests.swift
@@ -7,13 +7,13 @@ import Testing
 // These tests verify search/filter logic only.
 // SwiftData integration is tested in ClientRepositoryTests.
 
-@Suite("ClientSelectViewModel Tests")
+@Suite("ClientSelectViewModel Tests", .serialized)
 struct ClientSelectViewModelTests {
 
     /// Create a ViewModel with pre-loaded clients (no SwiftData dependency).
     @MainActor
     private func makeViewModel(clients: [ClientCache] = []) -> ClientSelectViewModel {
-        let container = try! makeClientOnlyTestModelContainer()
+        let container = try! makeTestModelContainer()
         let repo = ClientRepository(modelContext: container.mainContext)
         let vm = ClientSelectViewModel(clientRepository: repo)
         vm.clients = clients
@@ -29,7 +29,7 @@ struct ClientSelectViewModelTests {
 
     @Test @MainActor
     func loadClientsでクライアント一覧が読み込まれる() async throws {
-        let container = try makeClientOnlyTestModelContainer()
+        let container = try makeTestModelContainer()
         let repo = ClientRepository(modelContext: container.mainContext)
         let vm = ClientSelectViewModel(clientRepository: repo)
 

--- a/CareNoteTests/OutboxSyncServiceTests.swift
+++ b/CareNoteTests/OutboxSyncServiceTests.swift
@@ -66,9 +66,14 @@ private actor StubTranscriber: Transcribing {
     }
 }
 
-@Suite("OutboxSyncService incrementRetryCount Tests")
+@Suite("OutboxSyncService incrementRetryCount Tests", .serialized)
 struct OutboxSyncServiceTests {
 
+    // OutboxSyncService は DI された modelContainer から独自に ModelContext を
+    // 派生させて処理するため、共有 container では mainContext の save が service
+    // 側 context に反映されない場合がある。Issue #141 root-cause fix の対象外と
+    // し、per-suite で独立 container を生成する。
+    @MainActor
     private static func makeContainer() throws -> ModelContainer {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent("swiftdata-test-\(UUID().uuidString).sqlite")
@@ -502,8 +507,9 @@ struct OutboxSyncServiceTests {
     ///   `FileManager.default.fileExists(atPath:)` ガード（stale item 除外）を
     ///   通過させるために必要。呼出側は `defer { try? FileManager.default.removeItem(atPath:) }`
     ///   でクリーンアップする。
+    @MainActor
     private static func setupContainerWithAudioFile() throws -> (ModelContainer, String) {
-        let container = try makeContainer()
+        let container = try Self.makeContainer()
         let audioPath = FileManager.default.temporaryDirectory
             .appendingPathComponent("test-audio-\(UUID().uuidString).m4a").path
         try Data().write(to: URL(fileURLWithPath: audioPath))

--- a/CareNoteTests/OutboxSyncServiceTests.swift
+++ b/CareNoteTests/OutboxSyncServiceTests.swift
@@ -69,10 +69,13 @@ private actor StubTranscriber: Transcribing {
 @Suite("OutboxSyncService incrementRetryCount Tests", .serialized)
 struct OutboxSyncServiceTests {
 
-    // OutboxSyncService は DI された modelContainer から独自に ModelContext を
-    // 派生させて処理するため、共有 container では mainContext の save が service
-    // 側 context に反映されない場合がある。Issue #141 root-cause fix の対象外と
-    // し、per-suite で独立 container を生成する。
+    // Shared container (SharedTestModelContainer) を使うと本 suite の
+    // processQueueImmediately 系 2 test が uploadCalls.count == 0 で回帰する。
+    // OutboxSyncService は modelContainer.mainContext をそのまま使っているため
+    // 当初仮説（独自 ModelContext 派生）は誤り。真因は未確定（候補: cleanup
+    // timing と async hop の race、cross-suite state pollution 等）。
+    // Issue #164 で真因調査し shared container へ合流させるまでは per-suite
+    // container を維持する。
     @MainActor
     private static func makeContainer() throws -> ModelContainer {
         let url = FileManager.default.temporaryDirectory

--- a/CareNoteTests/RecordingConfirmViewModelTests.swift
+++ b/CareNoteTests/RecordingConfirmViewModelTests.swift
@@ -3,23 +3,13 @@ import Foundation
 import SwiftData
 import Testing
 
-@Suite("RecordingConfirmViewModel Tests")
+@Suite("RecordingConfirmViewModel Tests", .serialized)
 struct RecordingConfirmViewModelTests {
-
-    private static func makeContainer() throws -> ModelContainer {
-        let url = FileManager.default.temporaryDirectory
-            .appendingPathComponent("swiftdata-test-\(UUID().uuidString).sqlite")
-        let config = ModelConfiguration(url: url)
-        return try ModelContainer(
-            for: RecordingRecord.self, OutboxItem.self, ClientCache.self, OutputTemplate.self,
-            configurations: config
-        )
-    }
 
     // tenantId を空にしてFirestore呼び出しをスキップ（テスト環境ではFirebaseApp未初期化）
     @Test @MainActor
     func loadTemplatesでプリセットが自動seedされる() async throws {
-        let container = try Self.makeContainer()
+        let container = try makeTestModelContainer()
         let context = container.mainContext
 
         let vm = RecordingConfirmViewModel(
@@ -41,7 +31,7 @@ struct RecordingConfirmViewModelTests {
 
     @Test @MainActor
     func loadTemplatesで既存テンプレートがある場合は再seedしない() async throws {
-        let container = try Self.makeContainer()
+        let container = try makeTestModelContainer()
         let context = container.mainContext
 
         PresetTemplates.seedIfNeeded(modelContext: context)
@@ -64,7 +54,7 @@ struct RecordingConfirmViewModelTests {
 
     @Test @MainActor
     func loadTemplatesでプリセットが先頭にソートされる() async throws {
-        let container = try Self.makeContainer()
+        let container = try makeTestModelContainer()
         let context = container.mainContext
 
         let custom = OutputTemplate(
@@ -94,7 +84,7 @@ struct RecordingConfirmViewModelTests {
 
     @Test @MainActor
     func デフォルト選択は最初のプリセット() async throws {
-        let container = try Self.makeContainer()
+        let container = try makeTestModelContainer()
         let context = container.mainContext
 
         let vm = RecordingConfirmViewModel(
@@ -114,7 +104,7 @@ struct RecordingConfirmViewModelTests {
 
     @Test @MainActor
     func テナントテンプレート取得失敗時にerrorMessageが設定されプリセットは残る() async throws {
-        let container = try Self.makeContainer()
+        let container = try makeTestModelContainer()
         let context = container.mainContext
         let mock = MockTemplateService()
         mock.fetchError = NSError(domain: "test", code: 1)

--- a/CareNoteTests/RecordingListViewModelTests.swift
+++ b/CareNoteTests/RecordingListViewModelTests.swift
@@ -3,18 +3,8 @@ import Foundation
 import SwiftData
 import Testing
 
-@Suite("RecordingListViewModel Tests")
+@Suite("RecordingListViewModel Tests", .serialized)
 struct RecordingListViewModelTests {
-
-    private static func makeContainer() throws -> ModelContainer {
-        let url = FileManager.default.temporaryDirectory
-            .appendingPathComponent("swiftdata-test-\(UUID().uuidString).sqlite")
-        let config = ModelConfiguration(url: url)
-        return try ModelContainer(
-            for: RecordingRecord.self, OutboxItem.self, ClientCache.self,
-            configurations: config
-        )
-    }
 
     private static func makeErrorRecording(id: UUID = UUID(), context: ModelContext) -> RecordingRecord {
         let recording = RecordingRecord(
@@ -35,7 +25,7 @@ struct RecordingListViewModelTests {
 
     @Test @MainActor
     func retryRecordingでステータスがpendingにリセットされる() async throws {
-        let container = try Self.makeContainer()
+        let container = try makeTestModelContainer()
         let context = container.mainContext
         let repo = RecordingRepository(modelContext: context)
         let vm = RecordingListViewModel(recordingRepository: repo)
@@ -70,7 +60,7 @@ struct RecordingListViewModelTests {
 
     @Test @MainActor
     func saveTranscriptionでテキストがSwiftDataに保存される() async throws {
-        let container = try Self.makeContainer()
+        let container = try makeTestModelContainer()
         let context = container.mainContext
         let repo = RecordingRepository(modelContext: context)
         let vm = RecordingListViewModel(recordingRepository: repo)
@@ -98,7 +88,7 @@ struct RecordingListViewModelTests {
 
     @Test @MainActor
     func deleteRecordingでリストから除外される() async throws {
-        let container = try Self.makeContainer()
+        let container = try makeTestModelContainer()
         let context = container.mainContext
         let repo = RecordingRepository(modelContext: context)
         let vm = RecordingListViewModel(recordingRepository: repo)

--- a/CareNoteTests/RecordingRepositoryTests.swift
+++ b/CareNoteTests/RecordingRepositoryTests.swift
@@ -3,19 +3,8 @@ import Foundation
 import SwiftData
 import Testing
 
-@Suite("RecordingRepository Tests")
+@Suite("RecordingRepository Tests", .serialized)
 struct RecordingRepositoryTests {
-
-    /// インメモリ ModelContainer を作成するヘルパー
-    private static func makeContainer() throws -> ModelContainer {
-        let url = FileManager.default.temporaryDirectory
-            .appendingPathComponent("swiftdata-test-\(UUID().uuidString).sqlite")
-        let config = ModelConfiguration(url: url)
-        return try ModelContainer(
-            for: RecordingRecord.self, OutboxItem.self, ClientCache.self,
-            configurations: config
-        )
-    }
 
     /// テスト用 RecordingRecord を作成するヘルパー
     private static func makeRecording(id: UUID = UUID()) -> RecordingRecord {
@@ -34,7 +23,7 @@ struct RecordingRepositoryTests {
 
     @Test @MainActor
     func resetOutboxItemで既存OutboxItemが削除され新規作成される() throws {
-        let container = try Self.makeContainer()
+        let container = try makeTestModelContainer()
         let context = container.mainContext
         let repo = RecordingRepository(modelContext: context)
 
@@ -61,7 +50,7 @@ struct RecordingRepositoryTests {
 
     @Test @MainActor
     func resetOutboxItemでOutboxItemが存在しなくても新規作成される() throws {
-        let container = try Self.makeContainer()
+        let container = try makeTestModelContainer()
         let context = container.mainContext
         let repo = RecordingRepository(modelContext: context)
 
@@ -85,7 +74,7 @@ struct RecordingRepositoryTests {
 
     @Test @MainActor
     func deleteで関連OutboxItemも削除される() throws {
-        let container = try Self.makeContainer()
+        let container = try makeTestModelContainer()
         let context = container.mainContext
         let repo = RecordingRepository(modelContext: context)
 

--- a/CareNoteTests/TemplateCreateViewModelTests.swift
+++ b/CareNoteTests/TemplateCreateViewModelTests.swift
@@ -5,24 +5,14 @@ import Testing
 
 // MARK: - TemplateCreateViewModelTests
 
-@Suite("TemplateCreateViewModel Tests")
+@Suite("TemplateCreateViewModel Tests", .serialized)
 struct TemplateCreateViewModelTests {
-
-    private static func makeContainer() throws -> ModelContainer {
-        let url = FileManager.default.temporaryDirectory
-            .appendingPathComponent("swiftdata-test-\(UUID().uuidString).sqlite")
-        let config = ModelConfiguration(url: url)
-        return try ModelContainer(
-            for: RecordingRecord.self, OutboxItem.self, ClientCache.self, OutputTemplate.self,
-            configurations: config
-        )
-    }
 
     // MARK: - Validation
 
     @Test @MainActor
     func 空の名前ではisValidがfalse() throws {
-        let container = try Self.makeContainer()
+        let container = try makeTestModelContainer()
         let vm = TemplateCreateViewModel(
             modelContext: container.mainContext,
             firestoreService: MockTemplateService()
@@ -34,7 +24,7 @@ struct TemplateCreateViewModelTests {
 
     @Test @MainActor
     func 空のプロンプトではisValidがfalse() throws {
-        let container = try Self.makeContainer()
+        let container = try makeTestModelContainer()
         let vm = TemplateCreateViewModel(
             modelContext: container.mainContext,
             firestoreService: MockTemplateService()
@@ -46,7 +36,7 @@ struct TemplateCreateViewModelTests {
 
     @Test @MainActor
     func 空白のみの名前ではisValidがfalse() throws {
-        let container = try Self.makeContainer()
+        let container = try makeTestModelContainer()
         let vm = TemplateCreateViewModel(
             modelContext: container.mainContext,
             firestoreService: MockTemplateService()
@@ -58,7 +48,7 @@ struct TemplateCreateViewModelTests {
 
     @Test @MainActor
     func 名前とプロンプト両方あればisValidがtrue() throws {
-        let container = try Self.makeContainer()
+        let container = try makeTestModelContainer()
         let vm = TemplateCreateViewModel(
             modelContext: container.mainContext,
             firestoreService: MockTemplateService()
@@ -72,7 +62,7 @@ struct TemplateCreateViewModelTests {
 
     @Test @MainActor
     func admin権限とtenantIdがあればテナントスコープ選択可能() throws {
-        let container = try Self.makeContainer()
+        let container = try makeTestModelContainer()
         let vm = TemplateCreateViewModel(
             modelContext: container.mainContext,
             tenantId: "tenant-1",
@@ -84,7 +74,7 @@ struct TemplateCreateViewModelTests {
 
     @Test @MainActor
     func admin権限なしではテナントスコープ選択不可() throws {
-        let container = try Self.makeContainer()
+        let container = try makeTestModelContainer()
         let vm = TemplateCreateViewModel(
             modelContext: container.mainContext,
             tenantId: "tenant-1",
@@ -96,7 +86,7 @@ struct TemplateCreateViewModelTests {
 
     @Test @MainActor
     func tenantIdなしではテナントスコープ選択不可() throws {
-        let container = try Self.makeContainer()
+        let container = try makeTestModelContainer()
         let vm = TemplateCreateViewModel(
             modelContext: container.mainContext,
             tenantId: nil,
@@ -110,7 +100,7 @@ struct TemplateCreateViewModelTests {
 
     @Test @MainActor
     func 個人テンプレートの保存がSwiftDataに保存される() async throws {
-        let container = try Self.makeContainer()
+        let container = try makeTestModelContainer()
         let context = container.mainContext
         let vm = TemplateCreateViewModel(
             modelContext: context,
@@ -133,7 +123,7 @@ struct TemplateCreateViewModelTests {
 
     @Test @MainActor
     func テナントテンプレートの保存がFirestoreServiceを呼ぶ() async throws {
-        let container = try Self.makeContainer()
+        let container = try makeTestModelContainer()
         let mock = MockTemplateService()
         let vm = TemplateCreateViewModel(
             modelContext: container.mainContext,
@@ -157,7 +147,7 @@ struct TemplateCreateViewModelTests {
 
     @Test @MainActor
     func テナント保存でuserIdがnilの場合はエラー() async throws {
-        let container = try Self.makeContainer()
+        let container = try makeTestModelContainer()
         let mock = MockTemplateService()
         let vm = TemplateCreateViewModel(
             modelContext: container.mainContext,
@@ -179,7 +169,7 @@ struct TemplateCreateViewModelTests {
 
     @Test @MainActor
     func テナント保存でFirestore失敗時にerrorMessage設定() async throws {
-        let container = try Self.makeContainer()
+        let container = try makeTestModelContainer()
         let mock = MockTemplateService()
         mock.createError = NSError(domain: "test", code: 1)
         let vm = TemplateCreateViewModel(
@@ -203,7 +193,7 @@ struct TemplateCreateViewModelTests {
 
     @Test @MainActor
     func テナントテンプレートの編集でupdateが呼ばれる() async throws {
-        let container = try Self.makeContainer()
+        let container = try makeTestModelContainer()
         let mock = MockTemplateService()
         let existing = FirestoreTemplate(
             id: "tmpl-1",
@@ -237,7 +227,7 @@ struct TemplateCreateViewModelTests {
 
     @Test @MainActor
     func テナントテンプレート更新でFirestore失敗時にerrorMessage設定() async throws {
-        let container = try Self.makeContainer()
+        let container = try makeTestModelContainer()
         let mock = MockTemplateService()
         mock.updateError = NSError(domain: "test", code: 500)
         let existing = FirestoreTemplate(
@@ -266,7 +256,7 @@ struct TemplateCreateViewModelTests {
 
     @Test @MainActor
     func バリデーション失敗時にerrorMessage設定() async throws {
-        let container = try Self.makeContainer()
+        let container = try makeTestModelContainer()
         let vm = TemplateCreateViewModel(
             modelContext: container.mainContext,
             firestoreService: MockTemplateService()

--- a/CareNoteTests/TemplateListViewModelTests.swift
+++ b/CareNoteTests/TemplateListViewModelTests.swift
@@ -3,24 +3,14 @@ import Foundation
 import SwiftData
 import Testing
 
-@Suite("TemplateListViewModel Tests")
+@Suite("TemplateListViewModel Tests", .serialized)
 struct TemplateListViewModelTests {
-
-    private static func makeContainer() throws -> ModelContainer {
-        let url = FileManager.default.temporaryDirectory
-            .appendingPathComponent("swiftdata-test-\(UUID().uuidString).sqlite")
-        let config = ModelConfiguration(url: url)
-        return try ModelContainer(
-            for: RecordingRecord.self, OutboxItem.self, ClientCache.self, OutputTemplate.self,
-            configurations: config
-        )
-    }
 
     // MARK: - loadTemplates
 
     @Test @MainActor
     func loadTemplatesでSwiftDataからテンプレートを読み込む() throws {
-        let container = try Self.makeContainer()
+        let container = try makeTestModelContainer()
         let context = container.mainContext
 
         let t1 = OutputTemplate(name: "カスタム1", prompt: "p1", outputType: OutputType.custom.rawValue, isPreset: false)
@@ -40,7 +30,7 @@ struct TemplateListViewModelTests {
 
     @Test @MainActor
     func loadTemplatesでプリセットとカスタムが分類される() throws {
-        let container = try Self.makeContainer()
+        let container = try makeTestModelContainer()
         let context = container.mainContext
 
         PresetTemplates.seedIfNeeded(modelContext: context)
@@ -62,7 +52,7 @@ struct TemplateListViewModelTests {
 
     @Test @MainActor
     func tenantIdがnilの場合はテナントテンプレートをスキップ() async throws {
-        let container = try Self.makeContainer()
+        let container = try makeTestModelContainer()
         let mock = MockTemplateService()
         mock.fetchResult = [
             FirestoreTemplate(id: "1", name: "T", prompt: "P", outputType: .custom, createdBy: "u", createdByName: "U", createdAt: Date(), updatedAt: Date()),
@@ -81,7 +71,7 @@ struct TemplateListViewModelTests {
 
     @Test @MainActor
     func テナントテンプレート読み込み成功() async throws {
-        let container = try Self.makeContainer()
+        let container = try makeTestModelContainer()
         let mock = MockTemplateService()
         mock.fetchResult = [
             FirestoreTemplate(id: "1", name: "共有1", prompt: "P1", outputType: .custom, createdBy: "u1", createdByName: "User1", createdAt: Date(), updatedAt: Date()),
@@ -102,7 +92,7 @@ struct TemplateListViewModelTests {
 
     @Test @MainActor
     func テナントテンプレート読み込み失敗でerrorMessage設定() async throws {
-        let container = try Self.makeContainer()
+        let container = try makeTestModelContainer()
         let mock = MockTemplateService()
         mock.fetchError = NSError(domain: "test", code: 1)
 
@@ -122,7 +112,7 @@ struct TemplateListViewModelTests {
 
     @Test @MainActor
     func プリセットテンプレートは削除できない() throws {
-        let container = try Self.makeContainer()
+        let container = try makeTestModelContainer()
         let context = container.mainContext
 
         PresetTemplates.seedIfNeeded(modelContext: context)
@@ -141,7 +131,7 @@ struct TemplateListViewModelTests {
 
     @Test @MainActor
     func カスタムテンプレートを削除できる() throws {
-        let container = try Self.makeContainer()
+        let container = try makeTestModelContainer()
         let context = container.mainContext
 
         let custom = OutputTemplate(name: "削除対象", prompt: "p", outputType: OutputType.custom.rawValue, isPreset: false)
@@ -164,7 +154,7 @@ struct TemplateListViewModelTests {
 
     @Test @MainActor
     func admin権限ありでテナントテンプレート削除成功() async throws {
-        let container = try Self.makeContainer()
+        let container = try makeTestModelContainer()
         let mock = MockTemplateService()
         let tmpl = FirestoreTemplate(id: "tmpl-1", name: "共有", prompt: "P", outputType: .custom, createdBy: "u1", createdByName: "U1", createdAt: Date(), updatedAt: Date())
 
@@ -184,7 +174,7 @@ struct TemplateListViewModelTests {
 
     @Test @MainActor
     func admin権限なしではテナントテンプレート削除されない() async throws {
-        let container = try Self.makeContainer()
+        let container = try makeTestModelContainer()
         let mock = MockTemplateService()
         let tmpl = FirestoreTemplate(id: "tmpl-1", name: "共有", prompt: "P", outputType: .custom, createdBy: "u1", createdByName: "U1", createdAt: Date(), updatedAt: Date())
 
@@ -204,7 +194,7 @@ struct TemplateListViewModelTests {
 
     @Test @MainActor
     func テナントテンプレート削除失敗でerrorMessage設定() async throws {
-        let container = try Self.makeContainer()
+        let container = try makeTestModelContainer()
         let mock = MockTemplateService()
         mock.deleteError = NSError(domain: "test", code: 1)
         let tmpl = FirestoreTemplate(id: "tmpl-1", name: "共有", prompt: "P", outputType: .custom, createdBy: "u1", createdByName: "U1", createdAt: Date(), updatedAt: Date())

--- a/CareNoteTests/TestHelpers/SwiftDataTestHelper.swift
+++ b/CareNoteTests/TestHelpers/SwiftDataTestHelper.swift
@@ -2,28 +2,44 @@
 import Foundation
 import SwiftData
 
-/// Create a ModelContainer backed by a unique temporary file for testing.
-/// Each call creates an independent store to avoid cross-test SwiftData conflicts.
-/// NOTE: Add new `@Model` types here when introduced to the schema.
+/// Process-wide shared ModelContainer for CareNoteTests.
+///
+/// SwiftData SIGTRAPs when the same `@Model` type is registered in multiple
+/// `ModelContainer`s within one process. Per-test containers therefore cannot
+/// coexist with the host app's container (Issue #141). This shared container
+/// is created lazily once per process and reused by every test; isolation is
+/// provided by `cleanup()` which removes all records before each test.
 @MainActor
-func makeTestModelContainer() throws -> ModelContainer {
-    let url = FileManager.default.temporaryDirectory
-        .appendingPathComponent("swiftdata-test-\(UUID().uuidString).sqlite")
-    let config = ModelConfiguration(url: url)
-    return try ModelContainer(
-        for: RecordingRecord.self, OutboxItem.self, ClientCache.self, OutputTemplate.self,
-        configurations: config
-    )
+enum SharedTestModelContainer {
+    static let shared: ModelContainer = {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("swiftdata-test-shared-\(UUID().uuidString).sqlite")
+        let config = ModelConfiguration(url: url)
+        do {
+            return try ModelContainer(
+                for: RecordingRecord.self, OutboxItem.self, ClientCache.self, OutputTemplate.self,
+                configurations: config
+            )
+        } catch {
+            fatalError("Failed to create SharedTestModelContainer: \(error)")
+        }
+    }()
+
+    /// Reset to an empty store without reallocating the container itself —
+    /// reallocation would trigger the SIGTRAP this helper exists to avoid.
+    static func cleanup() throws {
+        let context = shared.mainContext
+        try context.delete(model: RecordingRecord.self)
+        try context.delete(model: OutboxItem.self)
+        try context.delete(model: ClientCache.self)
+        try context.delete(model: OutputTemplate.self)
+        try context.save()
+    }
 }
 
-/// Create a minimal ModelContainer with only ClientCache for lightweight tests.
+/// Returns the process-wide shared ModelContainer after cleaning all records.
 @MainActor
-func makeClientOnlyTestModelContainer() throws -> ModelContainer {
-    let url = FileManager.default.temporaryDirectory
-        .appendingPathComponent("swiftdata-test-\(UUID().uuidString).sqlite")
-    let config = ModelConfiguration(url: url)
-    return try ModelContainer(
-        for: ClientCache.self,
-        configurations: config
-    )
+func makeTestModelContainer() throws -> ModelContainer {
+    try SharedTestModelContainer.cleanup()
+    return SharedTestModelContainer.shared
 }


### PR DESCRIPTION
## Summary

Issue #141 の根本原因（同一プロセス内で同じ `@Model` 型を複数 `ModelContainer` に登録すると SwiftData が SIGTRAP）を解消。

- `SharedTestModelContainer` (static let) + `cleanup()` を `SwiftDataTestHelper` に導入し、9 test files を統一
- `OutboxSyncServiceTests` のみ per-suite container を維持。**shared 化で 2 test が回帰したが真因未確定**（当初の「service が独自 ModelContext を派生」仮説は grep で誤りと判明 — 全て `modelContainer.mainContext` を使用）。調査は Issue #164 で継続。
- `.serialized` を SwiftData-backed 全 suite（7 suites）に付与し、Swift Testing の parallel race を防止

### 変更ファイル（10 files / +95/-124）
- `CareNoteTests/TestHelpers/SwiftDataTestHelper.swift`: `SharedTestModelContainer` + `cleanup()` 導入、`makeClientOnlyTestModelContainer` 削除
- `CareNoteTests/{ClientRepository,ClientSelectViewModel,ClientCacheService}Tests.swift`: `makeClientOnlyTestModelContainer()` → `makeTestModelContainer()` (+`.serialized`)
- `CareNoteTests/{RecordingConfirmViewModel,RecordingListViewModel,RecordingRepository,TemplateCreateViewModel,TemplateListViewModel}Tests.swift`: per-suite makeContainer 削除 → `makeTestModelContainer()` (+`.serialized`)
- `CareNoteTests/OutboxSyncServiceTests.swift`: `.serialized` + `setupContainerWithAudioFile` に `@MainActor`（shared 非採用の理由と Issue #164 へのリンクをコメント）

### 検証プロセス

1. Acceptance Criteria の明示（impl-plan Phase 2.7）
2. `/simplify` 3 並列レビュー → reuse agent が「per-suite container 残存で SIGTRAP 再発リスク」を指摘 → 7 files を本 PR スコープに追加
3. shared container 導入後 `OutboxSyncServiceTests` 2 件が回帰 → 真因未確定のまま per-suite container に rollback（Issue #164）
4. `/review-pr` 6 並列レビュー → OutboxSync コメント factually 誤り (Critical) を検出し訂正、schema drift リスク (Critical) を Issue #165 で follow-up

## Test plan

- [x] `CareNoteTests` 全 135 tests / 18 suites PASS（localで 2 回確認、crash ゼロ）
- [x] `ClientRepositoryTests` 単独 3 連続 PASS（AC2、shared container の再入安定性）
- [x] `/review-pr` 6 エージェント並列レビュー実施 (Critical 2 件対応、Important は follow-up issue 化)
- [ ] CI (iOS Tests workflow) で green 確認

## Follow-up Issues

- #164: OutboxSyncServiceTests が SharedTestModelContainer と相性が悪く回帰する（真因未確定）
- #165: Schema drift risk: @Model 型を SharedTestModelContainer と LocalDataCleaner で hard-code している

## 参考

- [Issue #141](https://github.com/system-279/carenote-ios/issues/141)
- [handoff/LATEST.md § #141 再開時のアクションメモ](https://github.com/system-279/carenote-ios/blob/main/docs/handoff/LATEST.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #141