### PR TITLE
test(#164): shared container で OutboxSyncServiceTests を再統一（CI 再現確認）

### DIFF
--- a/CareNoteTests/OutboxSyncServiceTests.swift
+++ b/CareNoteTests/OutboxSyncServiceTests.swift
@@ -69,23 +69,11 @@ private actor StubTranscriber: Transcribing {
 @Suite("OutboxSyncService incrementRetryCount Tests", .serialized)
 struct OutboxSyncServiceTests {
 
-    // Shared container (SharedTestModelContainer) を使うと本 suite の
-    // processQueueImmediately 系 2 test が uploadCalls.count == 0 で回帰する。
-    // OutboxSyncService は modelContainer.mainContext をそのまま使っているため
-    // 当初仮説（独自 ModelContext 派生）は誤り。真因は未確定（候補: cleanup
-    // timing と async hop の race、cross-suite state pollution 等）。
-    // Issue #164 で真因調査し shared container へ合流させるまでは per-suite
-    // container を維持する。
-    @MainActor
-    private static func makeContainer() throws -> ModelContainer {
-        let url = FileManager.default.temporaryDirectory
-            .appendingPathComponent("swiftdata-test-\(UUID().uuidString).sqlite")
-        let config = ModelConfiguration(url: url)
-        return try ModelContainer(
-            for: RecordingRecord.self, OutboxItem.self, ClientCache.self, OutputTemplate.self,
-            configurations: config
-        )
-    }
+    // Issue #164 調査中: shared container (SharedTestModelContainer) に差し戻して
+    // 2 failing test (`processQueueImmediately_主経路_...`, `processQueueImmediately_uidNil...`)
+    // の再現と観測点を配置する。
+    // Codex セカンドオピニオン推奨の二分探索 (test save 直後 → service 入口 →
+    // fetch descriptor → cleanup 介入) で真因を絞り込む。
 
     private static func makeService(
         container: ModelContainer,
@@ -110,7 +98,7 @@ struct OutboxSyncServiceTests {
 
     @Test @MainActor
     func incrementRetryCountで通常時はretryCount増加のみ() async throws {
-        let container = try Self.makeContainer()
+        let container = try makeTestModelContainer()
         let context = container.mainContext
         let service = Self.makeService(container: container)
 
@@ -137,7 +125,7 @@ struct OutboxSyncServiceTests {
 
     @Test @MainActor
     func incrementRetryCountでmax超過時にステータスがerrorになる() async throws {
-        let container = try Self.makeContainer()
+        let container = try makeTestModelContainer()
         let context = container.mainContext
         let service = Self.makeService(container: container)
 
@@ -165,7 +153,7 @@ struct OutboxSyncServiceTests {
 
     @Test @MainActor
     func incrementRetryCountでtranscriptionStatusがdoneの場合は変更しない() async throws {
-        let container = try Self.makeContainer()
+        let container = try makeTestModelContainer()
         let context = container.mainContext
         let service = Self.makeService(container: container)
 
@@ -195,7 +183,7 @@ struct OutboxSyncServiceTests {
 
     @Test @MainActor
     func buildFirestoreRecordingでcurrentUidProviderが返すuidがcreatedByに入る() async throws {
-        let container = try Self.makeContainer()
+        let container = try makeTestModelContainer()
         let context = container.mainContext
         let service = Self.makeService(
             container: container,
@@ -224,7 +212,7 @@ struct OutboxSyncServiceTests {
 
     @Test @MainActor
     func buildFirestoreRecordingでuidが取れない場合はuserNotAuthenticatedエラー() async throws {
-        let container = try Self.makeContainer()
+        let container = try makeTestModelContainer()
         let context = container.mainContext
         let service = Self.makeService(
             container: container,
@@ -254,7 +242,7 @@ struct OutboxSyncServiceTests {
     func buildFirestoreRecordingでuidが空文字の場合もuserNotAuthenticatedエラー() async throws {
         // issue #99 二段防御の境界値テスト: nil と空文字を独立にカバー。
         // `currentUidProvider` が non-nil な空文字を返しても createdBy は保存されない。
-        let container = try Self.makeContainer()
+        let container = try makeTestModelContainer()
         let context = container.mainContext
         let service = Self.makeService(
             container: container,
@@ -282,7 +270,7 @@ struct OutboxSyncServiceTests {
 
     @Test @MainActor
     func buildFirestoreRecordingで更新対象外フィールドは既存値を保持する() async throws {
-        let container = try Self.makeContainer()
+        let container = try makeTestModelContainer()
         let context = container.mainContext
         let service = Self.makeService(
             container: container,
@@ -512,7 +500,7 @@ struct OutboxSyncServiceTests {
     ///   でクリーンアップする。
     @MainActor
     private static func setupContainerWithAudioFile() throws -> (ModelContainer, String) {
-        let container = try Self.makeContainer()
+        let container = try makeTestModelContainer()
         let audioPath = FileManager.default.temporaryDirectory
             .appendingPathComponent("test-audio-\(UUID().uuidString).m4a").path
         try Data().write(to: URL(fileURLWithPath: audioPath))

--- a/scripts/lint-model-container.sh
+++ b/scripts/lint-model-container.sh
@@ -35,11 +35,9 @@ cd "$ROOT"
 ALLOWED_TEST_FILES=(
   # Canonical shared container (PR #163 root-cause fix for Issue #141).
   "CareNoteTests/TestHelpers/SwiftDataTestHelper.swift"
-  # Temporarily allowed: PR #163 locally rolled back this one suite to a
-  # per-suite container because the shared container caused 2 tests to
-  # regress with uploadCalls.count == 0. Real cause still unknown — tracked
-  # in Issue #164. Remove from this list once #164 closes.
-  "CareNoteTests/OutboxSyncServiceTests.swift"
+  # NOTE (Issue #164 investigation, 2026-04-22): OutboxSyncServiceTests.swift は
+  # shared container に差し戻し済み。真因調査の観測点追加中につき暫定許可は不要。
+  # 真因特定 or workaround 適用後、必要があれば許可を復活させる。
 )
 
 # Matches `ModelContainer[<Generic>](<newline/spaces>for:` — tolerates


### PR DESCRIPTION
## Summary

- Issue #164「shared container で `processQueueImmediately_主経路_...` / `processQueueImmediately_uidNil...` の 2 test が `uploadCalls.count == 0` で回帰する」事象が **local で再現しない**ことが判明したため、CI macOS 15 runner で再現するか確認する **draft PR**
- `OutboxSyncServiceTests.swift` を `SharedTestModelContainer` に差し戻し、`ALLOWED_TEST_FILES` から除外
- Codex セカンドオピニオン（2026-04-22）の二分探索プロトコルに基づく

## 変更内容

- `CareNoteTests/OutboxSyncServiceTests.swift`: `Self.makeContainer()` → `makeTestModelContainer()` に一斉置換、per-suite `makeContainer()` 定義削除（-18 行）、`@Suite` コメント更新
- `scripts/lint-model-container.sh`: ALLOWED_TEST_FILES から `OutboxSyncServiceTests.swift` を削除

規模: 2 files / +16 / -30（Evaluator 分離対象外、`/simplify` 対象外）

## Local 検証結果

Darwin 25.3.0 + iPhone 17 Simulator:

| Run | 経過時間 | 結果 |
|-----|---------|------|
| 1 | 0.434s | 135/135 PASS |
| 2 | 0.608s | 135/135 PASS |
| 3 | 0.595s | 135/135 PASS |

観測点（test 側 `context.fetch` で save 直後可視性確認）追加/削除いずれでも PASS。

## CI 結果による判断フロー

| CI 結果 | 判断 | 次のアクション |
|--------|------|--------------|
| PASS | PR #163 以降の変更で自然解消 | Issue #164 close 検討、この PR を ready に変更してマージ |
| FAIL | CI runner 固有の race / concurrency | draft のまま深掘り調査継続（Codex 推奨の二分探索を CI 環境で実施） |

## Test plan

- [ ] CI `iOS Tests` job が success（全 135 tests PASS）
- [ ] CI `Lint - SwiftData schema drift guard (Issue #165)` job が success（1 approved file 確認）
- [ ] CI FAIL 時: 失敗 test と原因仮説を Issue #164 に記録（深掘り継続）
- [ ] CI PASS 時: Issue #164 に「再現不能を local + CI で確認」コメント追加し close 判定

## Refs

- Closes #164 (CI PASS 時のみ、draft の判断結果次第)
- Related: PR #163 (shared container 統一), PR #167 (ModelContainer drift lint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)