### PR TITLE
docs(runbook): Day 1 prod deploy 実施ログ記録（PASS）

### DIFF
--- a/docs/runbook/prod-deploy-smoke-test.md
+++ b/docs/runbook/prod-deploy-smoke-test.md
@@ -133,10 +133,36 @@ firebase deploy --only functions --project carenote-prod-279
 ### 実施ログ記入欄
 
 ```
-- 実施日時: YYYY-MM-DD HH:MM JST
-- 実施者: <GitHub handle>
-- 判定: PASS / FAIL
-- 異常時対応: （あれば）
+- 実施日時: 2026-04-23 03:51 JST (UTC 2026-04-22T18:51:04Z)
+- 実施者: system-279
+- 判定: PASS
+- 実行スコープ: Opt A（段階 deploy 原則で runtime 更新のみ分離、transferOwnership は Day 3 で別 deploy）
+- 実行コマンド:
+    CLOUDSDK_ACTIVE_CONFIG_NAME=carenote-prod \
+      firebase deploy \
+        --only functions:beforeSignIn,functions:deleteAccount \
+        --project carenote-prod-279
+- 対象関数の変更:
+  - beforeSignIn: nodejs20 → nodejs22 (runtime update のみ、コード変更なし)
+  - deleteAccount: nodejs20 → nodejs22 (runtime update のみ、コード変更なし)
+- 事前確認:
+  - dev functions 3 関数 nodejs22 ACTIVE（事前稼働中）
+  - dev 過去 48h Cloud Logging ERROR/WARNING 0 件（NOTICE 各 2 件のみ、lifecycle）
+  - iOS code CI 135 tests PASS（commit 581bf13）
+- 事後確認:
+  - firebase functions:list: beforeSignIn / deleteAccount ともに nodejs22 / ACTIVE
+  - Cloud Logging 15 分監視 (18:51:04Z→19:06:04Z): ERROR/WARNING 0 件
+  - 実機 smoke test:
+    - ① サインアウト→Google ログイン: PASS
+    - ② 新規録音: PASS
+    - ③ 文字起こし編集: PASS
+    - ④ 録音リスト表示: PASS
+- baseline 記録:
+  - エラー率: 0% (deploy 後 15 分)
+  - p95 レイテンシ: deploy 直後のため有意な計測不可（Day 2 以降で比較基準を確立）
+  - NOTICE (lifecycle): beforeSignIn / deleteAccount 各 2 件（container 起動ログ、正常）
+- 異常時対応: なし
+- 次工程: Day 2 (Phase 0.5 Rules prod deploy) に 12h 経過後に着手可
 ```
 
 ---

--- a/docs/runbook/prod-deploy-smoke-test.md
+++ b/docs/runbook/prod-deploy-smoke-test.md
@@ -146,23 +146,28 @@ firebase deploy --only functions --project carenote-prod-279
   - beforeSignIn: nodejs20 → nodejs22 (runtime update のみ、コード変更なし)
   - deleteAccount: nodejs20 → nodejs22 (runtime update のみ、コード変更なし)
 - 事前確認:
-  - dev functions 3 関数 nodejs22 ACTIVE（事前稼働中）
-  - dev 過去 48h Cloud Logging ERROR/WARNING 0 件（NOTICE 各 2 件のみ、lifecycle）
-  - iOS code CI 135 tests PASS（commit 581bf13）
+  - dev functions 3 関数 (beforeSignIn / deleteAccount / transferOwnership) 全て nodejs22 / ACTIVE（事前稼働中。prod 展開は Opt A により transferOwnership を除く 2 関数）
+  - dev 過去 48h Cloud Logging ERROR/WARNING 0 件（NOTICE 各 2 件のみ、lifecycle / dev 参考値）
+  - iOS code CI 135 tests PASS（commit 581bf13 / checklist 項目外、参考情報）
 - 事後確認:
   - firebase functions:list: beforeSignIn / deleteAccount ともに nodejs22 / ACTIVE
-  - Cloud Logging 15 分監視 (18:51:04Z→19:06:04Z): ERROR/WARNING 0 件
+  - Cloud Logging 15 分監視 (UTC 18:51:04Z→19:06:04Z / JST 03:51→04:06): ERROR/WARNING 0 件
   - 実機 smoke test:
     - ① サインアウト→Google ログイン: PASS
     - ② 新規録音: PASS
     - ③ 文字起こし編集: PASS
     - ④ 録音リスト表示: PASS
-- baseline 記録:
-  - エラー率: 0% (deploy 後 15 分)
-  - p95 レイテンシ: deploy 直後のため有意な計測不可（Day 2 以降で比較基準を確立）
-  - NOTICE (lifecycle): beforeSignIn / deleteAccount 各 2 件（container 起動ログ、正常）
+- baseline 記録（暫定 15 分値。24h ベースラインは Day 2 着手前に追記）:
+  - エラー率: 0% (deploy 後 15 分観測)
+  - p95 レイテンシ: deploy 直後のため有意な計測不可（12h 経過時点で Cloud Monitoring から取得して追記予定）
+  - prod NOTICE (lifecycle): beforeSignIn / deleteAccount 各 2 件（container 起動ログ、15 分間観測、正常）
+- 24h ベースライン（Day 2 事前確認 L174 比較基準、Day 2 着手前 = 2026-04-23 15:51 JST 以降に追記）:
+  - エラー率平均: TBD
+  - p95 レイテンシ: TBD
+  - invocation count: TBD
+  - 備考: Day 2 着手可能時刻（deploy + 12h = 2026-04-23 15:51 JST）に再観測する。Day 1 checklist L126 が要求する「24h ベースライン」のうち、12h〜24h の差分は Day 2 実施ログで補足する運用とする。
 - 異常時対応: なし
-- 次工程: Day 2 (Phase 0.5 Rules prod deploy) に 12h 経過後に着手可
+- 次工程: Day 2 (Phase 0.5 Rules prod deploy) に **2026-04-23 15:51 JST 以降（deploy 完了から 12h 経過）** 着手可
 ```
 
 ---


### PR DESCRIPTION
## Summary

- Day 1 (Node 22 runtime prod deploy) の実施ログを `docs/runbook/prod-deploy-smoke-test.md` に記録
- 結果: **PASS**

## 実施内容

- **日時**: 2026-04-23 03:51 JST (UTC 2026-04-22T18:51:04Z)
- **対象**: `beforeSignIn` / `deleteAccount` を nodejs20 → nodejs22
- **スコープ判断**: Opt A（段階 deploy 原則で runtime 更新のみ分離、`transferOwnership` は Day 3 で新規 deploy 予定）
- **コマンド**:
  ```bash
  CLOUDSDK_ACTIVE_CONFIG_NAME=carenote-prod \
    firebase deploy \
      --only functions:beforeSignIn,functions:deleteAccount \
      --project carenote-prod-279
  ```

## 事後確認（全 PASS）

| 項目 | 結果 |
|------|:---:|
| `firebase functions:list`: 両関数 nodejs22 / ACTIVE | ✅ |
| Cloud Logging 15 分監視（18:51:04Z→19:06:04Z）: ERROR/WARNING | ✅ 0 件 |
| 実機 Google ログイン→録音→編集→一覧 | ✅ 全 PASS |

## Baseline 記録

- エラー率: 0% (deploy 後 15 分)
- p95 レイテンシ: deploy 直後のため有意な計測不可（Day 2 以降で比較基準を確立）
- NOTICE (lifecycle): `beforeSignIn` / `deleteAccount` 各 2 件（container 起動、正常）

## 次工程

- **Day 2** (Phase 0.5 Rules prod deploy): 本 deploy 完了から **12h 経過後（2026-04-23 15:51 JST 以降）** に着手可能
- **Issue #100 close 候補**（Day 2 完了時）

## Test plan

- [x] `firebase functions:list` で両関数 nodejs22 / ACTIVE を確認済
- [x] Cloud Logging 15 分監視で ERROR/WARNING 0 件を確認済
- [x] 実機 Google ログイン → 録音 → 文字起こし編集 → 録音リスト、4 項目 PASS 確認済
- [x] 本 PR は RUNBOOK ログ追記のみ（コード変更なし）

## Refs

- RUNBOOK: `docs/runbook/prod-deploy-smoke-test.md` § Day 1
- 関連 Issue: #100（deploy-pending, Day 2 完了時 close 候補）、#110（closed）、#130（Node 22 upgrade）
- 次工程: `docs/runbook/prod-deploy-smoke-test.md` § Day 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)