### PR TITLE
fix(tests): force scheme parallelizable=NO + re-shared OutboxSync (#164/#170 H1)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,9 +4,11 @@ on:
   pull_request:
     branches: [main]
     paths-ignore:
+      # Note: 'scripts/**' was removed from this list (Issue #170 H1) because
+      # CI lint scripts (lint-model-container.sh, lint-scheme-parallel.sh) live
+      # under scripts/ and a tampered lint script must trigger CI to be caught.
       - 'functions/**'
       - 'docs/**'
-      - 'scripts/**'
       - '**.md'
       - '.github/**'
       - 'firestore.rules'
@@ -16,9 +18,11 @@ on:
   push:
     branches: [main]
     paths-ignore:
+      # Note: 'scripts/**' was removed from this list (Issue #170 H1) because
+      # CI lint scripts (lint-model-container.sh, lint-scheme-parallel.sh) live
+      # under scripts/ and a tampered lint script must trigger CI to be caught.
       - 'functions/**'
       - 'docs/**'
-      - 'scripts/**'
       - '**.md'
       - '.github/**'
       - 'firestore.rules'
@@ -40,6 +44,9 @@ jobs:
 
       - name: Lint - SwiftData schema drift guard (Issue #165)
         run: bash scripts/lint-model-container.sh
+
+      - name: Lint - Test scheme parallelization guard (Issue #170 H1)
+        run: bash scripts/lint-scheme-parallel.sh
 
       - name: Setup Xcode
         uses: maxim-lobanov/setup-xcode@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,14 +3,13 @@ name: iOS Tests
 on:
   pull_request:
     branches: [main]
+    # Intentionally NOT ignored: scripts/**, .github/** — changes to CI
+    # lint scripts or workflows must self-trigger CI so a tampered lint
+    # or workflow cannot land without validation (Issue #170 H1).
     paths-ignore:
-      # Note: 'scripts/**' was removed from this list (Issue #170 H1) because
-      # CI lint scripts (lint-model-container.sh, lint-scheme-parallel.sh) live
-      # under scripts/ and a tampered lint script must trigger CI to be caught.
       - 'functions/**'
       - 'docs/**'
       - '**.md'
-      - '.github/**'
       - 'firestore.rules'
       - 'storage.rules'
       - 'firebase.json'
@@ -18,13 +17,9 @@ on:
   push:
     branches: [main]
     paths-ignore:
-      # Note: 'scripts/**' was removed from this list (Issue #170 H1) because
-      # CI lint scripts (lint-model-container.sh, lint-scheme-parallel.sh) live
-      # under scripts/ and a tampered lint script must trigger CI to be caught.
       - 'functions/**'
       - 'docs/**'
       - '**.md'
-      - '.github/**'
       - 'firestore.rules'
       - 'storage.rules'
       - 'firebase.json'

--- a/CareNote.xcodeproj/xcshareddata/xcschemes/CareNote.xcscheme
+++ b/CareNote.xcodeproj/xcshareddata/xcschemes/CareNote.xcscheme
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2630"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      runPostActionsOnFailure = "NO">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A016D254A1D66E8BB915EFBE"
+               BuildableName = "CareNote.app"
+               BlueprintName = "CareNote"
+               ReferencedContainer = "container:CareNote.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "4066B81D21FB6D0304863AA0"
+               BuildableName = "CareNoteTests.xctest"
+               BlueprintName = "CareNoteTests"
+               ReferencedContainer = "container:CareNote.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "NO">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A016D254A1D66E8BB915EFBE"
+            BuildableName = "CareNote.app"
+            BlueprintName = "CareNote"
+            ReferencedContainer = "container:CareNote.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "4066B81D21FB6D0304863AA0"
+               BuildableName = "CareNoteTests.xctest"
+               BlueprintName = "CareNoteTests"
+               ReferencedContainer = "container:CareNote.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <CommandLineArguments>
+      </CommandLineArguments>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A016D254A1D66E8BB915EFBE"
+            BuildableName = "CareNote.app"
+            BlueprintName = "CareNote"
+            ReferencedContainer = "container:CareNote.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <CommandLineArguments>
+      </CommandLineArguments>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A016D254A1D66E8BB915EFBE"
+            BuildableName = "CareNote.app"
+            BlueprintName = "CareNote"
+            ReferencedContainer = "container:CareNote.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <CommandLineArguments>
+      </CommandLineArguments>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/CareNoteTests/OutboxSyncServiceTests.swift
+++ b/CareNoteTests/OutboxSyncServiceTests.swift
@@ -69,24 +69,6 @@ private actor StubTranscriber: Transcribing {
 @Suite("OutboxSyncService incrementRetryCount Tests", .serialized)
 struct OutboxSyncServiceTests {
 
-    // Shared container (SharedTestModelContainer) を使うと本 suite の
-    // processQueueImmediately 系 2 test が uploadCalls.count == 0 で回帰する。
-    // OutboxSyncService は modelContainer.mainContext をそのまま使っているため
-    // 当初仮説（独自 ModelContext 派生）は誤り。真因は未確定（候補: cleanup
-    // timing と async hop の race、cross-suite state pollution 等）。
-    // Issue #164 で真因調査し shared container へ合流させるまでは per-suite
-    // container を維持する。
-    @MainActor
-    private static func makeContainer() throws -> ModelContainer {
-        let url = FileManager.default.temporaryDirectory
-            .appendingPathComponent("swiftdata-test-\(UUID().uuidString).sqlite")
-        let config = ModelConfiguration(url: url)
-        return try ModelContainer(
-            for: RecordingRecord.self, OutboxItem.self, ClientCache.self, OutputTemplate.self,
-            configurations: config
-        )
-    }
-
     private static func makeService(
         container: ModelContainer,
         currentUidProvider: @escaping @Sendable @MainActor () -> String? = { "test-uid" }
@@ -110,7 +92,7 @@ struct OutboxSyncServiceTests {
 
     @Test @MainActor
     func incrementRetryCountで通常時はretryCount増加のみ() async throws {
-        let container = try Self.makeContainer()
+        let container = try makeTestModelContainer()
         let context = container.mainContext
         let service = Self.makeService(container: container)
 
@@ -137,7 +119,7 @@ struct OutboxSyncServiceTests {
 
     @Test @MainActor
     func incrementRetryCountでmax超過時にステータスがerrorになる() async throws {
-        let container = try Self.makeContainer()
+        let container = try makeTestModelContainer()
         let context = container.mainContext
         let service = Self.makeService(container: container)
 
@@ -165,7 +147,7 @@ struct OutboxSyncServiceTests {
 
     @Test @MainActor
     func incrementRetryCountでtranscriptionStatusがdoneの場合は変更しない() async throws {
-        let container = try Self.makeContainer()
+        let container = try makeTestModelContainer()
         let context = container.mainContext
         let service = Self.makeService(container: container)
 
@@ -195,7 +177,7 @@ struct OutboxSyncServiceTests {
 
     @Test @MainActor
     func buildFirestoreRecordingでcurrentUidProviderが返すuidがcreatedByに入る() async throws {
-        let container = try Self.makeContainer()
+        let container = try makeTestModelContainer()
         let context = container.mainContext
         let service = Self.makeService(
             container: container,
@@ -224,7 +206,7 @@ struct OutboxSyncServiceTests {
 
     @Test @MainActor
     func buildFirestoreRecordingでuidが取れない場合はuserNotAuthenticatedエラー() async throws {
-        let container = try Self.makeContainer()
+        let container = try makeTestModelContainer()
         let context = container.mainContext
         let service = Self.makeService(
             container: container,
@@ -254,7 +236,7 @@ struct OutboxSyncServiceTests {
     func buildFirestoreRecordingでuidが空文字の場合もuserNotAuthenticatedエラー() async throws {
         // issue #99 二段防御の境界値テスト: nil と空文字を独立にカバー。
         // `currentUidProvider` が non-nil な空文字を返しても createdBy は保存されない。
-        let container = try Self.makeContainer()
+        let container = try makeTestModelContainer()
         let context = container.mainContext
         let service = Self.makeService(
             container: container,
@@ -282,7 +264,7 @@ struct OutboxSyncServiceTests {
 
     @Test @MainActor
     func buildFirestoreRecordingで更新対象外フィールドは既存値を保持する() async throws {
-        let container = try Self.makeContainer()
+        let container = try makeTestModelContainer()
         let context = container.mainContext
         let service = Self.makeService(
             container: container,
@@ -512,7 +494,7 @@ struct OutboxSyncServiceTests {
     ///   でクリーンアップする。
     @MainActor
     private static func setupContainerWithAudioFile() throws -> (ModelContainer, String) {
-        let container = try Self.makeContainer()
+        let container = try makeTestModelContainer()
         let audioPath = FileManager.default.temporaryDirectory
             .appendingPathComponent("test-audio-\(UUID().uuidString).m4a").path
         try Data().write(to: URL(fileURLWithPath: audioPath))

--- a/project.yml
+++ b/project.yml
@@ -87,3 +87,30 @@ targets:
       base:
         SWIFT_VERSION: "6.0"
         GENERATE_INFOPLIST_FILE: true
+
+# Issue #170 H1 / #164: cross-suite race を構造的に抑止するため、
+# CareNoteTests は parallelizable=false で実行する（process-wide
+# SharedTestModelContainer の cleanup が他 suite の test body 中に
+# 介入する race を防ぐ）。CI 側の `-parallel-testing-enabled NO` と
+# 二重防御。scripts/lint-scheme-parallel.sh が回帰を検知。
+schemes:
+  CareNote:
+    build:
+      targets:
+        CareNote: all
+        CareNoteTests: [test]
+    run:
+      config: Debug
+    test:
+      config: Debug
+      gatherCoverageData: false
+      targets:
+        - name: CareNoteTests
+          parallelizable: false
+          randomExecutionOrder: false
+    profile:
+      config: Release
+    analyze:
+      config: Debug
+    archive:
+      config: Release

--- a/scripts/lint-model-container.sh
+++ b/scripts/lint-model-container.sh
@@ -35,11 +35,6 @@ cd "$ROOT"
 ALLOWED_TEST_FILES=(
   # Canonical shared container (PR #163 root-cause fix for Issue #141).
   "CareNoteTests/TestHelpers/SwiftDataTestHelper.swift"
-  # Temporarily allowed: PR #163 locally rolled back this one suite to a
-  # per-suite container because the shared container caused 2 tests to
-  # regress with uploadCalls.count == 0. Real cause still unknown — tracked
-  # in Issue #164. Remove from this list once #164 closes.
-  "CareNoteTests/OutboxSyncServiceTests.swift"
 )
 
 # Matches `ModelContainer[<Generic>](<newline/spaces>for:` — tolerates

--- a/scripts/lint-scheme-parallel.sh
+++ b/scripts/lint-scheme-parallel.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Lint: CareNote test scheme parallelization guard (Issue #170 H1 / #164)
+#
+# Cross-suite race in process-wide SharedTestModelContainer caused #164.
+# Root cause: Swift Testing's `@Suite(.serialized)` only serializes WITHIN
+# a suite, not BETWEEN suites. With shared SwiftData container, another
+# suite's `cleanup()` could fire mid-test-body of the active suite,
+# corrupting fetch results (e.g., uploadCalls.count == 0).
+#
+# Fix (PR for #170 H1): force the test scheme to be non-parallelizable
+# at the scheme level (defense in depth alongside CI's
+# `-parallel-testing-enabled NO`). This lint catches regressions where
+# someone re-enables parallelization in project.yml or via Xcode UI.
+#
+# Detection: parse the generated scheme XML and assert that ALL
+# <TestableReference> entries have `parallelizable="NO"` and that NO
+# entry has `parallelizable="YES"`. The positive assertion guards
+# against a missing attribute (which Xcode treats as parallelizable=YES
+# on some scheme versions).
+#
+# Implementation: `perl -0777` slurp (matches the established pattern in
+# scripts/lint-model-container.sh). xcodegen currently emits the
+# attribute on the same line as the tag, but Xcode's own scheme editor
+# may break long attribute lists across newlines on save — a
+# line-oriented `grep` would silently false-green that case.
+#
+# Usage:
+#   bash scripts/lint-scheme-parallel.sh
+#
+# Exit codes:
+#   0  scheme correctly disables test parallelization
+#   1  parallelization re-enabled, scheme missing, or assertion absent
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+SCHEME="CareNote.xcodeproj/xcshareddata/xcschemes/CareNote.xcscheme"
+
+# Tolerates whitespace + cross-line attributes (`parallelizable\n  = "YES"` etc.).
+PARALLEL_YES_PATTERN='parallelizable\s*=\s*"YES"'
+PARALLEL_NO_PATTERN='parallelizable\s*=\s*"NO"'
+
+# Pre-flight: scheme must exist. xcodegen must have run before this lint
+# (CI invokes `xcodegen generate` before any test step).
+if [ ! -f "$SCHEME" ]; then
+  echo "::error::Scheme not found: $SCHEME"
+  echo "Run 'xcodegen generate' first. The scheme is now committed (was auto-generated"
+  echo "before PR for #170 H1 added an explicit schemes: section to project.yml)."
+  exit 1
+fi
+
+# Negative assertion: NO TestableReference may be parallelizable="YES".
+# This is the regression guard.
+if perl -0777 -ne "exit (/$PARALLEL_YES_PATTERN/ ? 0 : 1)" "$SCHEME"; then
+  echo "::error::CareNote scheme has parallelizable=\"YES\" on a TestableReference."
+  echo ""
+  echo "Cross-suite parallelization re-enables the race that caused Issue #164:"
+  echo "process-wide SharedTestModelContainer cleanup() in suite A interleaves"
+  echo "with test body fetch in suite B, returning empty results."
+  echo ""
+  echo "Fix: ensure project.yml schemes.CareNote.test.targets[].parallelizable: false"
+  echo "and re-run 'xcodegen generate'."
+  exit 1
+fi
+
+# Positive assertion: at least one TestableReference must explicitly carry
+# parallelizable="NO". A missing attribute would silently default to
+# parallelizable behavior in some Xcode scheme versions, so we require
+# the explicit declaration.
+if ! perl -0777 -ne "exit (/$PARALLEL_NO_PATTERN/ ? 0 : 1)" "$SCHEME"; then
+  echo "::error::CareNote scheme missing explicit parallelizable=\"NO\" declaration."
+  echo ""
+  echo "Without explicit NO, Xcode's default may parallelize tests. The fix"
+  echo "must be load-bearing in the scheme XML, not implicit."
+  echo ""
+  echo "Fix: ensure project.yml schemes.CareNote.test.targets[].parallelizable: false"
+  echo "and re-run 'xcodegen generate'."
+  exit 1
+fi
+
+echo "lint-scheme-parallel: OK (CareNoteTests scheme has parallelizable=\"NO\")"

--- a/scripts/lint-scheme-parallel.sh
+++ b/scripts/lint-scheme-parallel.sh
@@ -3,81 +3,112 @@
 #
 # Cross-suite race in process-wide SharedTestModelContainer caused #164.
 # Root cause: Swift Testing's `@Suite(.serialized)` only serializes WITHIN
-# a suite, not BETWEEN suites. With shared SwiftData container, another
+# a suite, not BETWEEN suites. With a shared SwiftData container, another
 # suite's `cleanup()` could fire mid-test-body of the active suite,
 # corrupting fetch results (e.g., uploadCalls.count == 0).
 #
-# Fix (PR for #170 H1): force the test scheme to be non-parallelizable
-# at the scheme level (defense in depth alongside CI's
-# `-parallel-testing-enabled NO`). This lint catches regressions where
-# someone re-enables parallelization in project.yml or via Xcode UI.
+# Fix: force every test scheme to disable parallelization at the scheme
+# level (defense in depth alongside CI's `-parallel-testing-enabled NO`).
+# This lint catches regressions where someone re-enables parallelization
+# in project.yml, edits the scheme by hand, or adds a new scheme.
 #
-# Detection: parse the generated scheme XML and assert that ALL
-# <TestableReference> entries have `parallelizable="NO"` and that NO
-# entry has `parallelizable="YES"`. The positive assertion guards
-# against a missing attribute (which Xcode treats as parallelizable=YES
-# on some scheme versions).
-#
-# Implementation: `perl -0777` slurp (matches the established pattern in
-# scripts/lint-model-container.sh). xcodegen currently emits the
-# attribute on the same line as the tag, but Xcode's own scheme editor
-# may break long attribute lists across newlines on save — a
-# line-oriented `grep` would silently false-green that case.
+# Detection: walk every committed *.xcscheme and assert that EVERY
+# <TestableReference> entry explicitly carries `parallelizable="NO"`.
+# The pattern is anchored to the tag opening so a `parallelizable="NO"`
+# on an unrelated future element (e.g., <TestPlanReference>) cannot
+# satisfy the assertion. `perl -0777` slurp tolerates Xcode's
+# cross-line attribute formatting (matches scripts/lint-model-container.sh).
 #
 # Usage:
 #   bash scripts/lint-scheme-parallel.sh
 #
 # Exit codes:
-#   0  scheme correctly disables test parallelization
-#   1  parallelization re-enabled, scheme missing, or assertion absent
+#   0  every scheme correctly disables test parallelization
+#   1  parallelization re-enabled, scheme missing/empty, or count mismatch
 
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT"
 
-SCHEME="CareNote.xcodeproj/xcshareddata/xcschemes/CareNote.xcscheme"
+SCHEMES_DIR="CareNote.xcodeproj/xcshareddata/xcschemes"
 
-# Tolerates whitespace + cross-line attributes (`parallelizable\n  = "YES"` etc.).
-PARALLEL_YES_PATTERN='parallelizable\s*=\s*"YES"'
-PARALLEL_NO_PATTERN='parallelizable\s*=\s*"NO"'
-
-# Pre-flight: scheme must exist. xcodegen must have run before this lint
-# (CI invokes `xcodegen generate` before any test step).
-if [ ! -f "$SCHEME" ]; then
-  echo "::error::Scheme not found: $SCHEME"
-  echo "Run 'xcodegen generate' first. The scheme is now committed (was auto-generated"
-  echo "before PR for #170 H1 added an explicit schemes: section to project.yml)."
+# Pre-flight: schemes directory must exist. Schemes are committed
+# alongside project.pbxproj (xcodegen output is treated as source-of-truth).
+if [ ! -d "$SCHEMES_DIR" ]; then
+  echo "::error::Schemes directory missing: $SCHEMES_DIR"
+  echo "Run 'xcodegen generate' to materialize schemes from project.yml."
   exit 1
 fi
 
-# Negative assertion: NO TestableReference may be parallelizable="YES".
-# This is the regression guard.
-if perl -0777 -ne "exit (/$PARALLEL_YES_PATTERN/ ? 0 : 1)" "$SCHEME"; then
-  echo "::error::CareNote scheme has parallelizable=\"YES\" on a TestableReference."
-  echo ""
-  echo "Cross-suite parallelization re-enables the race that caused Issue #164:"
-  echo "process-wide SharedTestModelContainer cleanup() in suite A interleaves"
-  echo "with test body fetch in suite B, returning empty results."
-  echo ""
-  echo "Fix: ensure project.yml schemes.CareNote.test.targets[].parallelizable: false"
-  echo "and re-run 'xcodegen generate'."
+# Collect every committed scheme. Sort for deterministic CI output.
+mapfile -t SCHEMES < <(find "$SCHEMES_DIR" -name '*.xcscheme' | sort)
+if [ "${#SCHEMES[@]}" -eq 0 ]; then
+  echo "::error::No *.xcscheme files in $SCHEMES_DIR — cannot enforce parallelization guard."
   exit 1
 fi
 
-# Positive assertion: at least one TestableReference must explicitly carry
-# parallelizable="NO". A missing attribute would silently default to
-# parallelizable behavior in some Xcode scheme versions, so we require
-# the explicit declaration.
-if ! perl -0777 -ne "exit (/$PARALLEL_NO_PATTERN/ ? 0 : 1)" "$SCHEME"; then
-  echo "::error::CareNote scheme missing explicit parallelizable=\"NO\" declaration."
-  echo ""
-  echo "Without explicit NO, Xcode's default may parallelize tests. The fix"
-  echo "must be load-bearing in the scheme XML, not implicit."
-  echo ""
-  echo "Fix: ensure project.yml schemes.CareNote.test.targets[].parallelizable: false"
-  echo "and re-run 'xcodegen generate'."
+failed=0
+checked_with_tests=0
+for SCHEME in "${SCHEMES[@]}"; do
+  # Empty-file guard. `perl -0777 -ne 'exit (/.../ ? 0 : 1)'` runs the
+  # END block 0 times for an empty file and so exits 0 — silently
+  # turning every regex assertion into a green pass. Refuse to lint
+  # an empty scheme.
+  if [ ! -s "$SCHEME" ]; then
+    echo "::error::Scheme is empty: $SCHEME"
+    failed=1
+    continue
+  fi
+
+  # Count <TestableReference …> openings. Schemes with no TestAction
+  # (build-only schemes) have zero, and are outside this guard's scope.
+  testable_count=$(perl -0777 -ne 'my @m = /<TestableReference\b/g; print scalar(@m)' "$SCHEME")
+  if [ "$testable_count" -eq 0 ]; then
+    continue
+  fi
+
+  # Negative assertion: no <TestableReference …> may carry
+  # parallelizable="YES". Anchored to the tag opening so the match
+  # cannot leak across element boundaries; [^>]*? tolerates any
+  # attribute order. /s flag lets [^>]*? span newlines.
+  yes_count=$(perl -0777 -ne 'my @m = /<TestableReference\b[^>]*?parallelizable\s*=\s*"YES"/gs; print scalar(@m)' "$SCHEME")
+  if [ "$yes_count" -gt 0 ]; then
+    echo "::error::$SCHEME has $yes_count <TestableReference> with parallelizable=\"YES\"."
+    echo ""
+    echo "Cross-suite parallelization re-enables the race that caused Issue #164:"
+    echo "SharedTestModelContainer cleanup() in suite A interleaves with the test"
+    echo "body of suite B, returning empty fetch results."
+    echo ""
+    echo "Fix: set parallelizable: false in project.yml schemes.<name>.test.targets[]"
+    echo "and re-run 'xcodegen generate'."
+    failed=1
+    continue
+  fi
+
+  # Positive ALL assertion: every <TestableReference …> must carry
+  # parallelizable="NO" explicitly. A missing attribute defaults to
+  # parallel on some Xcode scheme versions, so absence is also a
+  # regression — counting NO matches and comparing to the total
+  # <TestableReference> count catches both "missing" and "different
+  # value" forms.
+  no_count=$(perl -0777 -ne 'my @m = /<TestableReference\b[^>]*?parallelizable\s*=\s*"NO"/gs; print scalar(@m)' "$SCHEME")
+  if [ "$no_count" -ne "$testable_count" ]; then
+    missing=$((testable_count - no_count))
+    echo "::error::$SCHEME has $missing of $testable_count <TestableReference> without explicit parallelizable=\"NO\"."
+    echo ""
+    echo "Implicit parallelizable defaults to parallel on some Xcode scheme versions."
+    echo "Fix: set parallelizable: false in project.yml schemes.<name>.test.targets[]"
+    echo "and re-run 'xcodegen generate'."
+    failed=1
+    continue
+  fi
+
+  checked_with_tests=$((checked_with_tests + 1))
+done
+
+if [ "$failed" -ne 0 ]; then
   exit 1
 fi
 
-echo "lint-scheme-parallel: OK (CareNoteTests scheme has parallelizable=\"NO\")"
+echo "lint-scheme-parallel: OK (${#SCHEMES[@]} scheme(s) scanned, $checked_with_tests with TestAction, all <TestableReference> have parallelizable=\"NO\")"

--- a/scripts/lint-scheme-parallel.sh
+++ b/scripts/lint-scheme-parallel.sh
@@ -42,7 +42,12 @@ if [ ! -d "$SCHEMES_DIR" ]; then
 fi
 
 # Collect every committed scheme. Sort for deterministic CI output.
-mapfile -t SCHEMES < <(find "$SCHEMES_DIR" -name '*.xcscheme' | sort)
+# Use `while read` instead of `mapfile` because macOS ships bash 3.2
+# (no mapfile) and CI runs on macos-15 with the default /bin/bash.
+SCHEMES=()
+while IFS= read -r scheme; do
+  SCHEMES+=("$scheme")
+done < <(find "$SCHEMES_DIR" -name '*.xcscheme' | sort)
 if [ "${#SCHEMES[@]}" -eq 0 ]; then
   echo "::error::No *.xcscheme files in $SCHEMES_DIR — cannot enforce parallelization guard."
   exit 1


### PR DESCRIPTION
## Summary
- Issue #170 H1 実装: scheme レベル `parallelizable=NO` + lint 機械検証で cross-suite race を構造的に抑止
- Issue #164 真因 (cross-suite race) を発生不可能化
- `OutboxSyncServiceTests` を `SharedTestModelContainer` に再合流（per-suite workaround 撤廃）

## 真因と設計
`@Suite(.serialized)` は **suite 内のみ** 直列化、suite 間は並列のままだった。process-wide shared container 使用時、別 suite の `cleanup()` が本 suite の test body 中に介入する race が #164 (`uploadCalls.count == 0`) の真因。

選定案: scheme レベル `parallelizable: false` 強制 + lint 機械検証 + CI の `-parallel-testing-enabled NO` と二重防御。代替案 (a) root `@Suite(.serialized)` ラップは 17 ファイル変更で diff 過大、(c) actor-locked helper は test body の atomic 化が技術的に不可能。

## 変更ファイル (6個)

| ファイル | 内容 |
|---------|------|
| `project.yml` | `schemes.CareNote.test.targets[].parallelizable: false` 追加 |
| `.github/workflows/test.yml` | lint-scheme-parallel.sh の CI step 追加 + paths-ignore から `'scripts/**'` 削除（lint script 改ざん検出のため） |
| `CareNoteTests/OutboxSyncServiceTests.swift` | per-suite `makeContainer()` 削除 + 8 箇所を `makeTestModelContainer()` に差し戻し |
| `scripts/lint-model-container.sh` | ALLOWED_TEST_FILES から `OutboxSyncServiceTests.swift` 削除 |
| `scripts/lint-scheme-parallel.sh` (新規) | perl -0777 slurp で scheme XML の `parallelizable="NO"` を機械検証 |
| `CareNote.xcodeproj/xcshareddata/xcschemes/CareNote.xcscheme` (新規) | xcodegen 生成、project.pbxproj 同様 commit 化 |

## Test plan
- [x] xcodebuild test 1 回 PASS（135 tests / 18 suites, ~23s）
- [x] xcodebuild test `-test-iterations 20 -run-tests-until-failure` PASS（2700 tests / 360 suites / 20 iterations, ~4.4s test time）
- [x] `bash scripts/lint-model-container.sh` green
- [x] `bash scripts/lint-scheme-parallel.sh` green
- [x] lint self-test: `parallelizable="NO"` → `"YES"` で fail（cross-line attribute simulation でも検出）
- [ ] CI 1 回 PASS（このPR）

## Quality Gate
- `/simplify` 3 並列（reuse / quality / efficiency）: Reuse Important × 1 修正（grep → perl -0777 slurp で `lint-model-container.sh` のパターンに統一）、quality / efficiency clean
- `/safe-refactor`: 検出問題 0 件
- Evaluator 分離プロトコル: HIGH × 1 修正（paths-ignore から `'scripts/**'` 削除）、MEDIUM × 1（xcodegen → lint 順序依存）は #170 H6 へ follow-up

## 関連
- Closes #164（cross-suite race 真因確立 + 構造的抑止）
- Implements #170 H1（H2–H6 は独立 follow-up）
- 関連 PR: #163（shared container 導入）/ #167（model container drift lint）/ #169（#164 CI 再現 probe）

🤖 Generated with [Claude Code](https://claude.com/claude-code)