### PR TITLE
fix(rules): rollback Phase 0.5 recordings Rules（稼働 iOS Build 35 との不整合で業務停止を緊急復旧）

### DIFF
--- a/docs/handoff/LATEST.md
+++ b/docs/handoff/LATEST.md
@@ -22,7 +22,8 @@ PR #179 merge 後の追加確認で、**Phase 0.5 Rules prod deploy (本日 19:2
 
 ### Rollback 実施
 
-- **実施時刻**: 2026-04-23 21:30 JST 頃（Phase 0.5 prod deploy から 2h05m 後）
+- **実施時刻**: 2026-04-23 **22:07:58 JST**（Phase 0.5 prod deploy から 2h42m56s 後、Firebase Rules REST API の ruleset `createTime` により一次確定）
+- **ruleset 識別子**: `projects/carenote-prod-279/rulesets/b86a7ee8-43f5-4a36-934d-50d21a596ee5`
 - **対応**: `firestore.rules` の `recordings` block を Phase 0.5 前の状態（`allow read, write: if isTenantMember(tenantId)`）に戻して `firebase deploy --only firestore:rules --project carenote-prod-279` 実施
 - **結果**: `cloud.firestore: rules file firestore.rules compiled successfully` / `released rules firestore.rules to cloud.firestore` → 業務復旧
 - **残置**: `migrationLogs` / `migrationState` の Rules は残した（Phase 1 transferOwnership 運用に必要、iOS app から触らないので影響なし）

--- a/docs/handoff/LATEST.md
+++ b/docs/handoff/LATEST.md
@@ -27,6 +27,7 @@ PR #179 merge 後の追加確認で、**Phase 0.5 Rules prod deploy (本日 19:2
 - **対応**: `firestore.rules` の `recordings` block を Phase 0.5 前の状態（`allow read, write: if isTenantMember(tenantId)`）に戻して `firebase deploy --only firestore:rules --project carenote-prod-279` 実施
 - **結果**: `cloud.firestore: rules file firestore.rules compiled successfully` / `released rules firestore.rules to cloud.firestore` → 業務復旧
 - **残置**: `migrationLogs` / `migrationState` の Rules は残した（Phase 1 transferOwnership 運用に必要、iOS app から触らないので影響なし）
+- **rules unit test は意図的に未修正**: `functions/test/firestore-rules.test.js` は Phase 0.5 強化版（create に createdBy 必須等）の期待のまま。rollback 後の rules と一時不整合となり CI `functions-test` workflow は FAIL 見込み。**Phase 0.5 Rules 再 deploy 時に test を合わせて戻す方針**。次セッションで Build 36 リリース + Phase 0.5 Rules 再 deploy を実施する際、rules と test を同じ PR で一緒に再適用する
 
 ### 影響を受けた/受けなかった今日の変更
 
@@ -34,7 +35,7 @@ PR #179 merge 後の追加確認で、**Phase 0.5 Rules prod deploy (本日 19:2
 |------|------|------|
 | Phase 0.5 Rules prod deploy (PR #115 / Day 2) | ❌ 業務停止発生 | **本 rollback で Phase 0.5 前の状態に戻した** |
 | Day 3 transferOwnership prod deploy | ✅ 影響なし（iOS app から呼ばない Callable） | そのまま継続 |
-| Phase 0.9 prod allowedDomains 設定 | ✅ 影響なし（beforeSignIn サーバ側変更のみ） | そのまま継続 |
+| Phase 0.9 prod allowedDomains 設定 | ⚠️ 機能自体は壊れていない（beforeSignIn 変更のみ）。ただし rollback 期間中は新規 `@279279.net` 自動加入 member にも **tenant-wide recordings 権限（read/write/delete）** が付与されるため、allowedDomains 有効 × 過剰権限の組合せリスク顕在（自社単独フェーズで受容、Phase 0.5 Rules 再 deploy で解消） | そのまま継続（自動加入 member は自社メンバーのみの前提） |
 | ADR-009 prod Firestore 運用パターン | ✅ 影響なし（文書のみ） | そのまま |
 | Issue #178 Stage 2 follow-up 起票 | ✅ 影響なし | そのまま |
 

--- a/docs/handoff/LATEST.md
+++ b/docs/handoff/LATEST.md
@@ -1,6 +1,83 @@
-# Handoff — 2026-04-23 夜セッション: Day 3 transferOwnership prod deploy + Phase 0.9 allowedDomains 有効化 + ADR-009 策定
+# Handoff — 2026-04-23 夜セッション: Day 3 + Phase 0.9 + ADR-009 → **Phase 0.5 Rules 判断ミス + 緊急 rollback**
 
-## セッション成果サマリ（2026-04-23 夜セッション）
+## ⚠️ セッション終盤に Phase 0.5 Rules の判断ミスが発覚し、業務停止 → rollback 実施
+
+### 何が起きたか
+
+PR #179 merge 後の追加確認で、**Phase 0.5 Rules prod deploy (本日 19:25 JST、Day 2) が稼働中の iOS バイナリ (Build 35 / App Store Unlisted 公開中) と整合しない**ことが判明。ユーザー実機で録音保存 → 文字起こし完了が permission-denied で失敗、**業務停止**。
+
+### 真因
+
+- Build 35 提出: 2026-04-16（= #101 "録音 createdBy 保存" (2026-04-20 merge) より前の iOS コード）
+- Build 35 は 2026-04-18 から App Store で Unlisted 配信中（自社メンバーが実機使用中）
+- 本日 Phase 0.5 Rules の `create` 条件 `request.resource.data.createdBy == request.auth.uid` を prod deploy
+- → Build 35 が createdBy を書き込まずに create → **permission-denied**
+
+### 判断ミスの構造
+
+1. **Phase 0.5 Rules deploy 前に「稼働中 iOS が #101 を含むか」を検証しなかった**
+2. Day 2 実施ログで「**実機 smoke test skip、rules-unit-tests 64 件で代替 PASS**」としたが、rules-unit-tests は「新 iOS コード (#101 適用済) × 新 Rules」の組合せしか検証していない。「**旧 Build 35 × 新 Rules**」= 実稼働中の組合せは一切検証されていなかった
+3. 「自社単独フェーズで 24h 監視圧縮」の流れで実機検証を軽視した判断全体が誤り
+4. Codex review (PR #179) は docs 整合性のみの軽量レビューで、Rules と稼働バイナリの整合には踏み込んでいなかった
+
+### Rollback 実施
+
+- **実施時刻**: 2026-04-23 21:30 JST 頃（Phase 0.5 prod deploy から 2h05m 後）
+- **対応**: `firestore.rules` の `recordings` block を Phase 0.5 前の状態（`allow read, write: if isTenantMember(tenantId)`）に戻して `firebase deploy --only firestore:rules --project carenote-prod-279` 実施
+- **結果**: `cloud.firestore: rules file firestore.rules compiled successfully` / `released rules firestore.rules to cloud.firestore` → 業務復旧
+- **残置**: `migrationLogs` / `migrationState` の Rules は残した（Phase 1 transferOwnership 運用に必要、iOS app から触らないので影響なし）
+
+### 影響を受けた/受けなかった今日の変更
+
+| 変更 | 影響 | 対応 |
+|------|------|------|
+| Phase 0.5 Rules prod deploy (PR #115 / Day 2) | ❌ 業務停止発生 | **本 rollback で Phase 0.5 前の状態に戻した** |
+| Day 3 transferOwnership prod deploy | ✅ 影響なし（iOS app から呼ばない Callable） | そのまま継続 |
+| Phase 0.9 prod allowedDomains 設定 | ✅ 影響なし（beforeSignIn サーバ側変更のみ） | そのまま継続 |
+| ADR-009 prod Firestore 運用パターン | ✅ 影響なし（文書のみ） | そのまま |
+| Issue #178 Stage 2 follow-up 起票 | ✅ 影響なし | そのまま |
+
+### Issue 再訂正
+
+- Issue #100 **reopen**（本日 close は時期尚早 → reopen コメントで rollback 経緯 + Close 再条件明記）
+- Open Issue: 開始時 7 → PR #179 merge 時 7（-#100 +#178）→ rollback 後 **8**（#100 reopen で +1）
+- Net 変化: セッション開始から +1（実害解消できず、むしろ業務停止を引き起こして復旧）
+
+### Close 再条件（Issue #100）
+
+次回以降:
+1. **Build 36 リリース**: `scripts/upload-testflight.sh` で Build 36 作成（#101 + 以降の 5 commit 込み）
+2. **全稼働実機に Build 36 を配布**（TestFlight / App Store update 経由）
+3. **Build 36 で `createdBy` が保存されることを実機確認**
+4. **Phase 0.5 Rules 再 deploy**（`firestore.rules` recordings に create/update/delete の createdBy 条件を復活）
+5. **再 deploy 後、実機で録音 CRUD を確認**（今回は skip した、今度は必須）
+6. 実機確認 PASS で Issue #100 close
+
+### プロセス改善（次セッションで別 ADR 化）
+
+**サーバ側 Rules / functions 変更が iOS app コードの前提を伴う場合、対応 iOS build が稼働実機に入ってから deploy する**を明文化:
+- `runbook/prod-deploy-smoke-test.md` の Day 2 Rules deploy 前提条件に「対応 iOS build の稼働実機反映」を追加
+- `firestore.rules` 変更 PR テンプレートに「前提 iOS build 番号」を必須記載
+- 「実機 smoke test を rules-unit-tests で代替」は **稼働中 iOS バイナリとの実機整合検証の代替にならない**ことを明示
+- 自社単独フェーズでも「稼働中 iOS バイナリとの互換性確認」は skip 禁止
+
+### Rollback で作成した PR / コミット
+
+- branch: `fix/rollback-phase-0-5-rules`
+- 手動編集: `firestore.rules` の `recordings` block を Phase 0.5 前に戻す
+- PR: （後述、本 handoff 更新 + 作成）
+- Issue #100 reopen コメント: https://github.com/system-279/carenote-ios/issues/100#issuecomment-4304611564
+
+### 次セッションの最優先アクション
+
+1. **Build 36 を `scripts/upload-testflight.sh` で作成・TestFlight upload**（#101 + 5 commit 込み）
+2. Build 36 を実機で受領（TestFlight 内部テスター経由）
+3. 実機で録音 CRUD を確認（createdBy が保存されるか）
+4. Phase 0.5 Rules を別 PR で再適用・prod deploy・実機再確認・Issue #100 close
+
+---
+
+## セッション成果サマリ（2026-04-23 夜セッション、rollback 前の成果）
 
 前セッション (2026-04-23 午後、PR #175/#176 merged) 直後に継続。`/catchup` で Day 1/Day 2 完了確認 → ユーザー判断「**自社単独フェーズで 24h 監視ゲートを圧縮し最速進行**」のもと、Day 2 deploy +1h30m 時点で Day 3 transferOwnership prod deploy に着手、続けて Phase 0.9 prod `allowedDomains` を有効化。
 

--- a/firestore.rules
+++ b/firestore.rules
@@ -41,21 +41,13 @@ service cloud.firestore {
       }
 
       // 録音
-      //   read   : 業務上、同一テナント内の member 間で閲覧共有（既存 UI 仕様）
-      //   create : 自分を createdBy にしたものだけ（他人のなりすまし作成防止）
-      //   update : 作成者本人または admin（transcription 編集・admin 補正のため）
-      //            + createdBy 不変制約（client からオーナーシップを書き換え不可。
-      //              所有権移管は Admin SDK 経由で実施し rules を bypass して createdBy を書換）
-      //   delete : 作成者本人または admin（現状 iOS は delete しないが、将来拡張に備えて対称化）
+      // NOTE(2026-04-23 rollback): Phase 0.5 強化版 rules を本日 prod deploy したが、
+      // 稼働中 iOS (Build 35 / App Store 公開中) が #101 (2026-04-20 merge) を含まず
+      // `createdBy` を書き込まないため、新 rules の create 条件 `createdBy == uid` で
+      // permission-denied → 業務停止。応急として本 block を Phase 0.5 前の状態に戻す。
+      // 再導入条件: #101 を含む Build 36 を全稼働実機に配布完了後、別 PR で再適用する。
       match /recordings/{recordingId} {
-        allow read: if isTenantMember(tenantId);
-        allow create: if isTenantMember(tenantId)
-          && request.resource.data.createdBy == request.auth.uid;
-        allow update: if (isAdmin(tenantId)
-            || (isTenantMember(tenantId) && resource.data.createdBy == request.auth.uid))
-          && request.resource.data.createdBy == resource.data.createdBy;
-        allow delete: if isAdmin(tenantId)
-          || (isTenantMember(tenantId) && resource.data.createdBy == request.auth.uid);
+        allow read, write: if isTenantMember(tenantId);
       }
 
       // 移行ログ（Phase 1 transferOwnership の監査用。admin SDK 経由でのみ書込）


### PR DESCRIPTION
## ⚠️ 緊急 Rollback PR

2026-04-23 に Phase 0.5 Rules を prod deploy (PR #115) したが、**稼働中の iOS (Build 35 / App Store Unlisted 公開中)** が #101 "録音 createdBy 保存" (2026-04-20 merge) を含まないため、新 rules の `create: createdBy == request.auth.uid` で **permission-denied → 業務停止**。

`firestore.rules` の `recordings` block のみを Phase 0.5 前の状態 (`allow read, write: if isTenantMember(tenantId)`) に戻して prod deploy 済。**deploy は既に実施済**（本 PR は記録用）。

## 経緯（時刻は一次証拠で訂正）

- 2026-04-16: Build 35 提出（#101 merge 前の iOS コード）
- 2026-04-18: Build 35 が App Store Unlisted 配信開始
- 2026-04-20: PR #101 "録音 createdBy 保存" merge（Build 36 以降向け）
- **2026-04-23 19:25 JST**: Phase 0.5 Rules prod deploy（PR #115 / Day 2、本 rollback 対象）
- 2026-04-23 21:00 JST: Phase 0.9 prod allowedDomains 設定
- **ユーザー実機で録音保存→文字起こし完了が permission-denied**（発生時刻は audit log 無効のため不明、22:07 JST の rollback 前）
- **2026-04-23 22:07:58 JST**: Phase 0.5 Rules rollback deploy 完了、業務復旧
  - 一次証拠: Firebase Rules REST API `projects/carenote-prod-279/releases/cloud.firestore` の `createTime`
  - ruleset name: `projects/carenote-prod-279/rulesets/b86a7ee8-43f5-4a36-934d-50d21a596ee5`

## 判断ミスの構造

1. Phase 0.5 Rules deploy 前に「稼働中 iOS が #101 を含むか」を検証しなかった
2. Day 2 実施ログで「実機 smoke test skip、rules-unit-tests 64 件で代替 PASS」としたが、rules-unit-tests は「新 iOS × 新 Rules」の組合せしか検証していない
3. 「Build 35 × 新 Rules」= 実稼働中の組合せは一切検証されていなかった
4. 「自社単独フェーズで 24h 監視圧縮」の流れで実機検証を軽視

## Test plan

- [x] `firebase deploy --only firestore:rules --project carenote-prod-279` 成功（`rules file firestore.rules compiled successfully` / `released rules`）
- [x] 実機 Build 35 で録音保存 → 文字起こし完了が通ること（ユーザー 2026-04-23 夜に確認済）
- [x] **現行 prod ruleset を Firebase Rules REST API で直接 fetch → `recordings` block が `allow read, write: if isTenantMember(tenantId)` に戻っていることを一次証拠で確認**
- [x] Cloud Functions 側 ERROR 直近 2h で 0 件確認
- [ ] CI `functions-test` workflow は FAIL する見込み（test は Phase 0.5 期待のまま、rules は戻した）。**本 PR は意図的に test を未修正**（Phase 0.5 Rules 再 deploy 時に test を復活させる方針）

## スコープ外（follow-up）

- `functions/test/firestore-rules.test.js` の test は Phase 0.5 期待を保持（rules と一時不整合）。Phase 0.5 Rules 再 deploy 時に復活
- runbook / 新 ADR での プロセス改善（iOS build 前提の deploy ゲート）は別 PR で整備

## Issue 影響

- Issue #100 **reopen 済**（https://github.com/system-279/carenote-ios/issues/100#issuecomment-4304611564）
- Close 再条件:
  1. Build 36 リリース（#101 + 後続 5 commit 込み）
  2. 全稼働実機に Build 36 配布
  3. Build 36 で createdBy 保存を実機確認
  4. Phase 0.5 Rules を別 PR で再適用・deploy
  5. 実機で録音 CRUD 確認（skip 禁止）
  6. 確認 PASS で Issue #100 close

## 影響を受けなかった今日の変更

| 変更 | 影響 | 対応 |
|------|------|------|
| Day 3 transferOwnership prod deploy | なし（iOS app から呼ばない Callable） | 継続 |
| Phase 0.9 prod allowedDomains | なし（サーバ側のみ） | 継続 |
| ADR-009 prod Firestore 運用パターン | なし（文書のみ） | 継続 |
| Issue #178 起票 | なし | 継続 |

Refs #100 (reopened)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
