### PR TITLE
fix(test): #170 H2/H3 — SharedTestModelContainer に NSError 詳細 diagnostic 追加

### DIFF
--- a/CareNote.xcodeproj/project.pbxproj
+++ b/CareNote.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		65E5E0CD5DBC914A92B91130 /* ClientSelectViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7452B80D90D9172B77475447 /* ClientSelectViewModel.swift */; };
 		6B0117657090C55B8D4A4A43 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 0201FF49E15F02E9E9054426 /* Assets.xcassets */; };
 		6DA2DDE0F90D3985BC3C5D17 /* AppEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2848993801DEF66A676C25D /* AppEnvironment.swift */; };
+		75D3B3D5ED8EB33EDC97B6D1 /* SwiftDataTestHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C75F7694513195B13FC911A0 /* SwiftDataTestHelperTests.swift */; };
 		792F0B0FB46944FA0363CDC5 /* AudioPlayerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43708B0DF054C4C514B8D58E /* AudioPlayerView.swift */; };
 		7CA851BF8A07B0D97F3903A3 /* RecordingConfirmViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0C0F8FB680432239DF40DE4 /* RecordingConfirmViewModelTests.swift */; };
 		8234CBC662F2FB30E1866158 /* AppleSignInCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9E130263BC2FE596468916F /* AppleSignInCoordinator.swift */; };
@@ -133,6 +134,7 @@
 		B6C5DFB4EEA458F1AA1EB33F /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		C1773834D66185AC4FF05004 /* RecordingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingViewModel.swift; sourceTree = "<group>"; };
 		C66B8FD7F4EEDA2F428C0A1F /* ClientRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientRepository.swift; sourceTree = "<group>"; };
+		C75F7694513195B13FC911A0 /* SwiftDataTestHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftDataTestHelperTests.swift; sourceTree = "<group>"; };
 		CE80E23E3C3633F29AC0F0DA /* TranscriptionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptionService.swift; sourceTree = "<group>"; };
 		DA628FEE8E8929DE6D2651EC /* GoogleService-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		E0C0F8FB680432239DF40DE4 /* RecordingConfirmViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingConfirmViewModelTests.swift; sourceTree = "<group>"; };
@@ -327,6 +329,7 @@
 			children = (
 				95C67F09979A83A8D77ED023 /* MockURLProtocol.swift */,
 				96464007F869DAE0DA555BA3 /* SwiftDataTestHelper.swift */,
+				C75F7694513195B13FC911A0 /* SwiftDataTestHelperTests.swift */,
 			);
 			path = TestHelpers;
 			sourceTree = "<group>";
@@ -520,6 +523,7 @@
 				4E553F6607752AD117DCE2E6 /* RecordingViewModelTests.swift in Sources */,
 				ABDABE93CD6D0DB3B2820C5E /* StorageServiceTests.swift in Sources */,
 				C72A378B599300A331056288 /* SwiftDataTestHelper.swift in Sources */,
+				75D3B3D5ED8EB33EDC97B6D1 /* SwiftDataTestHelperTests.swift in Sources */,
 				B5FD3368DC82D3A7F025330E /* TemplateCreateViewModelTests.swift in Sources */,
 				FD8997F1B7751D73EDA8FD45 /* TemplateListViewModelTests.swift in Sources */,
 				CCA4CF007249D2BA99FD5315 /* TranscriptionServiceTests.swift in Sources */,

--- a/CareNoteTests/TestHelpers/SwiftDataTestHelper.swift
+++ b/CareNoteTests/TestHelpers/SwiftDataTestHelper.swift
@@ -6,15 +6,16 @@ import SwiftData
 ///
 /// Reuses one container for all tests because SwiftData SIGTRAPs when the
 /// same `@Model` type is registered in multiple `ModelContainer`s within
-/// one process (Issue #141). `cleanup()` empties the store between tests
-/// instead of reallocating, which would re-trigger the SIGTRAP.
+/// one process (Issue #141). Per-test reallocation would re-trigger the
+/// crash.
 ///
-/// Diagnostic contract (Issue #170 H2/H3): container-init `fatalError` and
-/// per-model `cleanup()` failures both route through `formatNSError` so the
-/// `NSError` shape that names the offending `@Model` on schema drift is
-/// never lost. Without this, a partial cleanup or a drift crash surfaces
-/// only as `delete(model:)` / `ModelContainer(for:)` throwing — with no
-/// indication of which type is at fault.
+/// Diagnostic contract (Issue #170): on failure, container-init `fatalError`
+/// and `cleanup()` both route the offending `@Model` type name + full
+/// `NSError` shape through `formatNSError` — to `stderr` for `cleanup()`
+/// (before rethrow), and into the crash message for `fatalError`. Without
+/// this, a cleanup failure or schema-drift crash surfaces only as a bare
+/// `delete(model:)` / `ModelContainer(for:)` error, with no indication of
+/// which type is at fault.
 @MainActor
 enum SharedTestModelContainer {
     static let shared: ModelContainer = {
@@ -33,6 +34,10 @@ enum SharedTestModelContainer {
 
     static func cleanup() throws {
         let context = shared.mainContext
+        // fail-fast: the first failure rethrows and skips the rest, so a
+        // schema-drift surface cannot be buried under subsequent errors.
+        // Do not rewrite to "best-effort" — CLAUDE.md Debug Protocol wants
+        // the first diagnostic surfaced immediately.
         try delete(RecordingRecord.self, in: context)
         try delete(OutboxItem.self, in: context)
         try delete(ClientCache.self, in: context)
@@ -62,7 +67,10 @@ enum SharedTestModelContainer {
         FileHandle.standardError.write(Data(message.utf8))
     }
 
-    private static func formatNSError(_ error: Error) -> String {
+    // Exposed at file scope (not `private`) so `SwiftDataTestHelperTests`
+    // can pin the diagnostic string shape — a typo in this template would
+    // silently degrade exactly the signal the helper exists to provide.
+    static func formatNSError(_ error: Error) -> String {
         let ns = error as NSError
         return """
               domain: \(ns.domain)

--- a/CareNoteTests/TestHelpers/SwiftDataTestHelper.swift
+++ b/CareNoteTests/TestHelpers/SwiftDataTestHelper.swift
@@ -4,11 +4,17 @@ import SwiftData
 
 /// Process-wide shared ModelContainer for CareNoteTests.
 ///
-/// SwiftData SIGTRAPs when the same `@Model` type is registered in multiple
-/// `ModelContainer`s within one process. Per-test containers therefore cannot
-/// coexist with the host app's container (Issue #141). This shared container
-/// is created lazily once per process and reused by every test; isolation is
-/// provided by `cleanup()` which removes all records before each test.
+/// Reuses one container for all tests because SwiftData SIGTRAPs when the
+/// same `@Model` type is registered in multiple `ModelContainer`s within
+/// one process (Issue #141). `cleanup()` empties the store between tests
+/// instead of reallocating, which would re-trigger the SIGTRAP.
+///
+/// Diagnostic contract (Issue #170 H2/H3): container-init `fatalError` and
+/// per-model `cleanup()` failures both route through `formatNSError` so the
+/// `NSError` shape that names the offending `@Model` on schema drift is
+/// never lost. Without this, a partial cleanup or a drift crash surfaces
+/// only as `delete(model:)` / `ModelContainer(for:)` throwing — with no
+/// indication of which type is at fault.
 @MainActor
 enum SharedTestModelContainer {
     static let shared: ModelContainer = {
@@ -21,19 +27,50 @@ enum SharedTestModelContainer {
                 configurations: config
             )
         } catch {
-            fatalError("Failed to create SharedTestModelContainer: \(error)")
+            fatalError("Failed to create SharedTestModelContainer.\n\(formatNSError(error))")
         }
     }()
 
-    /// Reset to an empty store without reallocating the container itself —
-    /// reallocation would trigger the SIGTRAP this helper exists to avoid.
     static func cleanup() throws {
         let context = shared.mainContext
-        try context.delete(model: RecordingRecord.self)
-        try context.delete(model: OutboxItem.self)
-        try context.delete(model: ClientCache.self)
-        try context.delete(model: OutputTemplate.self)
-        try context.save()
+        try delete(RecordingRecord.self, in: context)
+        try delete(OutboxItem.self, in: context)
+        try delete(ClientCache.self, in: context)
+        try delete(OutputTemplate.self, in: context)
+        do {
+            try context.save()
+        } catch {
+            reportCleanupFailure(model: "save()", error: error)
+            throw error
+        }
+    }
+
+    private static func delete<Model: PersistentModel>(
+        _ type: Model.Type,
+        in context: ModelContext
+    ) throws {
+        do {
+            try context.delete(model: type)
+        } catch {
+            reportCleanupFailure(model: String(describing: type), error: error)
+            throw error
+        }
+    }
+
+    private static func reportCleanupFailure(model: String, error: Error) {
+        let message = "SharedTestModelContainer.cleanup() failed for \(model).\n\(formatNSError(error))\n"
+        FileHandle.standardError.write(Data(message.utf8))
+    }
+
+    private static func formatNSError(_ error: Error) -> String {
+        let ns = error as NSError
+        return """
+              domain: \(ns.domain)
+              code: \(ns.code)
+              description: \(ns.localizedDescription)
+              userInfo: \(ns.userInfo)
+              raw: \(error)
+            """
     }
 }
 

--- a/CareNoteTests/TestHelpers/SwiftDataTestHelperTests.swift
+++ b/CareNoteTests/TestHelpers/SwiftDataTestHelperTests.swift
@@ -1,0 +1,50 @@
+@testable import CareNote
+import Foundation
+import Testing
+
+/// Pins the diagnostic string shape produced by `SharedTestModelContainer.formatNSError`.
+///
+/// A typo in the interpolation template (missing key, wrong label) would
+/// silently degrade the very signal Issue #170 H2/H3 adds: the offending
+/// `@Model` type name + `NSError` shape on cleanup failure / schema drift.
+/// Integration tests that inject a cleanup failure live in the H5
+/// follow-up PR — the format function itself is pure and pinned here.
+@MainActor
+@Suite("SharedTestModelContainer formatNSError")
+struct SwiftDataTestHelperTests {
+
+    @Test("formatNSError surfaces domain, code, description, and userInfo")
+    func formatNSError_includesAllNSErrorFields() {
+        let error = NSError(
+            domain: "TestDomain.SchemaDrift",
+            code: 4242,
+            userInfo: [
+                NSLocalizedDescriptionKey: "model registration mismatch",
+                "NSUnderlyingError": "stub-underlying",
+                "offendingModel": "OutboxItem"
+            ]
+        )
+
+        let formatted = SharedTestModelContainer.formatNSError(error)
+
+        #expect(formatted.contains("TestDomain.SchemaDrift"))
+        #expect(formatted.contains("4242"))
+        #expect(formatted.contains("model registration mismatch"))
+        #expect(formatted.contains("offendingModel"))
+        #expect(formatted.contains("OutboxItem"))
+        #expect(formatted.contains("stub-underlying"))
+    }
+
+    @Test("formatNSError labels every NSError field for grep-ability")
+    func formatNSError_hasLabeledFields() {
+        let error = NSError(domain: "X", code: 0, userInfo: [:])
+
+        let formatted = SharedTestModelContainer.formatNSError(error)
+
+        #expect(formatted.contains("domain:"))
+        #expect(formatted.contains("code:"))
+        #expect(formatted.contains("description:"))
+        #expect(formatted.contains("userInfo:"))
+        #expect(formatted.contains("raw:"))
+    }
+}


### PR DESCRIPTION
## Summary
- `SharedTestModelContainer.cleanup()` に per-model 失敗ログ追加（H2、silent-failure-hunter Critical conf 95）
- lazy init `fatalError` に NSError 詳細 unpack 追加（H3、High conf 80、schema drift 診断用）
- `formatNSError` helper で fatalError 側と cleanup 側の format を共通化（/simplify レビュー反映）

## Context

Issue #170 hardening bundle の H2/H3 のみを扱う partial PR。H1 は PR #173 で完了済。H4〜H6 は独立 follow-up PR（impl-plan v1 に記載）。

### Before
```swift
try context.delete(model: RecordingRecord.self)  // 失敗時にどの model か特定不能
...
fatalError("Failed to create SharedTestModelContainer: \(error)")  // NSError.userInfo が失われる
```

### After
- 各 `delete(model:)` と `save()` を個別 do-catch で wrap → 失敗時に model 名 + NSError (domain/code/description/userInfo/raw) を stderr 出力後 rethrow
- fail-fast 挙動は維持（first failure で短絡、partial cleanup の silent 蓄積なし）
- `fatalError` も同じ `formatNSError` を通過、schema drift で「どの型が missing か」が常に残る

## Test plan
- [x] 全 135 tests / 18 suites PASS（fail-fast 挙動の regression なし）
- [x] 20 回連続実行で全 PASS（race-free 検証、PR #173 の scheme parallelizable=NO を前提）
- [x] /simplify 3 並列レビュー（reuse/quality/efficiency）: 指摘 2 件反映、残 2 件は意図的見送り
- [x] /safe-refactor: 追加問題 0 件
- [ ] CI (GitHub Actions) green（push 後確認）

## Acceptance Criteria

| AC | 内容 | 検証 |
|----|------|------|
| AC-A1 | cleanup() 失敗時、stderr に model 名 + NSError.domain/code/description/userInfo が出力 | コード review + unit test は H5 で整備予定 |
| AC-A2 | fail-fast 維持（first failure で短絡） | コード review（`try delete(...)` の plain try 使用） |
| AC-A3 | fatalError に NSError 詳細 | 手動確認（意図的 schema drift で message 内容確認）+ コメント化 |
| AC-A4 | 既存 135 test PASS | 20 回連続実行 all green |

## Notes
- Partial fix: Refs #170（H2/H3 のみ）。close は H4-H6 完了時
- impl-plan v1: https://github.com/system-279/carenote-ios/issues/170#issuecomment-4308689214

🤖 Generated with [Claude Code](https://claude.com/claude-code)