### PR TITLE
fix(ci): #170 H6 — lint-model-container 強化 + xcodegen→lint 順序修正

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,6 +37,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # XcodeGen must run BEFORE the lint steps so the schemes they audit
+      # reflect what xcodebuild will actually consume (Issue #170 H6).
+      # Running lint on the committed .xcscheme before regeneration would
+      # miss a case where project.yml and the committed scheme diverge —
+      # the lint could pass on a stale scheme that xcodegen then rewrites.
+      - name: Install XcodeGen
+        run: brew install xcodegen
+
+      - name: Generate Xcode project
+        run: xcodegen generate
+
       - name: Lint - SwiftData schema drift guard (Issue #165)
         run: bash scripts/lint-model-container.sh
 
@@ -70,9 +81,6 @@ jobs:
           echo "::error::Failed to install iOS simulator runtime after $MAX_ATTEMPTS attempts"
           exit 1
 
-      - name: Install XcodeGen
-        run: brew install xcodegen
-
       - name: Cache SPM packages
         uses: actions/cache@v4
         with:
@@ -82,9 +90,6 @@ jobs:
           key: ${{ runner.os }}-spm-${{ hashFiles('project.yml') }}
           restore-keys: |
             ${{ runner.os }}-spm-
-
-      - name: Generate Xcode project
-        run: xcodegen generate
 
       - name: Boot Simulator
         run: |

--- a/scripts/lint-model-container.sh
+++ b/scripts/lint-model-container.sh
@@ -31,9 +31,14 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT"
 
 # Files allowed to construct `ModelContainer(for:)`. Keep this list minimal;
-# every entry must be justified in a comment that points to the tracking Issue.
+# every entry MUST be preceded by an `# Issue #NNN:` justification comment
+# (enforced by Pre-flight 3 below) that points to the tracking Issue — when
+# someone hits a cross-suite regression like Issue #164 and is tempted to
+# whitelist a new file, the comment requirement forces them to first record
+# the investigation in a new Issue instead of silently expanding the allow-
+# list and losing the drift-guard coverage.
 ALLOWED_TEST_FILES=(
-  # Canonical shared container (PR #163 root-cause fix for Issue #141).
+  # Issue #141: Canonical shared container (PR #163 root-cause fix).
   "CareNoteTests/TestHelpers/SwiftDataTestHelper.swift"
 )
 
@@ -67,6 +72,50 @@ for allowed in "${ALLOWED_TEST_FILES[@]}"; do
   fi
 done
 
+# Pre-flight 3: each allowed entry must be preceded by an `# Issue #NNN:`
+# comment. Without this, a future engineer hitting a cross-suite regression
+# (Issue #164 style) can silently expand the allow-list with a vague `# TODO`
+# comment, erasing the drift-guard coverage without leaving an investigation
+# trail. The check scans this very script so the policy is self-enforcing.
+# Pattern: find the ALLOWED_TEST_FILES=( block, then assert every quoted
+# entry's preceding non-blank line starts with `# Issue #`.
+missing_issue_refs=$(
+  perl -0777 -ne '
+    my @lines = split /\n/;
+    my $in_list = 0;
+    my $prev_comment = "";
+    for my $line (@lines) {
+      if ($line =~ /^ALLOWED_TEST_FILES=\(/) { $in_list = 1; next; }
+      if ($in_list && $line =~ /^\)/) { last; }
+      if ($in_list) {
+        # Quoted entry line (whitelisted file path)
+        if ($line =~ /^\s*"([^"]+)"/) {
+          my $entry = $1;
+          if ($prev_comment !~ /^\s*#\s*Issue\s*#\d+:/i) {
+            print "$entry\n";
+          }
+        }
+        # Track the last non-blank comment line for the next entry
+        if ($line =~ /^\s*#/) { $prev_comment = $line; }
+        elsif ($line =~ /^\s*$/) { } # blank: keep prev_comment
+        else { $prev_comment = ""; }
+      }
+    }
+  ' "$0"
+)
+if [ -n "$missing_issue_refs" ]; then
+  echo "::error::ALLOWED_TEST_FILES entries must be preceded by an '# Issue #NNN:' comment."
+  echo ""
+  echo "Entries without an Issue reference (add '# Issue #NNN: <justification>' above each):"
+  printf '%s\n' "$missing_issue_refs" | sed 's/^/  - /'
+  echo ""
+  echo "If you are whitelisting a new file because of a cross-suite regression"
+  echo "(Issue #164-style failure), FIRST open a new Issue with the investigation,"
+  echo "then reference that Issue number here. Silent expansion of the allow-list"
+  echo "erases the drift-guard coverage with no audit trail."
+  exit 1
+fi
+
 # Scan for violations: any *.swift under CareNoteTests/ (except allowed
 # ones) that contains the banned pattern. `perl -0777` slurps each file
 # so the pattern matches across newlines.
@@ -95,6 +144,16 @@ if [ -n "$violations" ]; then
   printf '%s\n' "$violations" | sed 's/^/  - /'
   echo ""
   echo "Fix: route tests through SharedTestModelContainer.shared instead."
+  echo ""
+  echo "If the offending file genuinely CANNOT use the shared container due to"
+  echo "a cross-suite regression (Issue #164-style failure where the shared"
+  echo "container's cleanup interacts badly with a specific test's timing):"
+  echo "  1. Open a new Issue documenting the regression investigation"
+  echo "     (repro steps, shared-container hypotheses tried, root cause)."
+  echo "  2. Add the file to ALLOWED_TEST_FILES in this script with a"
+  echo "     preceding '# Issue #NNN: <one-line justification>' comment."
+  echo "  3. Do NOT add a file to the whitelist without an Issue reference —"
+  echo "     Pre-flight 3 will reject it."
   exit 1
 fi
 

--- a/scripts/lint-model-container.sh
+++ b/scripts/lint-model-container.sh
@@ -32,11 +32,17 @@ cd "$ROOT"
 
 # Files allowed to construct `ModelContainer(for:)`. Keep this list minimal;
 # every entry MUST be preceded by an `# Issue #NNN:` justification comment
-# (enforced by Pre-flight 3 below) that points to the tracking Issue — when
-# someone hits a cross-suite regression like Issue #164 and is tempted to
-# whitelist a new file, the comment requirement forces them to first record
-# the investigation in a new Issue instead of silently expanding the allow-
-# list and losing the drift-guard coverage.
+# (enforced by Pre-flight 3 below).
+#
+# Cross-suite regression pattern (the reason this comment policy exists):
+# when a test fails only because it shares a `ModelContainer` with the rest
+# of the suite — e.g. its `cleanup()` races with a sibling suite's state, or
+# its `@Model` relationship semantics conflict with another test's fixtures
+# — an engineer may be tempted to silently add the file to this allow-list.
+# That would erase the drift-guard coverage (Issue #141, SIGTRAP on
+# duplicate registration) with no audit trail. Issue #164 is the canonical
+# example of this pattern. The `# Issue #NNN:` requirement forces the
+# investigation to be recorded in a new Issue before the allow-list expands.
 ALLOWED_TEST_FILES=(
   # Issue #141: Canonical shared container (PR #163 root-cause fix).
   "CareNoteTests/TestHelpers/SwiftDataTestHelper.swift"
@@ -72,15 +78,29 @@ for allowed in "${ALLOWED_TEST_FILES[@]}"; do
   fi
 done
 
+# Pre-flight 3 meta-guard: the `ALLOWED_TEST_FILES=(` declaration must exist
+# in this script, otherwise a future refactor that renames the array (typo
+# or reorg) would silently disable the whole whitelist audit — the perl
+# parser below would find no entries and report "clean".
+if ! grep -q '^ALLOWED_TEST_FILES=(' "$0"; then
+  echo "::error::ALLOWED_TEST_FILES=( declaration not found in $0 — audit broken."
+  echo "If the array was renamed, update Pre-flight 3's grep + perl pattern in sync."
+  exit 1
+fi
+
 # Pre-flight 3: each allowed entry must be preceded by an `# Issue #NNN:`
-# comment. Without this, a future engineer hitting a cross-suite regression
-# (Issue #164 style) can silently expand the allow-list with a vague `# TODO`
-# comment, erasing the drift-guard coverage without leaving an investigation
-# trail. The check scans this very script so the policy is self-enforcing.
+# comment (see the cross-suite regression pattern note above the array).
+# The check scans this very script so the policy is self-enforcing.
 # Pattern: find the ALLOWED_TEST_FILES=( block, then assert every quoted
-# entry's preceding non-blank line starts with `# Issue #`.
-missing_issue_refs=$(
-  perl -0777 -ne '
+# entry's immediately preceding non-blank line starts with `# Issue #NNN:`.
+# Accepted: `# Issue #141: justification text` (case-insensitive, colon required)
+# Rejected: `# See issue 141`, `# TODO: fix later`, `# NOTE: issue #141`
+#
+# bash 3.2 note: `set -e` does NOT propagate failures from command
+# substitution, so a perl invocation that aborts silently would leave
+# $missing_issue_refs empty and Pre-flight 3 would pass. Run perl through
+# an explicit exit-code check instead of relying on pipefail semantics.
+if ! missing_issue_refs=$(perl -0777 -ne '
     my @lines = split /\n/;
     my $in_list = 0;
     my $prev_comment = "";
@@ -95,14 +115,18 @@ missing_issue_refs=$(
             print "$entry\n";
           }
         }
-        # Track the last non-blank comment line for the next entry
+        # Strict adjacency: only the IMMEDIATELY preceding comment line
+        # counts. Blank lines reset prev_comment so a far-away comment
+        # cannot be mistakenly paired with a new entry.
         if ($line =~ /^\s*#/) { $prev_comment = $line; }
-        elsif ($line =~ /^\s*$/) { } # blank: keep prev_comment
         else { $prev_comment = ""; }
       }
     }
-  ' "$0"
-)
+  ' "$0" 2>&1); then
+  echo "::error::Pre-flight 3 perl parser failed (exit status $?). Audit not enforced."
+  echo "Output: $missing_issue_refs"
+  exit 1
+fi
 if [ -n "$missing_issue_refs" ]; then
   echo "::error::ALLOWED_TEST_FILES entries must be preceded by an '# Issue #NNN:' comment."
   echo ""


### PR DESCRIPTION
## Summary
- `lint-model-container.sh` に Pre-flight 3 追加: ALLOWED_TEST_FILES の各 entry に `# Issue #NNN:` 参照コメントを強制
- エラーメッセージに「regression を踏んだら新 Issue 起票 → 参照付き whitelist 追加」の 3 ステップガイダンス明示
- `.github/workflows/test.yml` の step 順序を xcodegen → lint に変更（PR #173 Evaluator MEDIUM 対応）

## Context

Issue #170 hardening bundle の H6 partial PR。H1 (PR #173) / H2/H3 (PR #185) 済。残: H4 / H5。

### Motivation
1. Issue #164 型の cross-suite regression を踏んだ際、silent に ALLOWED_TEST_FILES に追加して drift-guard カバーが消える経路があった
2. xcodegen → lint 順序が逆で、project.yml と commit 済 scheme の divergence を見逃す経路があった

### Before / After (scripts)
```bash
# Before: コメント欠落でも通る
ALLOWED_TEST_FILES=(
  "CareNoteTests/SomeFile.swift"  # comment なし可
)

# After: Pre-flight 3 が `# Issue #NNN:` を強制
ALLOWED_TEST_FILES=(
  # Issue #141: Canonical shared container (PR #163 root-cause fix).
  "CareNoteTests/TestHelpers/SwiftDataTestHelper.swift"
)
```

### Before / After (CI)
```yaml
# Before
- checkout
- lint-model-container.sh    # ← commit 済 scheme に対して lint
- lint-scheme-parallel.sh
- Setup Xcode
- ...
- xcodegen generate          # ← lint 後に再生成

# After
- checkout
- Install XcodeGen
- xcodegen generate          # ← 先に再生成
- lint-model-container.sh    # ← 最新 scheme に対して lint
- lint-scheme-parallel.sh
- Setup Xcode
- ...
```

## Test plan
- [x] lint self-test 4 種: Issue コメント欠落 / whitelist entry 削除 / 違反ファイル挿入 / 正常系 すべて PASS
- [x] ローカル bash self-test（bash 3.2 互換確認: perl slurp モードで `mapfile` 不使用）
- [ ] CI (GitHub Actions) green（push 後確認）

## Acceptance Criteria

| AC | 内容 | 結果 |
|----|------|------|
| AC-D1 | lint 文言に Issue 参照要求 | PASS（3 ステップガイダンス明示） |
| AC-D2 | 各 entry が `# Issue #NNN:` 形式を必須 | PASS（Pre-flight 3 で perl check） |
| AC-D3 | xcodegen → lint-model-container 順序 | PASS（test.yml step 順序変更） |
| AC-D4 | lint self-test 3 種 + 正常系 PASS | PASS（4 種 self-test 全 green） |

## Notes
- Partial fix: Refs #170（H6 のみ）。close は H4 + H5 完了時
- impl-plan v2（PR B/C 詳細）: https://github.com/system-279/carenote-ios/issues/170#issuecomment-4309204177

🤖 Generated with [Claude Code](https://claude.com/claude-code)