### PR TITLE
fix(test): #170 H4 — processQueueImmediately 系 test に preflight assertion 追加

### DIFF
--- a/CareNoteTests/OutboxSyncServiceTests.swift
+++ b/CareNoteTests/OutboxSyncServiceTests.swift
@@ -338,6 +338,7 @@ struct OutboxSyncServiceTests {
         ))
         context.insert(OutboxItem(recordingId: recordingId))
         try context.save()
+        try Self.assertPreflightState(context: context, audioPath: audioPath)
 
         try await service.processQueueImmediately()
 
@@ -383,6 +384,7 @@ struct OutboxSyncServiceTests {
         ))
         context.insert(OutboxItem(recordingId: recordingId))
         try context.save()
+        try Self.assertPreflightState(context: context, audioPath: audioPath)
 
         await #expect(throws: OutboxSyncError.self) {
             try await service.processQueueImmediately()
@@ -424,6 +426,7 @@ struct OutboxSyncServiceTests {
         ))
         context.insert(OutboxItem(recordingId: recordingId))
         try context.save()
+        try Self.assertPreflightState(context: context, audioPath: audioPath)
 
         await #expect(throws: OutboxSyncError.self) {
             try await service.processQueueImmediately()
@@ -469,6 +472,7 @@ struct OutboxSyncServiceTests {
         ))
         context.insert(OutboxItem(recordingId: recordingId))
         try context.save()
+        try Self.assertPreflightState(context: context, audioPath: audioPath)
 
         // OutboxSyncService は原因 error を `OutboxSyncError.uploadFailed(_)` で wrap して throw する。
         await #expect(throws: OutboxSyncError.self) {
@@ -499,5 +503,39 @@ struct OutboxSyncServiceTests {
             .appendingPathComponent("test-audio-\(UUID().uuidString).m4a").path
         try Data().write(to: URL(fileURLWithPath: audioPath))
         return (container, audioPath)
+    }
+
+    /// processQueueImmediately 直前の不変条件を確認する preflight 検査（Issue #170 H4）。
+    /// 呼び出しは `try context.save()` の直後、`service.processQueueImmediately()` の直前。
+    ///
+    /// Fail したら test infra 側（cleanup 残留 / save 未 flush / audio file 欠落）の問題で、
+    /// service 実装は無関係と切り分けられる — service 呼出後の assertion が fail した場合は
+    /// service 実装（uid 分岐 / upload 順序 / throw 経路）側に絞り込める。
+    ///
+    /// - Throws: `fetchCount` の失敗時のみ。assertion 失敗は `#expect` 経由で報告されるため
+    ///   call site の `try` は fetch error 伝播のみを意味する。
+    @MainActor
+    private static func assertPreflightState(
+        context: ModelContext,
+        audioPath: String,
+        sourceLocation: SourceLocation = #_sourceLocation
+    ) throws {
+        let outboxCount = try context.fetchCount(FetchDescriptor<OutboxItem>())
+        let recordingCount = try context.fetchCount(FetchDescriptor<RecordingRecord>())
+        #expect(
+            outboxCount == 1,
+            "Preflight: OutboxItem count == 1 expected, got \(outboxCount) (cleanup 残留 / save 未 flush)",
+            sourceLocation: sourceLocation
+        )
+        #expect(
+            recordingCount == 1,
+            "Preflight: RecordingRecord count == 1 expected, got \(recordingCount) (cleanup 残留 / save 未 flush)",
+            sourceLocation: sourceLocation
+        )
+        #expect(
+            FileManager.default.fileExists(atPath: audioPath),
+            "Preflight: audio file must exist at \(audioPath) (stale-item guard を通過させるため必須)",
+            sourceLocation: sourceLocation
+        )
     }
 }

--- a/CareNoteTests/OutboxSyncServiceTests.swift
+++ b/CareNoteTests/OutboxSyncServiceTests.swift
@@ -338,6 +338,7 @@ struct OutboxSyncServiceTests {
         ))
         context.insert(OutboxItem(recordingId: recordingId))
         try context.save()
+        // H4 preflight (Issue #170) — removing this weakens diagnostic for #164-style regressions.
         try Self.assertPreflightState(context: context, audioPath: audioPath)
 
         try await service.processQueueImmediately()
@@ -384,6 +385,7 @@ struct OutboxSyncServiceTests {
         ))
         context.insert(OutboxItem(recordingId: recordingId))
         try context.save()
+        // H4 preflight (Issue #170) — removing this weakens diagnostic for #164-style regressions.
         try Self.assertPreflightState(context: context, audioPath: audioPath)
 
         await #expect(throws: OutboxSyncError.self) {
@@ -426,6 +428,7 @@ struct OutboxSyncServiceTests {
         ))
         context.insert(OutboxItem(recordingId: recordingId))
         try context.save()
+        // H4 preflight (Issue #170) — removing this weakens diagnostic for #164-style regressions.
         try Self.assertPreflightState(context: context, audioPath: audioPath)
 
         await #expect(throws: OutboxSyncError.self) {
@@ -472,6 +475,7 @@ struct OutboxSyncServiceTests {
         ))
         context.insert(OutboxItem(recordingId: recordingId))
         try context.save()
+        // H4 preflight (Issue #170) — removing this weakens diagnostic for #164-style regressions.
         try Self.assertPreflightState(context: context, audioPath: audioPath)
 
         // OutboxSyncService は原因 error を `OutboxSyncError.uploadFailed(_)` で wrap して throw する。
@@ -512,16 +516,30 @@ struct OutboxSyncServiceTests {
     /// service 実装は無関係と切り分けられる — service 呼出後の assertion が fail した場合は
     /// service 実装（uid 分岐 / upload 順序 / throw 経路）側に絞り込める。
     ///
+    /// `SharedTestModelContainer.cleanup()` の stderr diagnostic（PR #185）が CI 環境で
+    /// 埋もれても、ここの count 検証で cleanup 残留（count > 1）を捕捉できる backup 経路。
+    ///
     /// - Throws: `fetchCount` の失敗時のみ。assertion 失敗は `#expect` 経由で報告されるため
-    ///   call site の `try` は fetch error 伝播のみを意味する。
+    ///   call site の `try` は fetch error 伝播のみを意味する。fetch error の場合も
+    ///   `Issue.record` で「preflight が fetch 段階で壊れた」旨を残してから rethrow する。
     @MainActor
     private static func assertPreflightState(
         context: ModelContext,
         audioPath: String,
         sourceLocation: SourceLocation = #_sourceLocation
     ) throws {
-        let outboxCount = try context.fetchCount(FetchDescriptor<OutboxItem>())
-        let recordingCount = try context.fetchCount(FetchDescriptor<RecordingRecord>())
+        let outboxCount: Int
+        let recordingCount: Int
+        do {
+            outboxCount = try context.fetchCount(FetchDescriptor<OutboxItem>())
+            recordingCount = try context.fetchCount(FetchDescriptor<RecordingRecord>())
+        } catch {
+            Issue.record(
+                "Preflight fetch failed — test infra broken (ModelContext unusable before service call): \(error)",
+                sourceLocation: sourceLocation
+            )
+            throw error
+        }
         #expect(
             outboxCount == 1,
             "Preflight: OutboxItem count == 1 expected, got \(outboxCount) (cleanup 残留 / save 未 flush)",


### PR DESCRIPTION
## Summary
- `OutboxSyncServiceTests` の 4 つの processQueueImmediately 系 test に preflight assertion 追加
- 新設 `assertPreflightState(context:audioPath:)` helper で 3 種 assertion を共通化（OutboxItem count / RecordingRecord count / audio file existence）
- Issue #164 型 cross-suite regression が再発した場合の診断切り分け支援

## Context

Issue #170 hardening bundle の H4 partial PR。H1 (#173) / H2/H3 (#185) / H6 (#186) 済。残: H5。

### 動機
前回 Issue #164 で発生した regression では `uploadCalls.count → 0 == 1` という失敗が出たが、原因候補が複数あり切り分け困難だった:
1. `.serialized` + `@MainActor` hop のタイミング → PR #173 で構造的に抑止済
2. `SharedTestModelContainer.cleanup()` の pending change 残留
3. 他 suite が shared container に残した OutboxItem 先行 consume
4. SwiftData の `delete(model:)` relationship cascade タイミング

preflight assertion が fail すれば問題は **test infra 側（2/3/4）**、pass して service 呼出後に fail すれば **service 実装側（uid 分岐 / upload 順序 / throw 経路）** と即座に切り分け可能。

### Before/After
```swift
// Before
context.insert(OutboxItem(recordingId: recordingId))
try context.save()

try await service.processQueueImmediately()  // 全 stub が呼ばれないまま 0 件 fail

// After
context.insert(OutboxItem(recordingId: recordingId))
try context.save()
try Self.assertPreflightState(context: context, audioPath: audioPath)  // ← 先に不変条件確認

try await service.processQueueImmediately()
```

## Test plan
- [x] 全 137 tests / 19 suites PASS（regression 0）
- [x] 20 回連続実行で全 PASS（race-free 検証、PR #173 scheme parallelizable=NO 前提）
- [x] /simplify 3 並列レビュー: Efficiency `fetchCount` 切替 / Quality Important doc 圧縮 反映
- [ ] CI (GitHub Actions) green（push 後確認）

## Acceptance Criteria

| AC | 内容 | 結果 |
|----|------|------|
| AC-B1 | 4 test の save 後に 3 種 assertion 追加 | PASS |
| AC-B2 | preflight 失敗時に service 呼出前の診断切り分け可能 | PASS（doc comment で明記、helper の throws/＃expect 分離） |
| AC-B3 | 20 回連続実行で全 PASS | PASS |

## 設計判断

- **`fetchCount` 使用**: object hydration 回避 / regression で大量 stale row が出た時のスケール
- **`throws` は fetchCount 失敗のみ**: assertion 失敗は `#expect` 経由で報告、call site の `try` は fetch error 伝播のみ（doc に明記）
- **fail-fast ではなく 3 assertion 並列**: どの不変条件が崩れたか一度に把握（診断価値を最大化）
- **`#_sourceLocation` default 引数**: fail 時に helper 行ではなく呼出元 test を指す

## Notes
- Partial fix: Refs #170（H4 のみ）。close は H5 完了時
- impl-plan v2 (PR B/C 詳細): https://github.com/system-279/carenote-ios/issues/170#issuecomment-4309204177

🤖 Generated with [Claude Code](https://claude.com/claude-code)