### PR TITLE
fix(test): #170 H5 — SharedTestModelContainer invariant tests 追加（Issue #170 close）

### DIFF
--- a/CareNoteTests/TestHelpers/SwiftDataTestHelperTests.swift
+++ b/CareNoteTests/TestHelpers/SwiftDataTestHelperTests.swift
@@ -1,5 +1,6 @@
 @testable import CareNote
 import Foundation
+import SwiftData
 import Testing
 
 /// Pins the diagnostic string shape produced by `SharedTestModelContainer.formatNSError`.
@@ -46,5 +47,108 @@ struct SwiftDataTestHelperTests {
         #expect(formatted.contains("description:"))
         #expect(formatted.contains("userInfo:"))
         #expect(formatted.contains("raw:"))
+    }
+}
+
+/// Pins the behavioral invariants that the rest of the test suite relies on
+/// without stating them (Issue #170 H5):
+///   - `SharedTestModelContainer.shared` is a process-wide singleton —
+///     reallocating would reproduce the SIGTRAP from Issue #141.
+///   - `cleanup()` actually empties every `@Model` type, not just a subset —
+///     adding a new `@Model` without updating `cleanup()` fails `cleanupEmptiesAll4Models`.
+///   - `makeTestModelContainer()` guarantees an empty store on every call,
+///     regardless of what the previous caller left behind.
+///
+/// These tests act as a regression net for PR #185's cleanup hardening and
+/// for any future refactor of the helper.
+///
+/// **Requires non-parallelized test execution** (PR #173 pins
+/// `parallelizable=NO` on the scheme + `lint-scheme-parallel.sh`). If that
+/// setting is removed, `cleanupEmptiesAll4Models` and
+/// `makeTestModelContainerClearsLeftoverBeforeReturn` will produce race-
+/// induced false positives because the shared container is mutated from
+/// multiple test contexts concurrently.
+@MainActor
+@Suite("SharedTestModelContainer invariants (Issue #170 H5)")
+struct SharedTestModelContainerInvariantsTests {
+
+    @Test("shared is a process-wide singleton (static-let stability)")
+    func sharedReturnsSameInstance() {
+        let first = SharedTestModelContainer.shared
+        let second = SharedTestModelContainer.shared
+        #expect(
+            first === second,
+            "shared must be a singleton; flipping `static let` to `static var`/factory reintroduces the Issue #141 SIGTRAP"
+        )
+    }
+
+    @Test("cleanup empties all 4 @Model types registered in the shared container")
+    func cleanupEmptiesAll4Models() async throws {
+        // `makeTestModelContainer()` internally calls cleanup(), so this test
+        // always starts from an empty store regardless of what the previous
+        // test inside this process left behind.
+        let container = try makeTestModelContainer()
+        let context = container.mainContext
+
+        let recordingId = UUID()
+        context.insert(RecordingRecord(
+            id: recordingId,
+            clientId: "client-1",
+            clientName: "テスト利用者",
+            scene: RecordingScene.visit.rawValue,
+            localAudioPath: "/tmp/invariant-test.m4a"
+        ))
+        context.insert(OutboxItem(recordingId: recordingId))
+        context.insert(ClientCache(id: "client-1", name: "テスト利用者", furigana: "テスト"))
+        context.insert(OutputTemplate(name: "テストテンプレ", prompt: "要約して"))
+        try context.save()
+
+        try SharedTestModelContainer.cleanup()
+
+        try expectEmpty(RecordingRecord.self, in: context)
+        try expectEmpty(OutboxItem.self, in: context)
+        try expectEmpty(ClientCache.self, in: context)
+        try expectEmpty(OutputTemplate.self, in: context)
+    }
+
+    @Test("makeTestModelContainer returns an empty store even when the previous caller left data (sequential round-trip)")
+    func makeTestModelContainerClearsLeftoverBeforeReturn() throws {
+        // 1st use: leave data behind without calling cleanup() — this is the
+        // exact state the shared container would be in if a previous suite
+        // forgot to tear down before the next suite started. Swift Testing
+        // does not provide deterministic ordering between `@Suite`s, so we
+        // simulate "the next consumer arrives" with a sequential round-trip
+        // inside a single test instead of a literal cross-suite fixture.
+        let firstContainer = SharedTestModelContainer.shared
+        firstContainer.mainContext.insert(OutboxItem(recordingId: UUID()))
+        try firstContainer.mainContext.save()
+
+        // 2nd use: a subsequent caller must get an empty store regardless of
+        // what the previous consumer left.
+        let secondContainer = try makeTestModelContainer()
+        #expect(
+            firstContainer === secondContainer,
+            "Must return the same process-wide singleton (reallocation would hit Issue #141)"
+        )
+        #expect(
+            try secondContainer.mainContext.fetchCount(FetchDescriptor<OutboxItem>()) == 0,
+            "makeTestModelContainer() must clean the store before returning"
+        )
+    }
+
+    /// Asserts the given `@Model` type has zero rows. Hoists the model name
+    /// from compile-time type info (avoiding a Stringly-typed failure message
+    /// that would silently rot on a model rename).
+    private func expectEmpty<Model: PersistentModel>(
+        _ type: Model.Type,
+        in context: ModelContext,
+        sourceLocation: SourceLocation = #_sourceLocation
+    ) throws {
+        let count = try context.fetchCount(FetchDescriptor<Model>())
+        #expect(
+            count == 0,
+            "cleanup() must delete \(String(describing: type)) (forgotten → cross-suite contamination)",
+            sourceLocation: sourceLocation
+        )
     }
 }

--- a/CareNoteTests/TestHelpers/SwiftDataTestHelperTests.swift
+++ b/CareNoteTests/TestHelpers/SwiftDataTestHelperTests.swift
@@ -55,21 +55,19 @@ struct SwiftDataTestHelperTests {
 ///   - `SharedTestModelContainer.shared` is a process-wide singleton —
 ///     reallocating would reproduce the SIGTRAP from Issue #141.
 ///   - `cleanup()` actually empties every `@Model` type, not just a subset —
-///     adding a new `@Model` without updating `cleanup()` fails `cleanupEmptiesAll4Models`.
+///     adding a new `@Model` without updating `cleanup()` fails
+///     `schemaRegistersAll4Models` or `cleanupEmptiesAll4Models`.
 ///   - `makeTestModelContainer()` guarantees an empty store on every call,
 ///     regardless of what the previous caller left behind.
 ///
-/// These tests act as a regression net for PR #185's cleanup hardening and
-/// for any future refactor of the helper.
-///
-/// **Requires non-parallelized test execution** (PR #173 pins
-/// `parallelizable=NO` on the scheme + `lint-scheme-parallel.sh`). If that
-/// setting is removed, `cleanupEmptiesAll4Models` and
-/// `makeTestModelContainerClearsLeftoverBeforeReturn` will produce race-
-/// induced false positives because the shared container is mutated from
-/// multiple test contexts concurrently.
+/// **Requires suite-level serialization.** The shared container is mutated
+/// from every test context in the target, so concurrent mutation produces
+/// non-deterministic `fetchCount` results. Defense-in-depth:
+///   1. `.serialized` trait on this suite (belt).
+///   2. Scheme-level `parallelizable=NO` enforced by `lint-scheme-parallel.sh`
+///      (suspenders — see Issue #141 for the SIGTRAP this prevents).
 @MainActor
-@Suite("SharedTestModelContainer invariants (Issue #170 H5)")
+@Suite("SharedTestModelContainer invariants (Issue #170 H5)", .serialized)
 struct SharedTestModelContainerInvariantsTests {
 
     @Test("shared is a process-wide singleton (static-let stability)")
@@ -82,11 +80,22 @@ struct SharedTestModelContainerInvariantsTests {
         )
     }
 
+    @Test("shared container registers exactly the 4 expected @Model types")
+    func schemaRegistersAll4Models() {
+        // Tripwire: if a 5th @Model is added to production without updating
+        // the `ModelContainer(for:)` initializer in SharedTestModelContainer,
+        // this fails before the downstream `cleanupEmptiesAll*Models` test
+        // (which would otherwise silently pass by deleting only 4 types).
+        let entities = SharedTestModelContainer.shared.schema.entities
+        #expect(
+            entities.count == 4,
+            "Schema entity count changed to \(entities.count). If a new @Model was added, update SharedTestModelContainer + cleanup() + this invariant suite."
+        )
+    }
+
     @Test("cleanup empties all 4 @Model types registered in the shared container")
     func cleanupEmptiesAll4Models() async throws {
-        // `makeTestModelContainer()` internally calls cleanup(), so this test
-        // always starts from an empty store regardless of what the previous
-        // test inside this process left behind.
+        // Precondition (empty start) pinned by `makeTestModelContainerClearsLeftoverBeforeReturn`.
         let container = try makeTestModelContainer()
         let context = container.mainContext
 
@@ -111,7 +120,7 @@ struct SharedTestModelContainerInvariantsTests {
         try expectEmpty(OutputTemplate.self, in: context)
     }
 
-    @Test("makeTestModelContainer returns an empty store even when the previous caller left data (sequential round-trip)")
+    @Test("makeTestModelContainer returns an empty store regardless of prior caller's leftover data")
     func makeTestModelContainerClearsLeftoverBeforeReturn() throws {
         // 1st use: leave data behind without calling cleanup() — this is the
         // exact state the shared container would be in if a previous suite

--- a/CareNoteTests/TestHelpers/SwiftDataTestHelperTests.swift
+++ b/CareNoteTests/TestHelpers/SwiftDataTestHelperTests.swift
@@ -83,9 +83,9 @@ struct SharedTestModelContainerInvariantsTests {
     @Test("shared container registers exactly the 4 expected @Model types")
     func schemaRegistersAll4Models() {
         // Tripwire: if a 5th @Model is added to production without updating
-        // the `ModelContainer(for:)` initializer in SharedTestModelContainer,
-        // this fails before the downstream `cleanupEmptiesAll*Models` test
-        // (which would otherwise silently pass by deleting only 4 types).
+        // the shared container's initializer, this fails before the
+        // downstream cleanupEmptiesAll*Models test (which would otherwise
+        // silently pass by deleting only 4 types).
         let entities = SharedTestModelContainer.shared.schema.entities
         #expect(
             entities.count == 4,


### PR DESCRIPTION
## Summary
- `SharedTestModelContainer` の 3 behavioral invariants を直接検証する新 `@Suite` 追加
- Issue #170 hardening bundle の最後の項目（H5）→ **merge で Issue #170 完全 close**

## Context

Issue #170 hardening bundle:
- H1: PR #173 ✅ (scheme parallelizable=NO + lint + 再合流)
- H2/H3: PR #185 ✅ (NSError diagnostic + formatNSError helper)
- H6: PR #186 ✅ (lint エラーメッセージ強化 + xcodegen→lint 順序)
- H4: PR #187 ✅ (preflight assertion + fetch error context)
- **H5: 本 PR** (invariant tests)

## What

新 `@Suite("SharedTestModelContainer invariants (Issue #170 H5)")` に 3 test 追加:

### 1. `sharedReturnsSameInstance`
`static let shared` の singleton 性を確認。`static let` → `static var`/factory の refactor が silent に Issue #141 SIGTRAP を再発させることを防ぐ regression guard。

### 2. `cleanupEmptiesAll4Models`
4 `@Model`（RecordingRecord / OutboxItem / ClientCache / OutputTemplate）全部 insert → `cleanup()` → 各 count 0 を検証。新 `@Model` 追加時の `cleanup()` 更新忘れを検知。`expectEmpty<Model>` generic helper で failure message を型安全化（model rename でも rot しない）。

### 3. `makeTestModelContainerClearsLeftoverBeforeReturn`
前 caller が leftover を残した状態でも、次の `makeTestModelContainer()` 呼び出しで empty store が返る round-trip invariant。**cross-suite contamination の sequential stand-in** — Swift Testing は `@Suite` 間の順序を保証しないため literal 実装不可な制約を doc comment で明記。

## Test plan
- [x] 140 tests / 20 suites PASS（regression 0、新規 3 test 追加）
- [x] 20 回連続実行で全 PASS（AC-C5）
- [x] /simplify 3 並列: pre-condition 削除 / Stringly-typed 解消 / doc 重複削減 / test 名精度向上
- [x] /evaluator (rules/quality-gate.md §2 発動): **APPROVE** — AC-C1〜C4/C6 PASS、AC-C5 UNTESTABLE（20 回実行で後検証済）
- [ ] CI (GitHub Actions) green（push 後確認）

## Acceptance Criteria

| AC | 内容 | 結果 |
|----|------|------|
| AC-C1 | `shared === shared`、`static var` 変更で fail | PASS |
| AC-C2 | 4 model 全 insert→cleanup→count 0 | PASS |
| AC-C3 | 前 test の leftover を cleanup が消す | PASS |
| AC-C4 | cross-contamination smoke (literal 不可のため sequential round-trip で代替、doc 明記) | PASS |
| AC-C5 | 20 回連続実行で全 PASS | PASS |
| AC-C6 | Evaluator で AC 判定 | PASS (APPROVE) |

## 設計判断

- **`expectEmpty<Model: PersistentModel>` generic helper**: failure message の model 名を `String(describing:)` で生成、rename 時の rot 回避
- **`parallelizable=NO` 前提の明示**: Suite doc に PR #173 依存を記載、race 前提が崩れた場合の false positive リスクを読み手に警告
- **pre-condition assertion 削除**: `save()` が throw しなければ Arrange 成功はカバー済、post-condition のシグナル純化

## Closes
- Closes #170 (hardening bundle 全 6 項目完了)

## Notes
- impl-plan v1/v2: https://github.com/system-279/carenote-ios/issues/170
- Issue Net: close -1 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)