### PR TITLE
chore: Build 36 / v0.1.1 に同期（Build 36 TestFlight アップロード済み）

### DIFF
--- a/CareNote.xcodeproj/project.pbxproj
+++ b/CareNote.xcodeproj/project.pbxproj
@@ -675,7 +675,7 @@
 				CODE_SIGN_ENTITLEMENTS = CareNote/CareNote.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 35;
+				CURRENT_PROJECT_VERSION = 36;
 				DEVELOPMENT_TEAM = C96A7EHVW8;
 				GENERATE_INFOPLIST_FILE = NO;
 				GID_CLIENT_ID = "781674225072-ggct0s6glel3ma7isb79ge72mn8sbivj.apps.googleusercontent.com";
@@ -685,7 +685,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.1.0;
+				MARKETING_VERSION = 0.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = jp.carenote.app;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
@@ -775,7 +775,7 @@
 				CODE_SIGN_ENTITLEMENTS = CareNote/CareNote.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 35;
+				CURRENT_PROJECT_VERSION = 36;
 				DEVELOPMENT_TEAM = C96A7EHVW8;
 				GENERATE_INFOPLIST_FILE = NO;
 				GID_CLIENT_ID = "444137368705-6tppcletq10h3qhuprhafktpk5e2h1me.apps.googleusercontent.com";
@@ -785,7 +785,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.1.0;
+				MARKETING_VERSION = 0.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = jp.carenote.app;
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;

--- a/project.yml
+++ b/project.yml
@@ -27,8 +27,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: jp.carenote.app
-        MARKETING_VERSION: "0.1.0"
-        CURRENT_PROJECT_VERSION: "35"
+        MARKETING_VERSION: "0.1.1"
+        CURRENT_PROJECT_VERSION: "36"
         INFOPLIST_FILE: CareNote/Info.plist
         SWIFT_VERSION: "6.0"
         GENERATE_INFOPLIST_FILE: false


### PR DESCRIPTION
## Summary

Issue #182 (delete Firestore sync) 修正の TestFlight リリース。Build 36 が App Store Connect にアップロード完了済みのため、`project.yml` / `project.pbxproj` のバージョン番号を同期する。

## 主な変更（Build 35 → 36 の iOS アプリ差分、ユーザー体感）

| # | PR | 内容 |
|---|----|------|
| 1 | #191 (本日 merge) | **Issue #182**: 録音のスワイプ削除が Firestore にも同期され、再読込で復活しなくなる |
| 2 | #156 | Issue #91: アカウント削除後に端末内 SwiftData を purge |
| 3 | #158 | Issue #157: local purge 失敗時にユーザーへ通知 |

## Version bump 理由

- `MARKETING_VERSION` 0.1.0 は App Store Connect で closed（過去リリース済のバージョンは同じ番号で再提出不可）
- 初回 upload で以下のエラー: `The train version '0.1.0' is closed for new build submissions`
- semver の patch bump で **0.1.0 → 0.1.1** に変更して再 upload → 成功
- `CURRENT_PROJECT_VERSION` は 35 → 36 に自動インクリメント

## Upload 結果

- archive: **SUCCEEDED**
- export/upload: **SUCCEEDED** (`Uploaded CareNote` / `** EXPORT SUCCEEDED **`)
- Build 36 / v0.1.1 が App Store Connect processing 中
- dSYM 欠損 warning (FirebaseFirestoreInternal / absl / grpc / grpcpp / openssl_grpc) は既知で blocker ではない（過去の Build 35 upload でも同じ警告）

## Test plan

- [x] ローカル xcodebuild test 全 145 tests / 20 suites PASS（PR #191 merge 前）
- [x] archive / upload SUCCEEDED
- [ ] **次セッション**: TestFlight で Build 36 配布 → 実機 smoke（録音作成 → スワイプ削除 → Firebase Console で doc 消滅確認 → pull-to-refresh で復活しない）
- [ ] smoke PASS 後、Issue #182 を close（PR #191 merge で auto-close 済みの場合は再確認のみ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)