### PR TITLE
fix(ios): #194 polling silent catch を logger で可視化 (transient/permanent 分類)

### DIFF
--- a/CareNote.xcodeproj/project.pbxproj
+++ b/CareNote.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		4E553F6607752AD117DCE2E6 /* RecordingViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E51986CBBEC3607B0256C7A /* RecordingViewModelTests.swift */; };
 		4FF4C8E0919F05FD11606327 /* MockTemplateService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39111C77F72B0E1CD982EBF3 /* MockTemplateService.swift */; };
 		53F062DE9A557C10ABC064D2 /* ClientCacheServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97707E72915C49324CCC7394 /* ClientCacheServiceTests.swift */; };
+		5446D73FA2434C379F792573 /* FirestoreErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4868BF643DA1BB50626AEF76 /* FirestoreErrorTests.swift */; };
 		55BE8768F641C64BE1837884 /* ClientRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CCF73C9C8E3E2C08DD50815 /* ClientRepositoryTests.swift */; };
 		577059F7C878462433B3DC11 /* SignInView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED7A610D0269818D75C76641 /* SignInView.swift */; };
 		65E5E0CD5DBC914A92B91130 /* ClientSelectViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7452B80D90D9172B77475447 /* ClientSelectViewModel.swift */; };
@@ -108,6 +109,7 @@
 		43708B0DF054C4C514B8D58E /* AudioPlayerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioPlayerView.swift; sourceTree = "<group>"; };
 		46A7E7E108F739F5871EB716 /* TranscriptionServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptionServiceTests.swift; sourceTree = "<group>"; };
 		47604C61474A5EA44EABDF67 /* RecordingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingView.swift; sourceTree = "<group>"; };
+		4868BF643DA1BB50626AEF76 /* FirestoreErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirestoreErrorTests.swift; sourceTree = "<group>"; };
 		4A269AFC38F3097F4CDCF8DF /* SceneSelectView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneSelectView.swift; sourceTree = "<group>"; };
 		4D437E580EA429317272B4F9 /* WIFAuthServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WIFAuthServiceTests.swift; sourceTree = "<group>"; };
 		5145C7CB43880EF7C55A94B3 /* StorageService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageService.swift; sourceTree = "<group>"; };
@@ -298,6 +300,7 @@
 				6CCF73C9C8E3E2C08DD50815 /* ClientRepositoryTests.swift */,
 				2DD7DBB99EAE4823CA33FA82 /* ClientSelectViewModelTests.swift */,
 				7BD5333C19B8D05EBA8B140B /* EnumStableIdentifierTests.swift */,
+				4868BF643DA1BB50626AEF76 /* FirestoreErrorTests.swift */,
 				39111C77F72B0E1CD982EBF3 /* MockTemplateService.swift */,
 				042E6E584A73ED207A24A590 /* OutboxSyncServiceTests.swift */,
 				E0C0F8FB680432239DF40DE4 /* RecordingConfirmViewModelTests.swift */,
@@ -514,6 +517,7 @@
 				55BE8768F641C64BE1837884 /* ClientRepositoryTests.swift in Sources */,
 				EE6FD95E89E69854891FD11C /* ClientSelectViewModelTests.swift in Sources */,
 				F816CF04479CE47B08176B58 /* EnumStableIdentifierTests.swift in Sources */,
+				5446D73FA2434C379F792573 /* FirestoreErrorTests.swift in Sources */,
 				4FF4C8E0919F05FD11606327 /* MockTemplateService.swift in Sources */,
 				1BCD8566873712BD882EEFB3 /* MockURLProtocol.swift in Sources */,
 				C6072255D88F74D009713EF5 /* OutboxSyncServiceTests.swift in Sources */,

--- a/CareNote/Features/RecordingList/RecordingListViewModel.swift
+++ b/CareNote/Features/RecordingList/RecordingListViewModel.swift
@@ -246,11 +246,61 @@ final class RecordingListViewModel {
                 if remote.transcriptionStatus != recording.transcriptionStatus {
                     recording.transcriptionStatus = remote.transcriptionStatus
                     recording.transcription = remote.transcription
-                    try? recordingRepository.save()
+                    do {
+                        try recordingRepository.save()
+                    } catch {
+                        // SwiftData save 失敗は DB 整合性破壊の可能性 → permanent 扱いで UI surface
+                        Self.logger.error(
+                            "Polling save failed for recording \(recording.id, privacy: .public): \(error.localizedDescription, privacy: .public)"
+                        )
+                        errorMessage = "録音の更新を保存できませんでした"
+                    }
                 }
             } catch {
-                // ポーリングエラーは静かに無視（次回リトライ）
+                // Issue #194: silent catch 廃止。transient/permanent で分類してログする。
+                logPollingFetchError(recordingId: firestoreId, error: error)
             }
+        }
+    }
+
+    /// polling 中の Firestore fetch エラーを transient/permanent に分類してログする。
+    ///
+    /// - transient: 次回 polling (5s 間隔) で自動リトライされるため info レベル。
+    /// - permanent: DI 設定 / 権限 / スキーマ drift 等、開発者の介入が必要なため error レベル。
+    ///
+    /// 分類基準は `rules/error-handling.md` §3 の transient/permanent プロトコルに準拠。
+    private func logPollingFetchError(recordingId: String, error: Error) {
+        if isTransientFirestoreError(error) {
+            Self.logger.info(
+                "Polling fetchRecording transient error for \(recordingId, privacy: .public), will retry: \(error.localizedDescription, privacy: .public)"
+            )
+        } else {
+            Self.logger.error(
+                "Polling fetchRecording permanent error for \(recordingId, privacy: .public): \(error.localizedDescription, privacy: .public)"
+            )
+        }
+    }
+
+    /// Firestore エラーが transient（自動リトライで回復しうる）かを判定する。
+    ///
+    /// Firestore SDK のエラーコード (`FIRFirestoreErrorDomain`) のうち以下を transient 扱い:
+    /// - `4` deadlineExceeded: ネットワーク timeout
+    /// - `8` resourceExhausted: quota / rate limit
+    /// - `14` unavailable: Firestore backend 一時障害
+    ///
+    /// それ以外 (permissionDenied / unauthenticated / notFound / decoding 失敗等) は permanent。
+    private func isTransientFirestoreError(_ error: Error) -> Bool {
+        guard case let FirestoreError.operationFailed(underlying) = error else {
+            // FirestoreError 以外（decodingFailed 等、独自定義分）はすべて permanent 扱い
+            return false
+        }
+        let nsError = underlying as NSError
+        guard nsError.domain == "FIRFirestoreErrorDomain" else { return false }
+        switch nsError.code {
+        case 4, 8, 14:
+            return true
+        default:
+            return false
         }
     }
 }

--- a/CareNote/Features/RecordingList/RecordingListViewModel.swift
+++ b/CareNote/Features/RecordingList/RecordingListViewModel.swift
@@ -248,12 +248,17 @@ final class RecordingListViewModel {
                     recording.transcription = remote.transcription
                     do {
                         try recordingRepository.save()
+                        // 過去の polling save 失敗警告をクリア（成功 iteration で回復と判定）。
+                        // 他のエラー源との混同を防ぐためリテラル一致でのみクリアする。
+                        if errorMessage == Self.pollingSaveFailureMessage {
+                            errorMessage = nil
+                        }
                     } catch {
                         // SwiftData save 失敗は DB 整合性破壊の可能性 → permanent 扱いで UI surface
                         Self.logger.error(
                             "Polling save failed for recording \(recording.id, privacy: .public): \(error.localizedDescription, privacy: .public)"
                         )
-                        errorMessage = "録音の更新を保存できませんでした"
+                        errorMessage = Self.pollingSaveFailureMessage
                     }
                 }
             } catch {
@@ -263,14 +268,19 @@ final class RecordingListViewModel {
         }
     }
 
+    /// polling save 失敗時に UI へ出す errorMessage リテラル（成功時 clear のため定数化）。
+    private static let pollingSaveFailureMessage = "録音の更新を保存できませんでした"
+
     /// polling 中の Firestore fetch エラーを transient/permanent に分類してログする。
     ///
     /// - transient: 次回 polling (5s 間隔) で自動リトライされるため info レベル。
     /// - permanent: DI 設定 / 権限 / スキーマ drift 等、開発者の介入が必要なため error レベル。
     ///
-    /// 分類基準は `rules/error-handling.md` §3 の transient/permanent プロトコルに準拠。
+    /// 分類ロジックは `FirestoreError.isTransient` を使用（Firestore SDK 知識を service 層に集約）。
+    /// 基準はグローバル `~/.claude/rules/error-handling.md` §3 の transient/permanent プロトコル準拠。
     private func logPollingFetchError(recordingId: String, error: Error) {
-        if isTransientFirestoreError(error) {
+        let isTransient = (error as? FirestoreError)?.isTransient ?? false
+        if isTransient {
             Self.logger.info(
                 "Polling fetchRecording transient error for \(recordingId, privacy: .public), will retry: \(error.localizedDescription, privacy: .public)"
             )
@@ -278,29 +288,6 @@ final class RecordingListViewModel {
             Self.logger.error(
                 "Polling fetchRecording permanent error for \(recordingId, privacy: .public): \(error.localizedDescription, privacy: .public)"
             )
-        }
-    }
-
-    /// Firestore エラーが transient（自動リトライで回復しうる）かを判定する。
-    ///
-    /// Firestore SDK のエラーコード (`FIRFirestoreErrorDomain`) のうち以下を transient 扱い:
-    /// - `4` deadlineExceeded: ネットワーク timeout
-    /// - `8` resourceExhausted: quota / rate limit
-    /// - `14` unavailable: Firestore backend 一時障害
-    ///
-    /// それ以外 (permissionDenied / unauthenticated / notFound / decoding 失敗等) は permanent。
-    private func isTransientFirestoreError(_ error: Error) -> Bool {
-        guard case let FirestoreError.operationFailed(underlying) = error else {
-            // FirestoreError 以外（decodingFailed 等、独自定義分）はすべて permanent 扱い
-            return false
-        }
-        let nsError = underlying as NSError
-        guard nsError.domain == "FIRFirestoreErrorDomain" else { return false }
-        switch nsError.code {
-        case 4, 8, 14:
-            return true
-        default:
-            return false
         }
     }
 }

--- a/CareNote/Services/FirestoreService.swift
+++ b/CareNote/Services/FirestoreService.swift
@@ -9,6 +9,32 @@ enum FirestoreError: Error, Sendable {
     case decodingFailed(Error)
     case documentNotFound(String)
     case operationFailed(Error)
+
+    /// エラーが transient (自動リトライで回復しうる) かを判定する。
+    ///
+    /// `operationFailed` が `FirestoreErrorDomain` 内の以下コードを包む場合のみ transient:
+    /// - `deadlineExceeded`: ネットワーク timeout
+    /// - `resourceExhausted`: quota / rate limit
+    /// - `unavailable`: Firestore backend 一時障害
+    ///
+    /// それ以外 (`encodingFailed` / `decodingFailed` / `documentNotFound`、及び
+    /// permissionDenied / unauthenticated / notFound 等のコード) はすべて permanent 扱い。
+    ///
+    /// 分類基準はグローバル `~/.claude/rules/error-handling.md` §3 の
+    /// transient/permanent プロトコルに準拠。
+    var isTransient: Bool {
+        guard case let .operationFailed(underlying) = self else { return false }
+        let nsError = underlying as NSError
+        guard nsError.domain == FirestoreErrorDomain else { return false }
+        switch nsError.code {
+        case FirestoreErrorCode.deadlineExceeded.rawValue,
+             FirestoreErrorCode.resourceExhausted.rawValue,
+             FirestoreErrorCode.unavailable.rawValue:
+            return true
+        default:
+            return false
+        }
+    }
 }
 
 // MARK: - RecordingStoring

--- a/CareNoteTests/FirestoreErrorTests.swift
+++ b/CareNoteTests/FirestoreErrorTests.swift
@@ -1,0 +1,81 @@
+import FirebaseFirestore
+import Foundation
+import Testing
+
+@testable import CareNote
+
+/// FirestoreError.isTransient の分類ロジックを検証する。
+///
+/// `isTransient` は polling の silent catch 可視化（Issue #194）で追加された判定ロジック。
+/// transient (deadlineExceeded / resourceExhausted / unavailable) のみ true を返し、
+/// 他はすべて permanent 扱いで false を返す。
+@Suite("FirestoreError.isTransient classification")
+struct FirestoreErrorTests {
+    // MARK: - Transient codes
+
+    @Test(
+        "Firestore SDK transient code は true を返す",
+        arguments: [
+            FirestoreErrorCode.deadlineExceeded.rawValue,
+            FirestoreErrorCode.resourceExhausted.rawValue,
+            FirestoreErrorCode.unavailable.rawValue,
+        ]
+    )
+    func operationFailed_withTransientCode_isTransient(code: Int) {
+        let underlying = NSError(domain: FirestoreErrorDomain, code: code)
+        let error = FirestoreError.operationFailed(underlying)
+        #expect(error.isTransient == true)
+    }
+
+    // MARK: - Permanent codes
+
+    @Test(
+        "Firestore SDK permanent code は false を返す",
+        arguments: [
+            FirestoreErrorCode.permissionDenied.rawValue,
+            FirestoreErrorCode.unauthenticated.rawValue,
+            FirestoreErrorCode.notFound.rawValue,
+            FirestoreErrorCode.invalidArgument.rawValue,
+            FirestoreErrorCode.internal.rawValue,
+        ]
+    )
+    func operationFailed_withPermanentCode_isNotTransient(code: Int) {
+        let underlying = NSError(domain: FirestoreErrorDomain, code: code)
+        let error = FirestoreError.operationFailed(underlying)
+        #expect(error.isTransient == false)
+    }
+
+    // MARK: - Wrong domain (load-bearing for typo-guard)
+
+    @Test("FirestoreErrorDomain 以外のドメインは code が何であれ false を返す")
+    func operationFailed_wrongDomain_isNotTransient() {
+        // transient に該当するコード (14 = unavailable) でも、ドメインが違えば transient 扱いしない
+        let underlying = NSError(domain: NSURLErrorDomain, code: 14)
+        let error = FirestoreError.operationFailed(underlying)
+        #expect(error.isTransient == false)
+    }
+
+    // MARK: - Non-operationFailed cases
+
+    @Test("encodingFailed は permanent 扱い")
+    func encodingFailed_isNotTransient() {
+        let error = FirestoreError.encodingFailed(
+            NSError(domain: "Test", code: 0)
+        )
+        #expect(error.isTransient == false)
+    }
+
+    @Test("decodingFailed は permanent 扱い")
+    func decodingFailed_isNotTransient() {
+        let error = FirestoreError.decodingFailed(
+            NSError(domain: "Test", code: 0)
+        )
+        #expect(error.isTransient == false)
+    }
+
+    @Test("documentNotFound は permanent 扱い")
+    func documentNotFound_isNotTransient() {
+        let error = FirestoreError.documentNotFound("path/to/doc")
+        #expect(error.isTransient == false)
+    }
+}


### PR DESCRIPTION
## Summary

`RecordingListViewModel.pollProcessingRecordings` の 2 箇所の silent failure を撤廃し、`rules/error-handling.md` §3 の transient/permanent 分類プロトコルに準拠したログに置き換える。

- **Firestore fetch catch**: 完全 swallow → `FirestoreError.operationFailed` unwrap + `FIRFirestoreErrorDomain` code 判定で transient (4 deadlineExceeded / 8 resourceExhausted / 14 unavailable) は `logger.info`、それ以外 (permissionDenied / unauthenticated / notFound / decodingFailed) は `logger.error`
- **SwiftData save `try?`**: 完全 swallow → `logger.error` + `errorMessage` で UI surface（DB 整合性破壊は permanent 扱い）
- helper: `logPollingFetchError(recordingId:error:)` / `isTransientFirestoreError(_:)` を private で追加

## 背景

Issue #194（PR #191 /review-pr silent-failure-hunter rating 7+ 指摘の follow-up）。従来 catch は `// ポーリングエラーは静かに無視（次回リトライ）` として `permissionDenied` / `unauthenticated` / `decodingFailed` / Firestore quota exceeded など **debug 不能な permanent failure** も黙殺していた。

## Acceptance Criteria

- [x] `pollProcessingRecordings` catch に `Self.logger` での記録を追加
- [x] polling save 失敗を `logger.error` + `errorMessage` で surface
- [x] transient (rateLimited, unavailable 等) は silent retry 許容、permanent はログ必須
- [x] 既存 polling test に regression なし

## Test plan

- [x] `xcodebuild test -scheme CareNote -destination "platform=iOS Simulator,name=iPhone 17 Pro"` → **145 tests / 0 failed PASS**
- [x] `bash scripts/lint-model-container.sh` → OK
- [x] `bash scripts/lint-scheme-parallel.sh` → OK
- [ ] TestFlight Build 37 で実機確認（transient 発生時は log.info のみ、permanent 時は errorMessage 表示）は次リリース時に確認

## 非スコープ（follow-up Issue）

- #193 Firestore error 分類 UI（現状は polling のログのみ。UI レベルの 3 分類は `FirestoreError` の type 拡張が必要）
- FirestoreService の DI 改善（`any RecordingStoring` 化、#182 follow-up TODO 済）

Closes #194

🤖 Generated with [Claude Code](https://claude.com/claude-code)