### PR TITLE
feat(ios): #193 Firestore delete error 分類 (permissionDenied / notFound / retryable)

### DIFF
--- a/CareNote/Features/RecordingList/RecordingListView.swift
+++ b/CareNote/Features/RecordingList/RecordingListView.swift
@@ -7,8 +7,10 @@ struct RecordingListView: View {
 
     /// Issue #193: delete 失敗時の state 更新を onDelete / retry 両経路で共通化する。
     /// `RecordingDeleteError` は専用 alert、それ以外は generic `errorMessage` alert へ流す。
+    /// 両 state を相互排他にして、同時に 2 つの alert が立ち上がる race を防ぐ。
     private func presentDeleteError(_ error: Error) {
         if let deleteError = error as? RecordingDeleteError {
+            viewModel.errorMessage = nil
             viewModel.deleteError = deleteError
         } else {
             viewModel.deleteError = nil
@@ -62,7 +64,6 @@ struct RecordingListView: View {
             presenting: viewModel.deleteError
         ) { error in
             // Issue #193: retryable case のみ再試行ボタンを表示する。
-            // Sendable 維持のため recordingId のみ保持しているので、VM の recordings から引き直す。
             if case let .retryable(recordingId, _) = error,
                let target = viewModel.recordings.first(where: { $0.id == recordingId }) {
                 Button("再試行") {

--- a/CareNote/Features/RecordingList/RecordingListView.swift
+++ b/CareNote/Features/RecordingList/RecordingListView.swift
@@ -5,6 +5,17 @@ import SwiftUI
 struct RecordingListView: View {
     @Bindable var viewModel: RecordingListViewModel
 
+    /// Issue #193: delete 失敗時の state 更新を onDelete / retry 両経路で共通化する。
+    /// `RecordingDeleteError` は専用 alert、それ以外は generic `errorMessage` alert へ流す。
+    private func presentDeleteError(_ error: Error) {
+        if let deleteError = error as? RecordingDeleteError {
+            viewModel.deleteError = deleteError
+        } else {
+            viewModel.deleteError = nil
+            viewModel.errorMessage = error.localizedDescription
+        }
+    }
+
     var body: some View {
         List {
             ForEach(viewModel.recordings, id: \.id) { recording in
@@ -22,10 +33,7 @@ struct RecordingListView: View {
                         do {
                             try await viewModel.deleteRecording(recording)
                         } catch {
-                            // Issue #182 AC5: 同期済み録音の local-only 削除ガード失敗等を
-                            // ユーザーに見せる。複数件中 1 件目が失敗したら以降を中断（データ
-                            // 整合性優先、エラーメッセージの上書きも回避）。
-                            viewModel.errorMessage = error.localizedDescription
+                            presentDeleteError(error)
                             break
                         }
                     }
@@ -44,6 +52,33 @@ struct RecordingListView: View {
             Button("OK", role: .cancel) { viewModel.errorMessage = nil }
         } message: { message in
             Text(message)
+        }
+        .alert(
+            "削除できませんでした",
+            isPresented: Binding(
+                get: { viewModel.deleteError != nil },
+                set: { if !$0 { viewModel.deleteError = nil } }
+            ),
+            presenting: viewModel.deleteError
+        ) { error in
+            // Issue #193: retryable case のみ再試行ボタンを表示する。
+            // Sendable 維持のため recordingId のみ保持しているので、VM の recordings から引き直す。
+            if case let .retryable(recordingId, _) = error,
+               let target = viewModel.recordings.first(where: { $0.id == recordingId }) {
+                Button("再試行") {
+                    Task {
+                        do {
+                            try await viewModel.deleteRecording(target)
+                            viewModel.deleteError = nil
+                        } catch {
+                            presentDeleteError(error)
+                        }
+                    }
+                }
+            }
+            Button("OK", role: .cancel) { viewModel.deleteError = nil }
+        } message: { error in
+            Text(error.errorDescription ?? "削除に失敗しました。")
         }
         .overlay {
             if viewModel.isLoading {

--- a/CareNote/Features/RecordingList/RecordingListViewModel.swift
+++ b/CareNote/Features/RecordingList/RecordingListViewModel.swift
@@ -11,14 +11,26 @@ enum RecordingDeleteError: LocalizedError, Sendable {
     ///
     /// 注意: case 名は "Unavailable" だが、実態は DI wiring bug または未サインイン状態。
     /// ネットワーク起因ではないため、ユーザーへは「再サインイン / アプリ再起動」を案内する。
-    /// 将来 Firestore 側の transient 失敗を別 case として分けるなら、本 case はそのまま
-    /// DI 欠落専用として残す（Issue #182 follow-up）。
     case remoteServiceUnavailable
+
+    /// Issue #193: Firestore security rules で拒否された（例: `createdBy=""` legacy record を
+    /// 管理者以外が削除しようとした）。local も削除しない（Firestore を primary truth として整合を維持）。
+    case permissionDenied
+
+    /// Issue #193: transient な Firestore 障害 (deadlineExceeded / resourceExhausted / unavailable)。
+    /// `recordingId` のみ保持する理由: `RecordingRecord` は SwiftData `@Model` で non-Sendable、
+    /// `any Error` も non-Sendable のため enum の Sendable 準拠を崩す。UUID + FirestoreError なら安全。
+    /// View 側は `viewModel.recordings.first(where: { $0.id == recordingId })` で対象を引き直す。
+    case retryable(recordingId: UUID, underlying: FirestoreError)
 
     var errorDescription: String? {
         switch self {
         case .remoteServiceUnavailable:
             return "削除できませんでした。アプリを再起動するか、再度サインインしてください。"
+        case .permissionDenied:
+            return "この録音は管理者権限が必要です。管理者に削除を依頼してください。"
+        case .retryable:
+            return "通信が不安定なため削除できませんでした。時間をおいて再試行してください。"
         }
     }
 }
@@ -30,6 +42,9 @@ final class RecordingListViewModel {
     var recordings: [RecordingRecord] = []
     var isLoading: Bool = false
     var errorMessage: String?
+    /// Issue #193: 削除専用のエラー state。`.retryable` の場合に View が「再試行」ボタンを出す。
+    /// `errorMessage` とは別 state にして、polling 等の generic エラーと混同しないようにする。
+    var deleteError: RecordingDeleteError?
 
     private let recordingRepository: RecordingRepository
     // TODO(Issue #182 follow-up): migrate to `any RecordingStoring` for testability.
@@ -146,6 +161,12 @@ final class RecordingListViewModel {
                 try await firestoreService.deleteRecording(
                     tenantId: tenantId,
                     recordingId: firestoreId
+                )
+            } catch let firestoreError as FirestoreError {
+                try Self.resolveDeleteError(
+                    firestoreError,
+                    recordingId: recording.id,
+                    firestoreId: firestoreId
                 )
             } catch {
                 Self.logger.error(
@@ -270,6 +291,45 @@ final class RecordingListViewModel {
 
     /// polling save 失敗時に UI へ出す errorMessage リテラル（成功時 clear のため定数化）。
     private static let pollingSaveFailureMessage = "録音の更新を保存できませんでした"
+
+    /// Issue #193: Firestore delete 失敗を分類し、UI 層へ見せる形 (RecordingDeleteError) に変換する。
+    ///
+    /// - `.notFound`: 他端末で既に削除済 → `return` で idempotent success。caller は local 削除を続行。
+    /// - `.permissionDenied`: rules で拒否 → `RecordingDeleteError.permissionDenied` を throw、local は消さない。
+    /// - `.operationFailed` かつ `isTransient`: 再試行可能 → `.retryable` を throw。
+    /// - その他 (非 transient `.operationFailed` / `.encodingFailed` / `.decodingFailed` / `.documentNotFound`):
+    ///   原因特定が難しいため、原 `FirestoreError` をそのまま re-throw して上位に委ねる。
+    ///
+    /// `static` かつ純粋関数として公開しているのは、concrete `FirestoreService` actor を
+    /// stub できない現状（Issue #182 follow-up）でも分類ロジックだけは単体テストできるようにするため。
+    static func resolveDeleteError(
+        _ firestoreError: FirestoreError,
+        recordingId: UUID,
+        firestoreId: String
+    ) throws {
+        switch firestoreError {
+        case .notFound:
+            Self.logger.info(
+                "Recording already removed on Firestore, proceeding with local cleanup: \(firestoreId, privacy: .public)"
+            )
+            return
+        case .permissionDenied:
+            Self.logger.warning(
+                "Firestore deleteRecording denied by rules for \(firestoreId, privacy: .public)"
+            )
+            throw RecordingDeleteError.permissionDenied
+        case .operationFailed where firestoreError.isTransient:
+            Self.logger.info(
+                "Firestore deleteRecording transient failure for \(firestoreId, privacy: .public): \(firestoreError.localizedDescription, privacy: .public)"
+            )
+            throw RecordingDeleteError.retryable(recordingId: recordingId, underlying: firestoreError)
+        case .operationFailed, .encodingFailed, .decodingFailed, .documentNotFound:
+            Self.logger.error(
+                "Firestore deleteRecording failed for \(firestoreId, privacy: .public): \(firestoreError.localizedDescription, privacy: .public)"
+            )
+            throw firestoreError
+        }
+    }
 
     /// polling 中の Firestore fetch エラーを transient/permanent に分類してログする。
     ///

--- a/CareNote/Services/FirestoreService.swift
+++ b/CareNote/Services/FirestoreService.swift
@@ -8,6 +8,12 @@ enum FirestoreError: Error, Sendable {
     case encodingFailed(Error)
     case decodingFailed(Error)
     case documentNotFound(String)
+    /// Firestore security rules 等によるアクセス拒否 (`FirestoreErrorCode.permissionDenied` = 7)。
+    /// メンバー権限では削除できない legacy document (例: `createdBy=""`) を検知するのに使う。
+    case permissionDenied
+    /// 対象 document が Firestore 側で既に存在しない (`FirestoreErrorCode.notFound` = 5)。
+    /// 他端末での先行削除など、idempotent success として扱うのが望ましい。
+    case notFound
     case operationFailed(Error)
 
     /// エラーが transient (自動リトライで回復しうる) かを判定する。
@@ -33,6 +39,30 @@ enum FirestoreError: Error, Sendable {
             return true
         default:
             return false
+        }
+    }
+
+    /// Firestore SDK が throw した NSError を `FirestoreError` にマップする。
+    ///
+    /// - `FirestoreErrorDomain` + `permissionDenied` (code 7) → `.permissionDenied`
+    /// - `FirestoreErrorDomain` + `notFound` (code 5) → `.notFound`
+    /// - その他 (transient / 未分類 / 異なる domain) → `.operationFailed(error)` で保持
+    ///
+    /// transient 判定は `.operationFailed` の `isTransient` プロパティで確認する。
+    /// 基準はグローバル `~/.claude/rules/error-handling.md` §3 の
+    /// transient/permanent プロトコルに準拠。
+    static func map(_ error: Error) -> FirestoreError {
+        let nsError = error as NSError
+        guard nsError.domain == FirestoreErrorDomain else {
+            return .operationFailed(error)
+        }
+        switch nsError.code {
+        case FirestoreErrorCode.permissionDenied.rawValue:
+            return .permissionDenied
+        case FirestoreErrorCode.notFound.rawValue:
+            return .notFound
+        default:
+            return .operationFailed(error)
         }
     }
 }
@@ -373,7 +403,9 @@ actor FirestoreService: RecordingStoring, ClientManaging, TemplateManaging {
         do {
             try await recordingsCollection(tenantId: tenantId).document(recordingId).delete()
         } catch {
-            throw FirestoreError.operationFailed(error)
+            // Issue #193: permissionDenied / notFound / transient を UI で区別できるよう分類する。
+            // updateTranscription / deleteClient / deleteTemplate は本 Issue では YAGNI で見送り。
+            throw FirestoreError.map(error)
         }
     }
 

--- a/CareNoteTests/FirestoreErrorTests.swift
+++ b/CareNoteTests/FirestoreErrorTests.swift
@@ -79,3 +79,97 @@ struct FirestoreErrorTests {
         #expect(error.isTransient == false)
     }
 }
+
+/// FirestoreError.map (Issue #193) の分類ロジックを検証する。
+///
+/// Firestore SDK が throw した NSError を `permissionDenied` / `notFound` /
+/// `operationFailed` にマップする。UI 層で permissionDenied=管理者依頼、
+/// notFound=idempotent success、transient=再試行ボタン付き alert、
+/// その他 permanent=generic alert と分岐させる前提。
+@Suite("FirestoreError.map classification (Issue #193)")
+struct FirestoreErrorMapTests {
+    // MARK: - Classified cases
+
+    @Test("FirestoreErrorDomain + permissionDenied (7) → .permissionDenied")
+    func map_permissionDenied() {
+        let ns = NSError(
+            domain: FirestoreErrorDomain,
+            code: FirestoreErrorCode.permissionDenied.rawValue
+        )
+        let mapped = FirestoreError.map(ns)
+        if case .permissionDenied = mapped {
+            // pass
+        } else {
+            Issue.record("Expected .permissionDenied, got \(mapped)")
+        }
+    }
+
+    @Test("FirestoreErrorDomain + notFound (5) → .notFound")
+    func map_notFound() {
+        let ns = NSError(
+            domain: FirestoreErrorDomain,
+            code: FirestoreErrorCode.notFound.rawValue
+        )
+        let mapped = FirestoreError.map(ns)
+        if case .notFound = mapped {
+            // pass
+        } else {
+            Issue.record("Expected .notFound, got \(mapped)")
+        }
+    }
+
+    // MARK: - Fallthrough to operationFailed
+
+    @Test(
+        "FirestoreErrorDomain + transient code → .operationFailed (isTransient=true)",
+        arguments: [
+            FirestoreErrorCode.deadlineExceeded.rawValue,
+            FirestoreErrorCode.resourceExhausted.rawValue,
+            FirestoreErrorCode.unavailable.rawValue,
+        ]
+    )
+    func map_transientCode_fallsThroughToOperationFailed(code: Int) {
+        let ns = NSError(domain: FirestoreErrorDomain, code: code)
+        let mapped = FirestoreError.map(ns)
+        guard case .operationFailed = mapped else {
+            Issue.record("Expected .operationFailed for transient code \(code), got \(mapped)")
+            return
+        }
+        #expect(mapped.isTransient == true)
+    }
+
+    @Test(
+        "FirestoreErrorDomain + permanent non-classified code → .operationFailed (isTransient=false)",
+        arguments: [
+            FirestoreErrorCode.internal.rawValue,
+            FirestoreErrorCode.invalidArgument.rawValue,
+            FirestoreErrorCode.unauthenticated.rawValue,
+        ]
+    )
+    func map_permanentCode_fallsThroughToOperationFailed(code: Int) {
+        let ns = NSError(domain: FirestoreErrorDomain, code: code)
+        let mapped = FirestoreError.map(ns)
+        guard case .operationFailed = mapped else {
+            Issue.record("Expected .operationFailed for permanent code \(code), got \(mapped)")
+            return
+        }
+        #expect(mapped.isTransient == false)
+    }
+
+    // MARK: - Wrong domain (load-bearing for typo-guard)
+
+    @Test("FirestoreErrorDomain 以外のドメインは code に関わらず .operationFailed 扱い")
+    func map_wrongDomain_fallsThroughToOperationFailed() {
+        // permissionDenied に該当するコード (7) でも、ドメインが違えば .permissionDenied にしない
+        let ns = NSError(
+            domain: NSURLErrorDomain,
+            code: FirestoreErrorCode.permissionDenied.rawValue
+        )
+        let mapped = FirestoreError.map(ns)
+        if case .operationFailed = mapped {
+            // pass
+        } else {
+            Issue.record("Expected .operationFailed for wrong domain, got \(mapped)")
+        }
+    }
+}

--- a/CareNoteTests/RecordingListViewModelTests.swift
+++ b/CareNoteTests/RecordingListViewModelTests.swift
@@ -352,6 +352,54 @@ struct RecordingListViewModelTests {
         }
     }
 
+    /// Issue #193: `FirestoreError.map` → `resolveDeleteError` の round-trip が
+    /// 実際の call site (`FirestoreService.deleteRecording`) と同じ経路で動くことを確認する。
+    /// map の fallthrough 動作が将来 refactor で壊れた場合に検知するための defense-in-depth。
+    @Test @MainActor
+    func mapResolve_roundTrip_transientCodeはRetryableに変換される() throws {
+        let ns = NSError(domain: FirestoreErrorDomain, code: FirestoreErrorCode.unavailable.rawValue)
+        let mapped = FirestoreError.map(ns)  // .operationFailed(ns) (isTransient=true)
+
+        #expect {
+            try RecordingListViewModel.resolveDeleteError(
+                mapped,
+                recordingId: UUID(),
+                firestoreId: "doc-1"
+            )
+        } throws: { error in
+            guard let deleteError = error as? RecordingDeleteError,
+                  case .retryable = deleteError else {
+                return false
+            }
+            return true
+        }
+    }
+
+    /// Issue #193: `FirestoreError.map` → `resolveDeleteError` の round-trip で
+    /// permissionDenied が UI 層の `.permissionDenied` に正しく伝播することを確認する。
+    @Test @MainActor
+    func mapResolve_roundTrip_permissionDeniedはUI層まで伝播する() throws {
+        let ns = NSError(
+            domain: FirestoreErrorDomain,
+            code: FirestoreErrorCode.permissionDenied.rawValue
+        )
+        let mapped = FirestoreError.map(ns)  // .permissionDenied
+
+        #expect {
+            try RecordingListViewModel.resolveDeleteError(
+                mapped,
+                recordingId: UUID(),
+                firestoreId: "doc-1"
+            )
+        } throws: { error in
+            guard let deleteError = error as? RecordingDeleteError,
+                  case .permissionDenied = deleteError else {
+                return false
+            }
+            return true
+        }
+    }
+
     /// Issue #193: encodingFailed / decodingFailed / documentNotFound も permanent として rethrow される。
     @Test @MainActor
     func resolveDeleteError_FirestoreErrorの独自case群は各々そのままrethrowされる() throws {

--- a/CareNoteTests/RecordingListViewModelTests.swift
+++ b/CareNoteTests/RecordingListViewModelTests.swift
@@ -1,4 +1,5 @@
 @testable import CareNote
+import FirebaseFirestore
 import Foundation
 import SwiftData
 import Testing
@@ -270,5 +271,105 @@ struct RecordingListViewModelTests {
         }
 
         #expect(try repo.findById(recordingId) != nil)
+    }
+
+    // MARK: - Issue #193: delete error classification (resolveDeleteError)
+
+    /// Issue #193 AC6: Firestore notFound は idempotent success (throw せず return)。
+    /// 他端末で先に削除済のケースを想定。
+    @Test @MainActor
+    func resolveDeleteError_notFoundは例外を投げず即return() throws {
+        try RecordingListViewModel.resolveDeleteError(
+            .notFound,
+            recordingId: UUID(),
+            firestoreId: "doc-1"
+        )
+        // ここに到達すれば pass (throw されないこと自体が期待)
+    }
+
+    /// Issue #193 AC7: Firestore permissionDenied は RecordingDeleteError.permissionDenied に変換される。
+    @Test @MainActor
+    func resolveDeleteError_permissionDeniedはRecordingDeleteErrorにマップされる() throws {
+        #expect {
+            try RecordingListViewModel.resolveDeleteError(
+                .permissionDenied,
+                recordingId: UUID(),
+                firestoreId: "doc-1"
+            )
+        } throws: { error in
+            guard let deleteError = error as? RecordingDeleteError,
+                  case .permissionDenied = deleteError else {
+                return false
+            }
+            return true
+        }
+    }
+
+    /// Issue #193 AC8: transient error (unavailable 等) は RecordingDeleteError.retryable にマップされ、
+    /// 渡した recordingId がそのまま保持される（View で再試行対象を引き直すため）。
+    @Test @MainActor
+    func resolveDeleteError_transientはRetryableにマップされrecordingIdを保持する() throws {
+        let recordingId = UUID()
+        let transientUnderlying = FirestoreError.operationFailed(
+            NSError(domain: FirestoreErrorDomain, code: FirestoreErrorCode.unavailable.rawValue)
+        )
+
+        #expect {
+            try RecordingListViewModel.resolveDeleteError(
+                transientUnderlying,
+                recordingId: recordingId,
+                firestoreId: "doc-1"
+            )
+        } throws: { error in
+            guard let deleteError = error as? RecordingDeleteError,
+                  case let .retryable(retryRecordingId, _) = deleteError else {
+                return false
+            }
+            return retryRecordingId == recordingId
+        }
+    }
+
+    /// Issue #193: non-classified FirestoreError (permanent かつ notFound/permissionDenied でない)
+    /// は原 error をそのまま re-throw する。呼び出し側の既存ハンドリングに委ねる。
+    @Test @MainActor
+    func resolveDeleteError_未分類permanentはそのままrethrowされる() throws {
+        let internalError = FirestoreError.operationFailed(
+            NSError(domain: FirestoreErrorDomain, code: FirestoreErrorCode.internal.rawValue)
+        )
+
+        #expect {
+            try RecordingListViewModel.resolveDeleteError(
+                internalError,
+                recordingId: UUID(),
+                firestoreId: "doc-1"
+            )
+        } throws: { error in
+            guard let firestoreError = error as? FirestoreError,
+                  case .operationFailed = firestoreError else {
+                return false
+            }
+            return true
+        }
+    }
+
+    /// Issue #193: encodingFailed / decodingFailed / documentNotFound も permanent として rethrow される。
+    @Test @MainActor
+    func resolveDeleteError_FirestoreErrorの独自case群は各々そのままrethrowされる() throws {
+        let cases: [FirestoreError] = [
+            .encodingFailed(NSError(domain: "Test", code: 0)),
+            .decodingFailed(NSError(domain: "Test", code: 0)),
+            .documentNotFound("path"),
+        ]
+        for firestoreError in cases {
+            #expect {
+                try RecordingListViewModel.resolveDeleteError(
+                    firestoreError,
+                    recordingId: UUID(),
+                    firestoreId: "doc-1"
+                )
+            } throws: { error in
+                error is FirestoreError
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary

Firestore の delete エラーを **permissionDenied / notFound / retryable / その他 (permanent)** に分類し、UI で区別できるようにする。PR #191 silent-failure-hunter 指摘の follow-up で、AC10「`createdBy=""` legacy record の member delete 失敗 UX 化」の完遂を狙う。

YAGNI で **delete 系のみ先行**（`updateTranscription` / `deleteClient` / `deleteTemplate` は別 Issue 化可）。

## 変更概要

### Service layer
- `FirestoreError` に `.permissionDenied` / `.notFound` case 追加
- `static func FirestoreError.map(_:)` で NSError → case 変換（`FirestoreErrorDomain` 限定、wrong domain は `.operationFailed` fallback）
- `FirestoreService.deleteRecording` で `FirestoreError.map(error)` 適用
- 他 API (update / deleteClient / deleteTemplate) は従来の `.operationFailed(error)` wrap のまま

### ViewModel
- `RecordingDeleteError` に `.permissionDenied` / `.retryable(recordingId: UUID, underlying: FirestoreError)` 追加
  - Sendable 維持のため `RecordingRecord` ではなく UUID を保持
- `var deleteError: RecordingDeleteError?` state 追加（generic `errorMessage` と分離）
- `static func resolveDeleteError(_:recordingId:firestoreId:) throws` で分類 + throw (pure function)
  - `notFound` → return (idempotent success)
  - `permissionDenied` → throw `.permissionDenied`
  - `.operationFailed where isTransient` → throw `.retryable`
  - その他 → 原 FirestoreError rethrow

### View
- `RecordingDeleteError` 専用 alert 追加（`errorMessage` 用 alert と併置）
- `.retryable` のみ「再試行」ボタン表示、`recordings` から `recordingId` で対象引き直し
- `presentDeleteError(_:)` private helper で onDelete / retry 両経路の state 更新を統合

## Acceptance Criteria

- [x] AC1-5: `FirestoreError.map` の 7 ケース (permissionDenied / notFound / transient 3 / permanent 3 / wrong domain) — FirestoreErrorMapTests
- [x] AC6: `resolveDeleteError(.notFound)` は return（throw しない） — RecordingListViewModelTests
- [x] AC7: `resolveDeleteError(.permissionDenied)` は `RecordingDeleteError.permissionDenied` throw — 同上
- [x] AC8: transient は `RecordingDeleteError.retryable` + 元 recordingId 保持 — 同上
- [x] AC10: 既存 157 test に regression なし → **171 tests / 0 failed PASS**
- [ ] AC9: 再試行ボタン押下で `viewModel.deleteRecording(recording)` 再呼び出し → TestFlight 実機確認 (UI test 困難)

## /simplify 反映

| 指摘 | 対応 |
|------|------|
| Q2+Eff-F5: signature 簡素化 | `recording: RecordingRecord` → `recordingId: UUID` で test から ModelContainer 除去 |
| Q3: alert retry / onDelete catch 重複 | `presentDeleteError(_:)` helper で統合 |
| Q6: switch default 内 nested if | `.operationFailed where isTransient` 明示 case に整理 |
| Q7 + DRY-F5: 冗長コメント / 未使用 `isRetryable` | 削除 |
| Q1 dual state (errorMessage vs deleteError) | retryable の associated value 必須で統合不可、見送り |
| Q8 classify の置き場所 | Service→VM 方向の依存回避で VM static が妥当、見送り |

## Test plan

- [x] `xcodebuild test -scheme CareNote -destination "platform=iOS Simulator,name=iPhone 17 Pro"` → **171 tests / 0 failed PASS**
- [x] `bash scripts/lint-model-container.sh` → OK
- [x] `bash scripts/lint-scheme-parallel.sh` → OK
- [x] `/simplify` 3 agent 並列レビュー反映済
- [ ] `/review-pr` 6 agent 並列レビュー（本 PR 作成後）
- [ ] Evaluator 分離評価（5 ファイル + 新機能、rules/quality-gate.md 発動条件）
- [ ] TestFlight Build 37 で実機シナリオ (permissionDenied / 再試行)

## 非スコープ (follow-up)

- updateTranscription / deleteClient / deleteTemplate への同パターン適用
- localization (error message のハードコード Japanese、i18n 対応)
- FirestoreService の DI 改善 (`any RecordingStoring`、Issue #182 follow-up TODO)

Closes #193

🤖 Generated with [Claude Code](https://claude.com/claude-code)