### PR TITLE
feat(functions): #192 Cloud Storage orphan audio cleanup trigger (Phase A: impl + test)

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -159,7 +159,9 @@ exports.deleteAccount = onCall(
           getStorage().bucket(gs.bucket).file(gs.object).delete({ ignoreNotFound: true })
         );
       } else if (data.audioStoragePath) {
-        console.warn("[deleteAccount] unparseable audioStoragePath", {
+        // Issue #193 review: writer-side のバグ / data corruption の可能性があるため
+        // error level (warn は「気にする必要のない」シグナル、これは actionable)。
+        console.error("[deleteAccount] unparseable audioStoragePath", {
           uid, docId: doc.id, audioStoragePath: data.audioStoragePath,
         });
       }
@@ -241,7 +243,9 @@ async function handleRecordingDeleted(event) {
 
   const gs = parseGsUri(audioStoragePath);
   if (!gs) {
-    console.warn("[onRecordingDeleted] unparseable audioStoragePath, skipping", {
+    // writer-side のバグ / data corruption が原因。orphan を作る silent failure に
+    // しないよう error level で記録 (warn は「気にする必要のない」シグナル)。
+    console.error("[onRecordingDeleted] unparseable audioStoragePath, skipping", {
       tenantId,
       recordingId,
       audioStoragePath,
@@ -284,4 +288,9 @@ exports.onRecordingDeleted = onDocumentDeleted(
 // Test 用: handler を直接呼べるよう named export する（v2 trigger は wrap 経由だと
 // 他テストの admin SDK mock と干渉するため）。production は `exports.onRecordingDeleted`
 // 経由で発火するので影響なし。
+//
+// Firebase は `onCall` / `onDocumentDeleted` などで wrap された `CloudFunction` オブジェクト
+// のみを trigger / function として登録するため、plain な async function である
+// `_handleRecordingDeleted` は `firebase deploy` の対象外（デプロイ後の Cloud Console にも
+// 表示されない）。テスト目的の export であり攻撃面の追加にはならない。
 exports._handleRecordingDeleted = handleRecordingDeleted;

--- a/functions/index.js
+++ b/functions/index.js
@@ -1,6 +1,7 @@
 const { beforeUserSignedIn } = require("firebase-functions/v2/identity");
 const { HttpsError } = require("firebase-functions/v2/identity");
 const { onCall, HttpsError: CallableHttpsError } = require("firebase-functions/v2/https");
+const { onDocumentDeleted } = require("firebase-functions/v2/firestore");
 const { initializeApp } = require("firebase-admin/app");
 const { getFirestore } = require("firebase-admin/firestore");
 const { getAuth } = require("firebase-admin/auth");
@@ -109,6 +110,10 @@ function parseGsUri(uri) {
 // Auth deletion runs even if Firestore/Storage cleanup partially fails, so the
 // identity is always removed (preferred for App Store compliance). Orphan blobs
 // can be reaped by Storage lifecycle rules.
+//
+// NOTE: doc.ref.delete() の発行で `onRecordingDeleted` trigger が発火し、同じ
+// audioStoragePath に対して二重削除が走るが、Storage delete は `ignoreNotFound: true`
+// なので冪等。Issue #192。
 exports.deleteAccount = onCall(
   { region: REGION, timeoutSeconds: 540 },
   async (request) => {
@@ -205,3 +210,78 @@ exports.deleteAccount = onCall(
 // recordings / templates / whitelist を書換える Callable Function。
 // 詳細は functions/src/transferOwnership.js および ADR-008 参照。
 exports.transferOwnership = require("./src/transferOwnership").transferOwnership;
+
+// Issue #192: 録音 doc が削除されたら関連の Cloud Storage audio object も削除する
+// Firestore trigger。iOS swipe delete (PR #191 / Issue #182) では Firestore doc のみ
+// 消えるため、この trigger がないと Storage が orphan blob で圧迫されていく。
+//
+// 既存の `deleteAccount` Callable も同じ Storage delete を呼ぶが、`ignoreNotFound: true`
+// で冪等。trigger 発火時に既に object が消えていても no-op で完走する。
+//
+// trigger 内では throw しない: trigger が throw すると Firebase は exponential backoff で
+// retry し続け、永久ループ + log spam になる。Storage delete 失敗は orphan として記録し、
+// `functions/scripts/delete-empty-createdby.mjs` 系の手動 cleanup スクリプトで回収する。
+//
+// handler を別関数で定義 + `_handleRecordingDeleted` として named export しているのは
+// `firebase-functions-test` の `makeDocumentSnapshot` が他テストの `getFirestore` mock と
+// 干渉するため、test では event 互換オブジェクトを直接渡して handler を call する設計のため。
+async function handleRecordingDeleted(event) {
+  const tenantId = event.params.tenantId;
+  const recordingId = event.params.recordingId;
+  const data = event.data?.data() || {};
+  const audioStoragePath = data.audioStoragePath;
+
+  if (!audioStoragePath) {
+    console.info("[onRecordingDeleted] no audioStoragePath, skipping", {
+      tenantId,
+      recordingId,
+    });
+    return;
+  }
+
+  const gs = parseGsUri(audioStoragePath);
+  if (!gs) {
+    console.warn("[onRecordingDeleted] unparseable audioStoragePath, skipping", {
+      tenantId,
+      recordingId,
+      audioStoragePath,
+    });
+    return;
+  }
+
+  try {
+    await getStorage()
+      .bucket(gs.bucket)
+      .file(gs.object)
+      .delete({ ignoreNotFound: true });
+    console.info("[onRecordingDeleted] storage object deleted", {
+      tenantId,
+      recordingId,
+      bucket: gs.bucket,
+      object: gs.object,
+    });
+  } catch (err) {
+    // throw すると trigger が retry backoff に入る。orphan は許容して log のみ残す。
+    console.error("[onRecordingDeleted] storage delete failed (orphan possible)", {
+      tenantId,
+      recordingId,
+      bucket: gs.bucket,
+      object: gs.object,
+      code: err.code,
+      message: err.message,
+    });
+  }
+}
+
+exports.onRecordingDeleted = onDocumentDeleted(
+  {
+    region: REGION,
+    document: "tenants/{tenantId}/recordings/{recordingId}",
+  },
+  handleRecordingDeleted
+);
+
+// Test 用: handler を直接呼べるよう named export する（v2 trigger は wrap 経由だと
+// 他テストの admin SDK mock と干渉するため）。production は `exports.onRecordingDeleted`
+// 経由で発火するので影響なし。
+exports._handleRecordingDeleted = handleRecordingDeleted;

--- a/functions/test/on-recording-deleted.test.js
+++ b/functions/test/on-recording-deleted.test.js
@@ -6,10 +6,40 @@ const test = functionsTest();
 // ---- Mock state ----
 let storageDeleteCalls = [];
 let storageDeleteFailureMode = null; // null | { code, message }
+let consoleWarnCalls = [];
+let consoleErrorCalls = [];
+let consoleInfoCalls = [];
+
+const originalConsole = {
+  warn: console.warn,
+  error: console.error,
+  info: console.info,
+};
 
 function resetState() {
   storageDeleteCalls = [];
   storageDeleteFailureMode = null;
+  consoleWarnCalls = [];
+  consoleErrorCalls = [];
+  consoleInfoCalls = [];
+}
+
+function installConsoleSpies() {
+  console.warn = (...args) => {
+    consoleWarnCalls.push(args);
+  };
+  console.error = (...args) => {
+    consoleErrorCalls.push(args);
+  };
+  console.info = (...args) => {
+    consoleInfoCalls.push(args);
+  };
+}
+
+function restoreConsole() {
+  console.warn = originalConsole.warn;
+  console.error = originalConsole.error;
+  console.info = originalConsole.info;
 }
 
 // ---- Admin SDK mock ----
@@ -38,8 +68,21 @@ function initializeAdminMocks() {
   });
 }
 
+// `before` フックは定義順に実行される。**順序必須**:
+// 1. `initializeAdminMocks` で `getStorage` 等の SDK を差し替える
+// 2. その後で `require("../index")` を実行 → handler closure が差し替え後の SDK を参照
+// 順序を入れ替えると handler が production の getStorage を bind してしまい test が壊れる。
+let handleRecordingDeleted;
+
 before(() => {
   initializeAdminMocks();
+  installConsoleSpies();
+});
+
+before(() => {
+  delete require.cache[require.resolve("../index")];
+  const functions = require("../index");
+  handleRecordingDeleted = functions._handleRecordingDeleted;
 });
 
 afterEach(() => {
@@ -47,14 +90,8 @@ afterEach(() => {
 });
 
 after(() => {
+  restoreConsole();
   test.cleanup();
-});
-
-let handleRecordingDeleted;
-before(() => {
-  delete require.cache[require.resolve("../index")];
-  const functions = require("../index");
-  handleRecordingDeleted = functions._handleRecordingDeleted;
 });
 
 // ---- Helpers ----
@@ -116,7 +153,7 @@ describe("onRecordingDeleted Firestore trigger", () => {
     assert.deepStrictEqual(storageDeleteCalls, []);
   });
 
-  it("audioStoragePath が gs:// 形式でない場合は Storage を呼ばず warn で完走する", async () => {
+  it("audioStoragePath が gs:// 形式でない場合は Storage を呼ばず error log で完走する", async () => {
     await invokeTrigger({
       data: {
         createdBy: "alice",
@@ -127,6 +164,35 @@ describe("onRecordingDeleted Firestore trigger", () => {
     });
 
     assert.deepStrictEqual(storageDeleteCalls, []);
+    // 不正 URI は data corruption / writer-side bug の signal なので error level
+    const matched = consoleErrorCalls.find((args) =>
+      typeof args[0] === "string" &&
+      args[0].includes("[onRecordingDeleted] unparseable audioStoragePath")
+    );
+    assert.ok(matched, "error log が emit されるはず");
+  });
+
+  it("audioStoragePath が非 string (number / object) の場合は parseGsUri が null を返し error log で skip", async () => {
+    await invokeTrigger({
+      data: { createdBy: "alice", audioStoragePath: 42 },
+      tenantId: "279",
+      recordingId: "r1",
+    });
+    assert.deepStrictEqual(storageDeleteCalls, []);
+
+    await invokeTrigger({
+      data: { createdBy: "alice", audioStoragePath: { foo: "bar" } },
+      tenantId: "279",
+      recordingId: "r2",
+    });
+    assert.deepStrictEqual(storageDeleteCalls, []);
+
+    // 両方とも error log で記録される
+    const errorLogs = consoleErrorCalls.filter((args) =>
+      typeof args[0] === "string" &&
+      args[0].includes("[onRecordingDeleted] unparseable audioStoragePath")
+    );
+    assert.strictEqual(errorLogs.length, 2);
   });
 
   it("audioStoragePath が空文字列の場合は Storage を呼ばず no-op", async () => {
@@ -159,6 +225,12 @@ describe("onRecordingDeleted Firestore trigger", () => {
 
     // Storage は1回呼ばれた上で error をのみ込んだ
     assert.strictEqual(storageDeleteCalls.length, 1);
+    // failure は error log で観測可能でなければならない (silent failure 禁止)
+    const matched = consoleErrorCalls.find((args) =>
+      typeof args[0] === "string" &&
+      args[0].includes("[onRecordingDeleted] storage delete failed (orphan possible)")
+    );
+    assert.ok(matched, "error log が emit されるはず");
   });
 
   it("Storage delete が generic エラーで失敗しても trigger は throw しない", async () => {

--- a/functions/test/on-recording-deleted.test.js
+++ b/functions/test/on-recording-deleted.test.js
@@ -1,0 +1,206 @@
+const assert = require("assert");
+const functionsTest = require("firebase-functions-test");
+
+const test = functionsTest();
+
+// ---- Mock state ----
+let storageDeleteCalls = [];
+let storageDeleteFailureMode = null; // null | { code, message }
+
+function resetState() {
+  storageDeleteCalls = [];
+  storageDeleteFailureMode = null;
+}
+
+// ---- Admin SDK mock ----
+//
+// `delete-account.test.js` と同じ思想: getStorage / getFirestore / getAuth を
+// 一度だけ差し替え、テスト本体は state と handler のみを切替える。
+function initializeAdminMocks() {
+  const adminStorage = require("firebase-admin/storage");
+  adminStorage.getStorage = () => ({
+    bucket: (name) => ({
+      file: (path) => ({
+        delete: async (opts) => {
+          storageDeleteCalls.push({
+            bucket: name,
+            object: path,
+            ignoreNotFound: opts?.ignoreNotFound === true,
+          });
+          if (storageDeleteFailureMode) {
+            const err = new Error(storageDeleteFailureMode.message);
+            err.code = storageDeleteFailureMode.code;
+            throw err;
+          }
+        },
+      }),
+    }),
+  });
+}
+
+before(() => {
+  initializeAdminMocks();
+});
+
+afterEach(() => {
+  resetState();
+});
+
+after(() => {
+  test.cleanup();
+});
+
+let handleRecordingDeleted;
+before(() => {
+  delete require.cache[require.resolve("../index")];
+  const functions = require("../index");
+  handleRecordingDeleted = functions._handleRecordingDeleted;
+});
+
+// ---- Helpers ----
+
+/**
+ * v2 `onDocumentDeleted` の event 互換オブジェクトを手で作る。
+ *
+ * `firebase-functions-test` の `makeDocumentSnapshot` は内部で `getFirestore()` を
+ * 呼ぶため、`delete-account.test.js` 等で SDK mock が installed されている状態だと
+ * `firestoreService.snapshot_ is not a function` で fail する。handler 側は
+ * `event.data?.data()` と `event.params` しか参照しないため、最小互換のみ用意する。
+ */
+async function invokeTrigger({ data, tenantId, recordingId }) {
+  await handleRecordingDeleted({
+    data: { data: () => data },
+    params: { tenantId, recordingId },
+  });
+}
+
+// ---- Tests ----
+
+describe("onRecordingDeleted Firestore trigger", () => {
+  it("audioStoragePath が valid な gs:// URI の場合、bucket.file().delete() を ignoreNotFound:true で呼ぶ", async () => {
+    await invokeTrigger({
+      data: {
+        createdBy: "alice",
+        audioStoragePath: "gs://carenote-dev-279-audio/279/r1.m4a",
+      },
+      tenantId: "279",
+      recordingId: "r1",
+    });
+
+    assert.deepStrictEqual(storageDeleteCalls, [
+      {
+        bucket: "carenote-dev-279-audio",
+        object: "279/r1.m4a",
+        ignoreNotFound: true,
+      },
+    ]);
+  });
+
+  it("audioStoragePath が undefined の場合は Storage を呼ばず no-op で完走する", async () => {
+    await invokeTrigger({
+      data: { createdBy: "alice" },
+      tenantId: "279",
+      recordingId: "r1",
+    });
+
+    assert.deepStrictEqual(storageDeleteCalls, []);
+  });
+
+  it("audioStoragePath が null の場合は Storage を呼ばず no-op で完走する", async () => {
+    await invokeTrigger({
+      data: { createdBy: "alice", audioStoragePath: null },
+      tenantId: "279",
+      recordingId: "r1",
+    });
+
+    assert.deepStrictEqual(storageDeleteCalls, []);
+  });
+
+  it("audioStoragePath が gs:// 形式でない場合は Storage を呼ばず warn で完走する", async () => {
+    await invokeTrigger({
+      data: {
+        createdBy: "alice",
+        audioStoragePath: "https://invalid-url/file.m4a",
+      },
+      tenantId: "279",
+      recordingId: "r1",
+    });
+
+    assert.deepStrictEqual(storageDeleteCalls, []);
+  });
+
+  it("audioStoragePath が空文字列の場合は Storage を呼ばず no-op", async () => {
+    await invokeTrigger({
+      data: { createdBy: "alice", audioStoragePath: "" },
+      tenantId: "279",
+      recordingId: "r1",
+    });
+
+    assert.deepStrictEqual(storageDeleteCalls, []);
+  });
+
+  it("Storage delete が permission エラーで失敗しても trigger は throw しない (retry backoff 防止)", async () => {
+    storageDeleteFailureMode = {
+      code: "storage/unauthorized",
+      message: "Permission denied",
+    };
+
+    // throw されないことを assert: rejects で false 検知
+    await assert.doesNotReject(async () => {
+      await invokeTrigger({
+        data: {
+          createdBy: "alice",
+          audioStoragePath: "gs://carenote-dev-279-audio/279/r1.m4a",
+        },
+        tenantId: "279",
+        recordingId: "r1",
+      });
+    });
+
+    // Storage は1回呼ばれた上で error をのみ込んだ
+    assert.strictEqual(storageDeleteCalls.length, 1);
+  });
+
+  it("Storage delete が generic エラーで失敗しても trigger は throw しない", async () => {
+    storageDeleteFailureMode = {
+      code: undefined,
+      message: "network unreachable",
+    };
+
+    await assert.doesNotReject(async () => {
+      await invokeTrigger({
+        data: {
+          createdBy: "alice",
+          audioStoragePath: "gs://carenote-dev-279-audio/279/r1.m4a",
+        },
+        tenantId: "279",
+        recordingId: "r1",
+      });
+    });
+
+    assert.strictEqual(storageDeleteCalls.length, 1);
+  });
+
+  it("複数回連続で trigger 発火しても各々独立に処理される (冪等性確認)", async () => {
+    await invokeTrigger({
+      data: {
+        createdBy: "alice",
+        audioStoragePath: "gs://carenote-dev-279-audio/279/r1.m4a",
+      },
+      tenantId: "279",
+      recordingId: "r1",
+    });
+    await invokeTrigger({
+      data: {
+        createdBy: "bob",
+        audioStoragePath: "gs://carenote-dev-279-audio/279/r2.m4a",
+      },
+      tenantId: "279",
+      recordingId: "r2",
+    });
+
+    assert.strictEqual(storageDeleteCalls.length, 2);
+    assert.strictEqual(storageDeleteCalls[0].object, "279/r1.m4a");
+    assert.strictEqual(storageDeleteCalls[1].object, "279/r2.m4a");
+  });
+});


### PR DESCRIPTION
## Summary

PR #191 (Issue #182 iOS delete) で iOS から Firestore doc のみ削除する設計にした結果、Cloud Storage の audio object が orphan blob として残る問題を解消。Firestore `onDocumentDeleted` trigger で `audioStoragePath` を参照して Storage object を server-side で削除する。

**本 PR は Phase A (impl + test) のみ。** Phase B (dev deploy) / Phase C (prod deploy + runbook) は merge 後に個別承認で実施するため、本 PR では `Closes #192` は **記載しない**。Phase C 完了時に手動で close する。

## 変更概要

### `functions/index.js`
- `exports.onRecordingDeleted = onDocumentDeleted("tenants/{tenantId}/recordings/{recordingId}", handleRecordingDeleted)` を追加
- handler は既存 `parseGsUri` helper を再利用、`getStorage().bucket().file().delete({ ignoreNotFound: true })` で Storage object 削除
- **失敗時は throw せず error log のみ**: trigger を throw すると Firebase は exponential backoff で retry し続ける。orphan は手動 cleanup (`scripts/delete-empty-createdby.mjs` 系) で回収可能
- handler を `exports._handleRecordingDeleted` として named export: `firebase-functions-test` の `makeDocumentSnapshot` が `delete-account.test.js` 等の `getFirestore` mock と干渉する問題を回避するため、test では handler を直接呼ぶ
- `deleteAccount` の docstring に「trigger との二重実行は `ignoreNotFound: true` で冪等」を明記

### `functions/test/on-recording-deleted.test.js` (新規 / +206 行)
カバー:
- valid `gs://carenote-dev-279-audio/279/r1.m4a` → bucket.file().delete({ ignoreNotFound: true }) 1 回呼出
- `audioStoragePath` が undefined / null / 空文字 → Storage 呼ばない、no-op 完走
- 非 gs:// URI (`https://...`) → warn ログ + skip
- Storage delete が permission error / generic error で fail → trigger は throw しない
- 複数連続発火 → 各々独立に処理 (冪等性確認)

## Acceptance Criteria

| # | 基準 | 検証 |
|---|------|------|
| AC1 | valid `gs://` URI で bucket.file().delete() を `ignoreNotFound:true` で呼ぶ | ✅ test |
| AC2 | `audioStoragePath` 欠落 (undefined/null/空) で no-op | ✅ test |
| AC3 | 不正 URI (`https://...` 等) で warn + skip | ✅ test |
| AC4 | Storage delete 失敗で error log + 非 throw | ✅ test |
| AC5 | `deleteAccount` との二重実行で冪等 | docstring + 既存 test 破壊なし |
| AC6 | 既存 test に regression なし | ✅ delete-account 14 + audit 8 + delete-empty-createdby + on-recording-deleted 8 = 43 tests / 0 failed (emulator 不要分) |
| AC7 (Phase B) | dev deploy + smoke | 別承認 |
| AC8 (Phase C) | prod deploy + runbook | 別承認 |

## Test plan

- [x] local: `npx mocha test/on-recording-deleted.test.js` → 8 / 0 failed
- [x] local: emulator 不要 test 合同実行 → 43 / 0 failed (regression なし)
- [ ] CI: `firebase emulators:exec ... npm test` (PR push で自動実行)
- [ ] Phase B: `firebase deploy --only functions:onRecordingDeleted -P dev`
- [ ] Phase B: dev TestFlight 経由で iOS swipe delete → Cloud Console で audio object 消滅確認
- [ ] Phase C: `firebase deploy --only functions:onRecordingDeleted -P prod` + runbook 追記

## 非スコープ (本 PR 範囲外)

- **Deploy** (Phase B / C): 個別承認後に実施
- **runbook**: Phase C で `docs/runbooks/` に Cloud Function 失敗時の手動 cleanup 手順を追記
- **iOS 側の表示変更**: trigger は server-side のみ、iOS は変更なし
- **既存 `deleteAccount` の Storage 削除ロジック整理**: 二重実行冪等で動作するため統合は YAGNI

Refs #192 (Phase A; auto-close は Phase C 完了後に手動で実施)

🤖 Generated with [Claude Code](https://claude.com/claude-code)