### PR TITLE
feat(ios): #201 transferOwnership iOS admin UI (ADR-008 Phase 2)

### DIFF
--- a/CareNote.xcodeproj/project.pbxproj
+++ b/CareNote.xcodeproj/project.pbxproj
@@ -70,6 +70,7 @@
 		D500243B9B526706E3BCE5AF /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = DA628FEE8E8929DE6D2651EC /* GoogleService-Info.plist */; };
 		D68884E97DC6ABD4E1501E05 /* WIFAuthService.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC5C0A2EB369429A8FD3D891 /* WIFAuthService.swift */; };
 		DEA5BEF6533AC992CA56ACE1 /* FirebaseAuth in Frameworks */ = {isa = PBXBuildFile; productRef = 780EB4E4898BE568D7C4B343 /* FirebaseAuth */; };
+		EB0C70705D8374EAD17EAFE3 /* AccountTransferViewMessageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 140C07CE41F695D5C8F29472 /* AccountTransferViewMessageTests.swift */; };
 		ED47579B2EE6DA52E42AD34D /* TransferOwnershipServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64D98898DABD5809A475A0C0 /* TransferOwnershipServiceTests.swift */; };
 		EE6FD95E89E69854891FD11C /* ClientSelectViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DD7DBB99EAE4823CA33FA82 /* ClientSelectViewModelTests.swift */; };
 		F059E67D489FA04FC0A4A455 /* TransferOwnershipService.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD847659B578124282BC38DB /* TransferOwnershipService.swift */; };
@@ -98,6 +99,7 @@
 		11F7A54E6C83AA0B51126525 /* TemplateListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemplateListView.swift; sourceTree = "<group>"; };
 		139399ACF89F42E029CD0CB1 /* AccountTransferView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountTransferView.swift; sourceTree = "<group>"; };
 		13ED2870967AA1A35CE8FA37 /* RecordingRepositoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingRepositoryTests.swift; sourceTree = "<group>"; };
+		140C07CE41F695D5C8F29472 /* AccountTransferViewMessageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountTransferViewMessageTests.swift; sourceTree = "<group>"; };
 		19852073B5385852F328F281 /* StorageServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageServiceTests.swift; sourceTree = "<group>"; };
 		1CEEA689FBC6B94B6C315907 /* CareNote.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = CareNote.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		1D1751BC835BB28519295961 /* AppConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfig.swift; sourceTree = "<group>"; };
@@ -306,6 +308,7 @@
 		716AE9A177EA66220562BECC /* CareNoteTests */ = {
 			isa = PBXGroup;
 			children = (
+				140C07CE41F695D5C8F29472 /* AccountTransferViewMessageTests.swift */,
 				85290DC06C806F0EEF4298F0 /* AccountTransferViewModelTests.swift */,
 				9BD36BBA888E8960D96DC910 /* AuthViewModelTests.swift */,
 				97707E72915C49324CCC7394 /* ClientCacheServiceTests.swift */,
@@ -527,6 +530,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				EB0C70705D8374EAD17EAFE3 /* AccountTransferViewMessageTests.swift in Sources */,
 				FC4E77C1A7F0C3B6376F93DE /* AccountTransferViewModelTests.swift in Sources */,
 				C60B40FD6A5D17715EAE0AD4 /* AuthViewModelTests.swift in Sources */,
 				53F062DE9A557C10ABC064D2 /* ClientCacheServiceTests.swift in Sources */,

--- a/CareNote.xcodeproj/project.pbxproj
+++ b/CareNote.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0258644D23C0B97A9D795C47 /* AccountTransferView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 139399ACF89F42E029CD0CB1 /* AccountTransferView.swift */; };
 		067B9DD725C1C464134BF7AE /* FirebaseFunctions in Frameworks */ = {isa = PBXBuildFile; productRef = A8351CF282FBD37D450C7CAA /* FirebaseFunctions */; };
 		0859FC46515B27F9B97FC1F6 /* SceneSelectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A269AFC38F3097F4CDCF8DF /* SceneSelectView.swift */; };
 		0902A03D28689676FBA5A55E /* WIFAuthServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D437E580EA429317272B4F9 /* WIFAuthServiceTests.swift */; };
@@ -19,6 +20,7 @@
 		32FB2DE8BCDAB9EA5285250B /* GoogleSignInSwift in Frameworks */ = {isa = PBXBuildFile; productRef = C6A8EFE7C4356D0F17B5D689 /* GoogleSignInSwift */; };
 		33992576E1D90FE68CFBFFA2 /* GoogleSignIn in Frameworks */ = {isa = PBXBuildFile; productRef = 1DFFB0082E42BA992D89756B /* GoogleSignIn */; };
 		3BD5BC7613B343D31D862160 /* KeychainHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9CB37C87346E35793C32386 /* KeychainHelper.swift */; };
+		3F363AE7FF848C519FE40C7A /* AccountTransferViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A24B525C492C30290B053980 /* AccountTransferViewModel.swift */; };
 		3F752F8424C4122A17EF1FEE /* PresetTemplates.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECB12BF484200EAC264DAC63 /* PresetTemplates.swift */; };
 		3FE937C69F2334F51FF60A32 /* TemplateListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 045FD4755BC7F09BF6967EB7 /* TemplateListViewModel.swift */; };
 		47FE4B218F49277FBB05F518 /* RecordingListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88B74F6BC7FCB2B9178B42F7 /* RecordingListViewModelTests.swift */; };
@@ -68,9 +70,12 @@
 		D500243B9B526706E3BCE5AF /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = DA628FEE8E8929DE6D2651EC /* GoogleService-Info.plist */; };
 		D68884E97DC6ABD4E1501E05 /* WIFAuthService.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC5C0A2EB369429A8FD3D891 /* WIFAuthService.swift */; };
 		DEA5BEF6533AC992CA56ACE1 /* FirebaseAuth in Frameworks */ = {isa = PBXBuildFile; productRef = 780EB4E4898BE568D7C4B343 /* FirebaseAuth */; };
+		ED47579B2EE6DA52E42AD34D /* TransferOwnershipServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64D98898DABD5809A475A0C0 /* TransferOwnershipServiceTests.swift */; };
 		EE6FD95E89E69854891FD11C /* ClientSelectViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DD7DBB99EAE4823CA33FA82 /* ClientSelectViewModelTests.swift */; };
+		F059E67D489FA04FC0A4A455 /* TransferOwnershipService.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD847659B578124282BC38DB /* TransferOwnershipService.swift */; };
 		F503CBD6C43A313174F070AA /* OutboxSyncService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31A63277501286D0902113FA /* OutboxSyncService.swift */; };
 		F816CF04479CE47B08176B58 /* EnumStableIdentifierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BD5333C19B8D05EBA8B140B /* EnumStableIdentifierTests.swift */; };
+		FC4E77C1A7F0C3B6376F93DE /* AccountTransferViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85290DC06C806F0EEF4298F0 /* AccountTransferViewModelTests.swift */; };
 		FD8997F1B7751D73EDA8FD45 /* TemplateListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9B4E2778FEE530A1DC4DF06 /* TemplateListViewModelTests.swift */; };
 /* End PBXBuildFile section */
 
@@ -91,6 +96,7 @@
 		042E6E584A73ED207A24A590 /* OutboxSyncServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OutboxSyncServiceTests.swift; sourceTree = "<group>"; };
 		045FD4755BC7F09BF6967EB7 /* TemplateListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemplateListViewModel.swift; sourceTree = "<group>"; };
 		11F7A54E6C83AA0B51126525 /* TemplateListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemplateListView.swift; sourceTree = "<group>"; };
+		139399ACF89F42E029CD0CB1 /* AccountTransferView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountTransferView.swift; sourceTree = "<group>"; };
 		13ED2870967AA1A35CE8FA37 /* RecordingRepositoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingRepositoryTests.swift; sourceTree = "<group>"; };
 		19852073B5385852F328F281 /* StorageServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageServiceTests.swift; sourceTree = "<group>"; };
 		1CEEA689FBC6B94B6C315907 /* CareNote.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = CareNote.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -114,11 +120,13 @@
 		4D437E580EA429317272B4F9 /* WIFAuthServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WIFAuthServiceTests.swift; sourceTree = "<group>"; };
 		5145C7CB43880EF7C55A94B3 /* StorageService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageService.swift; sourceTree = "<group>"; };
 		58D2B24492527E7C7CE59620 /* FirestoreModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirestoreModels.swift; sourceTree = "<group>"; };
+		64D98898DABD5809A475A0C0 /* TransferOwnershipServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransferOwnershipServiceTests.swift; sourceTree = "<group>"; };
 		6CCF73C9C8E3E2C08DD50815 /* ClientRepositoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientRepositoryTests.swift; sourceTree = "<group>"; };
 		7452B80D90D9172B77475447 /* ClientSelectViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientSelectViewModel.swift; sourceTree = "<group>"; };
 		7BD5333C19B8D05EBA8B140B /* EnumStableIdentifierTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnumStableIdentifierTests.swift; sourceTree = "<group>"; };
 		7C870BA88FAE7FE80BBF4DD2 /* SwiftDataModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftDataModels.swift; sourceTree = "<group>"; };
 		7E51986CBBEC3607B0256C7A /* RecordingViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingViewModelTests.swift; sourceTree = "<group>"; };
+		85290DC06C806F0EEF4298F0 /* AccountTransferViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountTransferViewModelTests.swift; sourceTree = "<group>"; };
 		88B74F6BC7FCB2B9178B42F7 /* RecordingListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingListViewModelTests.swift; sourceTree = "<group>"; };
 		933487C9E5291192E20D3FD6 /* RecordingListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingListViewModel.swift; sourceTree = "<group>"; };
 		95C67F09979A83A8D77ED023 /* MockURLProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockURLProtocol.swift; sourceTree = "<group>"; };
@@ -129,6 +137,7 @@
 		9BD36BBA888E8960D96DC910 /* AuthViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthViewModelTests.swift; sourceTree = "<group>"; };
 		9F9FC31CCE425A0E9107ACB3 /* CareNoteApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CareNoteApp.swift; sourceTree = "<group>"; };
 		A0B042EBE580E9D6CBA65F7C /* AudioRecorderService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioRecorderService.swift; sourceTree = "<group>"; };
+		A24B525C492C30290B053980 /* AccountTransferViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountTransferViewModel.swift; sourceTree = "<group>"; };
 		A98BBDBB5774B595F092430F /* RecordingListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingListView.swift; sourceTree = "<group>"; };
 		A9CBCE04F87683C59768366C /* TemplateCreateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemplateCreateView.swift; sourceTree = "<group>"; };
 		B19118D3C407ABA870A521B2 /* RecordingScene.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingScene.swift; sourceTree = "<group>"; };
@@ -137,6 +146,7 @@
 		C1773834D66185AC4FF05004 /* RecordingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingViewModel.swift; sourceTree = "<group>"; };
 		C66B8FD7F4EEDA2F428C0A1F /* ClientRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientRepository.swift; sourceTree = "<group>"; };
 		C75F7694513195B13FC911A0 /* SwiftDataTestHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftDataTestHelperTests.swift; sourceTree = "<group>"; };
+		CD847659B578124282BC38DB /* TransferOwnershipService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransferOwnershipService.swift; sourceTree = "<group>"; };
 		CE80E23E3C3633F29AC0F0DA /* TranscriptionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptionService.swift; sourceTree = "<group>"; };
 		DA628FEE8E8929DE6D2651EC /* GoogleService-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		E0C0F8FB680432239DF40DE4 /* RecordingConfirmViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingConfirmViewModelTests.swift; sourceTree = "<group>"; };
@@ -220,6 +230,7 @@
 				31A63277501286D0902113FA /* OutboxSyncService.swift */,
 				5145C7CB43880EF7C55A94B3 /* StorageService.swift */,
 				CE80E23E3C3633F29AC0F0DA /* TranscriptionService.swift */,
+				CD847659B578124282BC38DB /* TransferOwnershipService.swift */,
 				EC5C0A2EB369429A8FD3D891 /* WIFAuthService.swift */,
 			);
 			path = Services;
@@ -295,6 +306,7 @@
 		716AE9A177EA66220562BECC /* CareNoteTests */ = {
 			isa = PBXGroup;
 			children = (
+				85290DC06C806F0EEF4298F0 /* AccountTransferViewModelTests.swift */,
 				9BD36BBA888E8960D96DC910 /* AuthViewModelTests.swift */,
 				97707E72915C49324CCC7394 /* ClientCacheServiceTests.swift */,
 				6CCF73C9C8E3E2C08DD50815 /* ClientRepositoryTests.swift */,
@@ -311,6 +323,7 @@
 				2A76D8BBD11811BC4D741477 /* TemplateCreateViewModelTests.swift */,
 				E9B4E2778FEE530A1DC4DF06 /* TemplateListViewModelTests.swift */,
 				46A7E7E108F739F5871EB716 /* TranscriptionServiceTests.swift */,
+				64D98898DABD5809A475A0C0 /* TransferOwnershipServiceTests.swift */,
 				4D437E580EA429317272B4F9 /* WIFAuthServiceTests.swift */,
 				88C79EF519A21CCDA8506A62 /* TestHelpers */,
 			);
@@ -372,6 +385,8 @@
 		A2884EDBFB90B420152CD3FF /* Settings */ = {
 			isa = PBXGroup;
 			children = (
+				139399ACF89F42E029CD0CB1 /* AccountTransferView.swift */,
+				A24B525C492C30290B053980 /* AccountTransferViewModel.swift */,
 				B6C5DFB4EEA458F1AA1EB33F /* SettingsView.swift */,
 				A9CBCE04F87683C59768366C /* TemplateCreateView.swift */,
 				3ECEF75B614C6A2B223AB02F /* TemplateCreateViewModel.swift */,
@@ -512,6 +527,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				FC4E77C1A7F0C3B6376F93DE /* AccountTransferViewModelTests.swift in Sources */,
 				C60B40FD6A5D17715EAE0AD4 /* AuthViewModelTests.swift in Sources */,
 				53F062DE9A557C10ABC064D2 /* ClientCacheServiceTests.swift in Sources */,
 				55BE8768F641C64BE1837884 /* ClientRepositoryTests.swift in Sources */,
@@ -531,6 +547,7 @@
 				B5FD3368DC82D3A7F025330E /* TemplateCreateViewModelTests.swift in Sources */,
 				FD8997F1B7751D73EDA8FD45 /* TemplateListViewModelTests.swift in Sources */,
 				CCA4CF007249D2BA99FD5315 /* TranscriptionServiceTests.swift in Sources */,
+				ED47579B2EE6DA52E42AD34D /* TransferOwnershipServiceTests.swift in Sources */,
 				0902A03D28689676FBA5A55E /* WIFAuthServiceTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -539,6 +556,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0258644D23C0B97A9D795C47 /* AccountTransferView.swift in Sources */,
+				3F363AE7FF848C519FE40C7A /* AccountTransferViewModel.swift in Sources */,
 				C74386AC37344205E71E5B2B /* AppConfig.swift in Sources */,
 				6DA2DDE0F90D3985BC3C5D17 /* AppEnvironment.swift in Sources */,
 				8234CBC662F2FB30E1866158 /* AppleSignInCoordinator.swift in Sources */,
@@ -576,6 +595,7 @@
 				3FE937C69F2334F51FF60A32 /* TemplateListViewModel.swift in Sources */,
 				13A5A2945594CCE9F062EE03 /* TimeFormatting.swift in Sources */,
 				867BA544A9DB963182049D63 /* TranscriptionService.swift in Sources */,
+				F059E67D489FA04FC0A4A455 /* TransferOwnershipService.swift in Sources */,
 				D68884E97DC6ABD4E1501E05 /* WIFAuthService.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/CareNote/Features/Settings/AccountTransferView.swift
+++ b/CareNote/Features/Settings/AccountTransferView.swift
@@ -145,8 +145,9 @@ struct AccountTransferView: View {
     }
 
     /// `TransferOwnershipError` をユーザー向け文言にマップする。
-    /// テスト容易性のため static func で外部から検証可能にする。
-    static func message(for error: TransferOwnershipError) -> String {
+    /// SwiftUI `View` は `@MainActor` 隔離されるが、本関数は pure function (state 非依存) のため
+    /// `nonisolated` で外部 (テスト等) から MainActor 跨ぎでも呼び出せるようにする。
+    nonisolated static func message(for error: TransferOwnershipError) -> String {
         switch error {
         case .unauthenticated:
             return "ログインが必要です。再ログインしてください。"

--- a/CareNote/Features/Settings/AccountTransferView.swift
+++ b/CareNote/Features/Settings/AccountTransferView.swift
@@ -1,0 +1,192 @@
+import SwiftUI
+
+/// admin 専用「アカウント引き継ぎ」UI。
+///
+/// `AccountTransferViewModel` の state machine に bind して、入力 → dryRun → preview →
+/// 二段階 confirm → 結果表示の 1 画面を提供する。
+struct AccountTransferView: View {
+    @State private var viewModel: AccountTransferViewModel
+
+    init(service: any TransferOwnershipServicing = TransferOwnershipService()) {
+        self._viewModel = State(initialValue: AccountTransferViewModel(service: service))
+    }
+
+    var body: some View {
+        Form {
+            Section {
+                Text("旧アカウントの録音・テンプレート・ホワイトリスト登録を新アカウントに引き継ぎます。改姓等で uid が変わったメンバーが対象です。")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            }
+
+            Section("引き継ぎ元・先 (uid)") {
+                TextField("旧 uid (Firebase Auth uid)", text: $viewModel.fromUidInput)
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled()
+                    .disabled(isInputDisabled)
+                    .accessibilityLabel("旧アカウントの UID")
+                TextField("新 uid (Firebase Auth uid)", text: $viewModel.toUidInput)
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled()
+                    .disabled(isInputDisabled)
+                    .accessibilityLabel("新アカウントの UID")
+            }
+
+            Section {
+                Button {
+                    Task { await viewModel.runDryRun() }
+                } label: {
+                    if case .dryRunInFlight = viewModel.state {
+                        HStack {
+                            ProgressView()
+                            Text("件数を確認中…")
+                        }
+                    } else {
+                        Label("件数プレビュー (dryRun)", systemImage: "magnifyingglass")
+                    }
+                }
+                .disabled(isInputDisabled)
+            }
+
+            previewSection
+            completedSection
+            failedSection
+        }
+        .navigationTitle("アカウント引き継ぎ")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+
+    // MARK: - Conditional sections
+
+    @ViewBuilder
+    private var previewSection: some View {
+        if case let .preview(_, counts) = viewModel.state {
+            Section("引き継ぎ対象の件数") {
+                LabeledContent("録音 (recordings)") { Text("\(counts.recordings) 件") }
+                LabeledContent("テンプレート (templates)") { Text("\(counts.templates) 件") }
+                LabeledContent("ホワイトリスト (whitelist)") { Text("\(counts.whitelist) 件") }
+            }
+            Section {
+                Toggle(
+                    "上記の件数で引き継ぎを実行することを確認しました",
+                    isOn: $viewModel.confirmCheckboxChecked
+                )
+                Button(role: .destructive) {
+                    Task { await viewModel.confirmTransfer() }
+                } label: {
+                    Label("引き継ぎを実行", systemImage: "arrow.right.arrow.left")
+                }
+                .disabled(!viewModel.canConfirm)
+            } header: {
+                Text("最終確認")
+            } footer: {
+                Text("実行後、旧 uid の所有データは新 uid へ書き換わります。書き換えはチェックポイント方式で中断再開可能です。")
+                    .font(.caption2)
+            }
+        } else if case let .confirmInFlight(dryRunId) = viewModel.state {
+            Section {
+                HStack {
+                    ProgressView()
+                    Text("引き継ぎを実行中… (id: \(dryRunId))")
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var completedSection: some View {
+        if case let .completed(updated) = viewModel.state {
+            Section {
+                LabeledContent("録音") { Text("\(updated.recordings) 件 更新") }
+                LabeledContent("テンプレート") { Text("\(updated.templates) 件 更新") }
+                LabeledContent("ホワイトリスト") { Text("\(updated.whitelist) 件 更新") }
+                Button {
+                    viewModel.reset()
+                } label: {
+                    Label("画面をリセット", systemImage: "arrow.counterclockwise")
+                }
+            } header: {
+                Text("引き継ぎ完了")
+            } footer: {
+                Text("migrationLogs に実行記録が保存されました。新 uid で改めてログインすると引き継いだデータが表示されます。")
+                    .font(.caption2)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var failedSection: some View {
+        if case let .failed(error) = viewModel.state {
+            Section("エラー") {
+                Label(Self.message(for: error), systemImage: "exclamationmark.triangle.fill")
+                    .font(.footnote.weight(.semibold))
+                    .foregroundStyle(.red)
+                Button {
+                    viewModel.reset()
+                } label: {
+                    Label("最初からやり直す", systemImage: "arrow.counterclockwise")
+                }
+            }
+        }
+    }
+
+    // MARK: - Helpers
+
+    /// 実行中状態は入力編集を禁止して race condition を防ぐ。
+    private var isInputDisabled: Bool {
+        switch viewModel.state {
+        case .dryRunInFlight, .confirmInFlight:
+            return true
+        default:
+            return false
+        }
+    }
+
+    /// `TransferOwnershipError` をユーザー向け文言にマップする。
+    /// テスト容易性のため static func で外部から検証可能にする。
+    static func message(for error: TransferOwnershipError) -> String {
+        switch error {
+        case .unauthenticated:
+            return "ログインが必要です。再ログインしてください。"
+        case .permissionDenied:
+            return "管理者権限が必要です。"
+        case .failedPrecondition:
+            return "テナント情報が取得できません。サインアウトしてから再ログインしてください。"
+        case let .invalidArgument(message):
+            return message.isEmpty ? "入力内容に誤りがあります。" : message
+        case .notFound:
+            return "対象の dryRunId が見つかりません。最初からやり直してください。"
+        case .alreadyExists:
+            return "同じ操作が既に実行中または完了済みです。少し時間をおいて再度お試しください。"
+        case let .internal(message):
+            return "サーバー内部エラーが発生しました。\(message ?? "") \nしばらく時間をおいて再度お試しください。"
+        case .malformedResponse:
+            return "サーバーからの応答が不正です。アプリを最新版にアップデートしてください。"
+        case let .unknown(nsError):
+            return "想定外のエラーが発生しました (code: \(nsError.code))。"
+        }
+    }
+}
+
+#Preview {
+    NavigationStack {
+        AccountTransferView(service: PreviewTransferOwnershipService())
+    }
+}
+
+private final class PreviewTransferOwnershipService: TransferOwnershipServicing {
+    func dryRun(fromUid: String, toUid: String) async throws -> TransferOwnershipDryRunResult {
+        try await Task.sleep(nanoseconds: 300_000_000)
+        return TransferOwnershipDryRunResult(
+            dryRunId: "preview-dry-run-id",
+            counts: TransferOwnershipCounts(recordings: 12, templates: 3, whitelist: 1)
+        )
+    }
+
+    func confirm(dryRunId: String) async throws -> TransferOwnershipConfirmResult {
+        try await Task.sleep(nanoseconds: 500_000_000)
+        return TransferOwnershipConfirmResult(
+            updated: TransferOwnershipCounts(recordings: 12, templates: 3, whitelist: 1)
+        )
+    }
+}

--- a/CareNote/Features/Settings/AccountTransferView.swift
+++ b/CareNote/Features/Settings/AccountTransferView.swift
@@ -132,13 +132,15 @@ struct AccountTransferView: View {
 
     // MARK: - Helpers
 
-    /// 実行中状態は入力編集を禁止して race condition を防ぐ。
+    /// 実行中・preview/completed/failed 状態では入力ロック。
+    /// 特に preview 状態で uid を編集できると、表示中の counts と confirm 実行内容が
+    /// ズレる (二段階 confirm の安全性違反)。idle に戻すには「最初からやり直す」/「画面をリセット」を経由させる。
     private var isInputDisabled: Bool {
         switch viewModel.state {
-        case .dryRunInFlight, .confirmInFlight:
-            return true
-        default:
+        case .idle:
             return false
+        case .dryRunInFlight, .confirmInFlight, .preview, .completed, .failed:
+            return true
         }
     }
 
@@ -157,13 +159,16 @@ struct AccountTransferView: View {
         case .notFound:
             return "対象の dryRunId が見つかりません。最初からやり直してください。"
         case .alreadyExists:
-            return "同じ操作が既に実行中または完了済みです。少し時間をおいて再度お試しください。"
+            return "この dryRun は既に処理されています。「最初からやり直す」を選んで新しい操作として再開してください。"
         case let .internal(message):
-            return "サーバー内部エラーが発生しました。\(message ?? "") \nしばらく時間をおいて再度お試しください。"
+            let detail = (message?.isEmpty == false) ? "\n\(message!)" : ""
+            return "サーバー内部エラーが発生しました。\(detail)\nしばらく時間をおいて再度お試しください。"
         case .malformedResponse:
             return "サーバーからの応答が不正です。アプリを最新版にアップデートしてください。"
+        case .transient:
+            return "ネットワークまたはサーバーが一時的に応答していません。電波状況を確認のうえ、少し時間をおいて再度お試しください。"
         case let .unknown(nsError):
-            return "想定外のエラーが発生しました (code: \(nsError.code))。"
+            return "想定外のエラーが発生しました (\(nsError.domain) code: \(nsError.code))。"
         }
     }
 }

--- a/CareNote/Features/Settings/AccountTransferViewModel.swift
+++ b/CareNote/Features/Settings/AccountTransferViewModel.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Observation
+import os.log
 
 /// admin 専用「アカウント引き継ぎ」UI の状態機械。
 ///
@@ -26,6 +27,7 @@ final class AccountTransferViewModel {
     /// `confirmTransfer()` の実行が許可される。
     var confirmCheckboxChecked: Bool = false
 
+    private static let logger = Logger(subsystem: "jp.carenote.app", category: "AccountTransferVM")
     private let service: any TransferOwnershipServicing
 
     init(service: any TransferOwnershipServicing) {
@@ -71,9 +73,13 @@ final class AccountTransferViewModel {
     }
 
     /// preview 状態 + checkbox チェック済の場合のみ confirm を呼ぶ。
-    /// それ以外で呼ばれた場合は no-op (UI 制約からの呼び出し漏れを構造的に無害化)。
+    /// それ以外で呼ばれた場合は no-op + notice ログ (UI 制約からの呼び出し漏れを構造的に無害化、
+    /// race condition / 連打を silent に飲み込まないため Logger に痕跡を残す)。
     func confirmTransfer() async {
-        guard case let .preview(dryRunId, _) = state, confirmCheckboxChecked else { return }
+        guard case let .preview(dryRunId, _) = state, confirmCheckboxChecked else {
+            Self.logger.notice("confirmTransfer called outside valid context: state=\(String(describing: self.state), privacy: .public), checkbox=\(self.confirmCheckboxChecked, privacy: .public)")
+            return
+        }
         state = .confirmInFlight(dryRunId: dryRunId)
         do {
             let result = try await service.confirm(dryRunId: dryRunId)

--- a/CareNote/Features/Settings/AccountTransferViewModel.swift
+++ b/CareNote/Features/Settings/AccountTransferViewModel.swift
@@ -1,0 +1,96 @@
+import Foundation
+import Observation
+
+/// admin 専用「アカウント引き継ぎ」UI の状態機械。
+///
+/// `transferOwnership` Cloud Function (ADR-008 Phase 1) を 2 段階 (dryRun → confirm)
+/// で呼び出し、各ステップの状態と入力 validation を保持する。
+@MainActor
+@Observable
+final class AccountTransferViewModel {
+    /// state machine の状態。
+    /// `failed` 以外は遷移可能な経路が一意 (idle → dryRunInFlight → preview → confirmInFlight → completed)。
+    enum State: Sendable, Equatable {
+        case idle
+        case dryRunInFlight
+        case preview(dryRunId: String, counts: TransferOwnershipCounts)
+        case confirmInFlight(dryRunId: String)
+        case completed(updated: TransferOwnershipCounts)
+        case failed(TransferOwnershipError)
+    }
+
+    var state: State = .idle
+    var fromUidInput: String = ""
+    var toUidInput: String = ""
+    /// 二段階 confirm のチェックボックス。`preview` で `true` になって初めて
+    /// `confirmTransfer()` の実行が許可される。
+    var confirmCheckboxChecked: Bool = false
+
+    private let service: any TransferOwnershipServicing
+
+    init(service: any TransferOwnershipServicing) {
+        self.service = service
+    }
+
+    /// preview 状態かつ checkbox チェック済の場合のみ true。UI 側は確定ボタンの enabled に bind する。
+    var canConfirm: Bool {
+        if case .preview = state, confirmCheckboxChecked { return true }
+        return false
+    }
+
+    /// 入力検証 → dryRun 呼出。空文字 / 同一 uid は server へ行く前にローカルで弾く。
+    /// (server 側 `transferOwnership.js` も同等の検証を持つが、UX 改善のため UI でも行う)
+    func runDryRun() async {
+        let from = fromUidInput.trimmingCharacters(in: .whitespacesAndNewlines)
+        let to = toUidInput.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !from.isEmpty else {
+            state = .failed(.invalidArgument("旧 uid を入力してください"))
+            return
+        }
+        guard !to.isEmpty else {
+            state = .failed(.invalidArgument("新 uid を入力してください"))
+            return
+        }
+        guard from != to else {
+            state = .failed(.invalidArgument("同一 uid は指定できません"))
+            return
+        }
+        // 直前の preview / completed / failed で checkbox が true のまま残っていると、
+        // 新しい preview で confirm ボタンが即時 enabled になり二段階 confirm が崩れる。
+        // dryRun 開始時に必ずリセットする。
+        confirmCheckboxChecked = false
+        state = .dryRunInFlight
+        do {
+            let result = try await service.dryRun(fromUid: from, toUid: to)
+            state = .preview(dryRunId: result.dryRunId, counts: result.counts)
+        } catch let error as TransferOwnershipError {
+            state = .failed(error)
+        } catch {
+            state = .failed(.unknown(error as NSError))
+        }
+    }
+
+    /// preview 状態 + checkbox チェック済の場合のみ confirm を呼ぶ。
+    /// それ以外で呼ばれた場合は no-op (UI 制約からの呼び出し漏れを構造的に無害化)。
+    func confirmTransfer() async {
+        guard case let .preview(dryRunId, _) = state, confirmCheckboxChecked else { return }
+        state = .confirmInFlight(dryRunId: dryRunId)
+        do {
+            let result = try await service.confirm(dryRunId: dryRunId)
+            state = .completed(updated: result.updated)
+        } catch let error as TransferOwnershipError {
+            state = .failed(error)
+        } catch {
+            state = .failed(.unknown(error as NSError))
+        }
+    }
+
+    /// 入力と状態をすべてクリアして初期画面へ戻す。
+    /// completed / failed 後の「もう一度」ボタンや、画面離脱時に呼ぶ。
+    func reset() {
+        state = .idle
+        fromUidInput = ""
+        toUidInput = ""
+        confirmCheckboxChecked = false
+    }
+}

--- a/CareNote/Features/Settings/SettingsView.swift
+++ b/CareNote/Features/Settings/SettingsView.swift
@@ -29,6 +29,21 @@ struct SettingsView: View {
                 }
             }
 
+            if authViewModel.authState.isAdmin {
+                Section {
+                    NavigationLink {
+                        AccountTransferView()
+                    } label: {
+                        Label("アカウント引き継ぎ", systemImage: "arrow.right.arrow.left")
+                    }
+                } header: {
+                    Text("管理者メニュー")
+                } footer: {
+                    Text("メンバーが改姓等で uid が変わった際、旧アカウントの録音・テンプレートを新アカウントに引き継ぎます。")
+                        .font(.caption2)
+                }
+            }
+
             Section("アカウント") {
                 Button(role: .destructive) {
                     showSignOutConfirmation = true

--- a/CareNote/Services/TransferOwnershipService.swift
+++ b/CareNote/Services/TransferOwnershipService.swift
@@ -1,0 +1,182 @@
+@preconcurrency import FirebaseFunctions
+import Foundation
+import os.log
+
+// MARK: - Value types
+
+/// `transferOwnership` Cloud Function の counts/updated レスポンス。
+/// 3 サブコレクション (recordings / templates / whitelist) の件数。
+struct TransferOwnershipCounts: Sendable, Equatable {
+    let recordings: Int
+    let templates: Int
+    let whitelist: Int
+}
+
+/// dryRun 呼出の戻り値。
+struct TransferOwnershipDryRunResult: Sendable, Equatable {
+    let dryRunId: String
+    let counts: TransferOwnershipCounts
+}
+
+/// confirm 呼出の戻り値。
+struct TransferOwnershipConfirmResult: Sendable, Equatable {
+    let updated: TransferOwnershipCounts
+}
+
+// MARK: - Error
+
+/// Cloud Function `transferOwnership` の HttpsError を UI 分岐可能な型へマップしたもの。
+///
+/// マッピング規則は `functions/src/transferOwnership.js` のエラーコード表 (ADR-008 Phase 1) に対応。
+enum TransferOwnershipError: Error, Sendable, Equatable {
+    /// ログイン未実施。
+    case unauthenticated
+    /// 非 admin が呼び出した。
+    case permissionDenied
+    /// caller の token に tenantId claim が無い等の前提崩れ。
+    case failedPrecondition
+    /// 引数欠落・型不正・`fromUid == toUid` 等。message は Cloud Function 側の文言。
+    case invalidArgument(String)
+    /// `dryRunId` 指定時に該当 doc が存在しない。
+    case notFound
+    /// 同じ `dryRunId` が既に running / completed (二重実行防止)。
+    case alreadyExists
+    /// Cloud Function 内部例外。message は Cloud Function 側の文言（あれば）。
+    case `internal`(String?)
+    /// レスポンス JSON の decode 失敗。
+    case malformedResponse
+    /// 想定外のエラー (ネットワーク / Functions 以外の domain 等)。
+    case unknown(NSError)
+
+    /// `Functions.functions().httpsCallable(...).call(...)` が throw した Error を
+    /// 内部エラー型にマップする。`FunctionsErrorDomain` のもののみコード分類し、
+    /// それ以外は `.unknown` で包む。
+    static func map(_ error: Error) -> TransferOwnershipError {
+        let nsError = error as NSError
+        guard nsError.domain == FunctionsErrorDomain else {
+            return .unknown(nsError)
+        }
+        let message = nsError.userInfo[NSLocalizedDescriptionKey] as? String
+        switch nsError.code {
+        case FunctionsErrorCode.unauthenticated.rawValue:
+            return .unauthenticated
+        case FunctionsErrorCode.permissionDenied.rawValue:
+            return .permissionDenied
+        case FunctionsErrorCode.failedPrecondition.rawValue:
+            return .failedPrecondition
+        case FunctionsErrorCode.invalidArgument.rawValue:
+            return .invalidArgument(message ?? "")
+        case FunctionsErrorCode.notFound.rawValue:
+            return .notFound
+        case FunctionsErrorCode.alreadyExists.rawValue:
+            return .alreadyExists
+        case FunctionsErrorCode.internal.rawValue:
+            return .internal(message)
+        default:
+            return .unknown(nsError)
+        }
+    }
+
+    /// `.unknown(NSError)` の同値判定は domain + code のみで行う (userInfo は含めない)。
+    /// userInfo は呼出毎に異なるメタ情報 (タイムスタンプ等) を含みうるため、
+    /// 比較対象に入れると同じエラー種別が偽陽性で differ 扱いになる。
+    static func == (lhs: TransferOwnershipError, rhs: TransferOwnershipError) -> Bool {
+        switch (lhs, rhs) {
+        case (.unauthenticated, .unauthenticated),
+             (.permissionDenied, .permissionDenied),
+             (.failedPrecondition, .failedPrecondition),
+             (.notFound, .notFound),
+             (.alreadyExists, .alreadyExists),
+             (.malformedResponse, .malformedResponse):
+            return true
+        case let (.invalidArgument(l), .invalidArgument(r)):
+            return l == r
+        case let (.internal(l), .internal(r)):
+            return l == r
+        case let (.unknown(l), .unknown(r)):
+            return l.domain == r.domain && l.code == r.code
+        default:
+            return false
+        }
+    }
+}
+
+// MARK: - Protocol
+
+/// `transferOwnership` Cloud Function を呼び出す抽象化。
+/// テスト容易性のために protocol にする (ViewModel は具象 SDK に依存しない)。
+protocol TransferOwnershipServicing: Sendable {
+    func dryRun(fromUid: String, toUid: String) async throws -> TransferOwnershipDryRunResult
+    func confirm(dryRunId: String) async throws -> TransferOwnershipConfirmResult
+}
+
+// MARK: - Firebase Functions impl
+
+/// `Functions.functions(region:).httpsCallable("transferOwnership")` への薄い wrapper。
+/// リージョン・callable 名は ADR-008 / `functions/src/transferOwnership.js` の REGION / export と一致。
+final class TransferOwnershipService: TransferOwnershipServicing, Sendable {
+    private static let logger = Logger(subsystem: "jp.carenote.app", category: "TransferOwnershipService")
+    private static let callableName = "transferOwnership"
+    private static let defaultRegion = "asia-northeast1"
+    private let region: String
+
+    init(region: String = TransferOwnershipService.defaultRegion) {
+        self.region = region
+    }
+
+    func dryRun(fromUid: String, toUid: String) async throws -> TransferOwnershipDryRunResult {
+        let functions = Functions.functions(region: region)
+        let payload: [String: Any] = [
+            "fromUid": fromUid,
+            "toUid": toUid,
+            "dryRun": true,
+        ]
+        let response: HTTPSCallableResult
+        do {
+            response = try await functions.httpsCallable(Self.callableName).call(payload)
+        } catch {
+            Self.logger.error("transferOwnership dryRun failed: \(error.localizedDescription, privacy: .public)")
+            throw TransferOwnershipError.map(error)
+        }
+        guard let dict = response.data as? [String: Any],
+              let dryRunId = dict["dryRunId"] as? String,
+              let counts = Self.parseCounts(dict["counts"])
+        else {
+            Self.logger.error("transferOwnership dryRun returned malformed response")
+            throw TransferOwnershipError.malformedResponse
+        }
+        return TransferOwnershipDryRunResult(dryRunId: dryRunId, counts: counts)
+    }
+
+    func confirm(dryRunId: String) async throws -> TransferOwnershipConfirmResult {
+        let functions = Functions.functions(region: region)
+        let payload: [String: Any] = ["dryRunId": dryRunId]
+        let response: HTTPSCallableResult
+        do {
+            response = try await functions.httpsCallable(Self.callableName).call(payload)
+        } catch {
+            Self.logger.error("transferOwnership confirm failed: \(error.localizedDescription, privacy: .public)")
+            throw TransferOwnershipError.map(error)
+        }
+        guard let dict = response.data as? [String: Any],
+              let updated = Self.parseCounts(dict["updated"])
+        else {
+            Self.logger.error("transferOwnership confirm returned malformed response")
+            throw TransferOwnershipError.malformedResponse
+        }
+        return TransferOwnershipConfirmResult(updated: updated)
+    }
+
+    /// JSON 由来の `Any` から `TransferOwnershipCounts` を取り出す。
+    /// 数値は NSNumber 経由で来うるため `Int` 強制 cast を介する。
+    private static func parseCounts(_ value: Any?) -> TransferOwnershipCounts? {
+        guard let dict = value as? [String: Any],
+              let recordings = (dict["recordings"] as? NSNumber)?.intValue,
+              let templates = (dict["templates"] as? NSNumber)?.intValue,
+              let whitelist = (dict["whitelist"] as? NSNumber)?.intValue
+        else {
+            return nil
+        }
+        return TransferOwnershipCounts(recordings: recordings, templates: templates, whitelist: whitelist)
+    }
+}

--- a/CareNote/Services/TransferOwnershipService.swift
+++ b/CareNote/Services/TransferOwnershipService.swift
@@ -45,14 +45,29 @@ enum TransferOwnershipError: Error, Sendable, Equatable {
     case `internal`(String?)
     /// レスポンス JSON の decode 失敗。
     case malformedResponse
-    /// 想定外のエラー (ネットワーク / Functions 以外の domain 等)。
+    /// transient エラー (network timeout / SDK unavailable / quota 超過 等)。
+    /// 分類基準は `~/.claude/rules/error-handling.md` §3 transient/permanent プロトコル準拠、
+    /// `FirestoreError.isTransient` (PR #198) と整合させる。
+    case transient(NSError)
+    /// 想定外のエラー (Functions 以外の未分類 domain 等)。
     case unknown(NSError)
 
+    /// transient エラーは指数バックオフでリトライ可能と判定する目安。
+    /// UI 側のリトライ誘導文言の出し分けに使う。
+    var isTransient: Bool {
+        if case .transient = self { return true }
+        return false
+    }
+
     /// `Functions.functions().httpsCallable(...).call(...)` が throw した Error を
-    /// 内部エラー型にマップする。`FunctionsErrorDomain` のもののみコード分類し、
-    /// それ以外は `.unknown` で包む。
+    /// 内部エラー型にマップする。`FunctionsErrorDomain` のコードを分類し、
+    /// transient な network/quota 系は `.transient`、未マップは `.unknown` で包む。
+    /// `NSURLErrorDomain` (オフライン等) も transient 扱い。
     static func map(_ error: Error) -> TransferOwnershipError {
         let nsError = error as NSError
+        if nsError.domain == NSURLErrorDomain {
+            return .transient(nsError)
+        }
         guard nsError.domain == FunctionsErrorDomain else {
             return .unknown(nsError)
         }
@@ -72,13 +87,18 @@ enum TransferOwnershipError: Error, Sendable, Equatable {
             return .alreadyExists
         case FunctionsErrorCode.internal.rawValue:
             return .internal(message)
+        case FunctionsErrorCode.deadlineExceeded.rawValue,
+             FunctionsErrorCode.unavailable.rawValue,
+             FunctionsErrorCode.resourceExhausted.rawValue,
+             FunctionsErrorCode.cancelled.rawValue:
+            return .transient(nsError)
         default:
             return .unknown(nsError)
         }
     }
 
-    /// `.unknown(NSError)` の同値判定は domain + code のみで行う (userInfo は含めない)。
-    /// userInfo は呼出毎に異なるメタ情報 (タイムスタンプ等) を含みうるため、
+    /// `.unknown(NSError)` / `.transient(NSError)` の同値判定は domain + code のみで行う
+    /// (userInfo は含めない)。userInfo は呼出毎に異なるメタ情報 (タイムスタンプ等) を含みうるため、
     /// 比較対象に入れると同じエラー種別が偽陽性で differ 扱いになる。
     static func == (lhs: TransferOwnershipError, rhs: TransferOwnershipError) -> Bool {
         switch (lhs, rhs) {
@@ -93,6 +113,8 @@ enum TransferOwnershipError: Error, Sendable, Equatable {
             return l == r
         case let (.internal(l), .internal(r)):
             return l == r
+        case let (.transient(l), .transient(r)):
+            return l.domain == r.domain && l.code == r.code
         case let (.unknown(l), .unknown(r)):
             return l.domain == r.domain && l.code == r.code
         default:

--- a/CareNoteTests/AccountTransferViewMessageTests.swift
+++ b/CareNoteTests/AccountTransferViewMessageTests.swift
@@ -1,0 +1,79 @@
+@testable import CareNote
+import Foundation
+import Testing
+
+/// `AccountTransferView.message(for:)` の文言マッピング検証。
+/// AC-B5 「管理者権限が必要です」を含む各エラー文言が回帰しないことを保証する。
+/// 文言は admin への直接フィードバックなので、リファクタで揺れさせない。
+@Suite("AccountTransferView.message(for:) mapping")
+struct AccountTransferViewMessageTests {
+    @Test func unauthenticated_message() {
+        #expect(AccountTransferView.message(for: .unauthenticated)
+            == "ログインが必要です。再ログインしてください。")
+    }
+
+    @Test func permissionDenied_message() {
+        #expect(AccountTransferView.message(for: .permissionDenied)
+            == "管理者権限が必要です。")
+    }
+
+    @Test func failedPrecondition_message() {
+        #expect(AccountTransferView.message(for: .failedPrecondition)
+            == "テナント情報が取得できません。サインアウトしてから再ログインしてください。")
+    }
+
+    @Test func invalidArgument_withMessage_returnsServerMessage() {
+        #expect(AccountTransferView.message(for: .invalidArgument("同一 uid は指定できません"))
+            == "同一 uid は指定できません")
+    }
+
+    @Test func invalidArgument_emptyMessage_fallsBackToGeneric() {
+        #expect(AccountTransferView.message(for: .invalidArgument(""))
+            == "入力内容に誤りがあります。")
+    }
+
+    @Test func notFound_message() {
+        #expect(AccountTransferView.message(for: .notFound)
+            == "対象の dryRunId が見つかりません。最初からやり直してください。")
+    }
+
+    @Test func alreadyExists_doesNotMisleadAsTransient() {
+        // 過去版は「少し時間をおいて再度お試しください」と transient かのように
+        // 誤誘導していたが、`alreadyExists` は permanent (同 dryRunId 2 重実行 guard) のため
+        // 「最初からやり直す」を案内する文言に修正済み。
+        let message = AccountTransferView.message(for: .alreadyExists)
+        #expect(message.contains("最初からやり直す"))
+        #expect(!message.contains("少し時間をおいて"))
+    }
+
+    @Test func internalError_withMessage_includesServerDetail() {
+        let message = AccountTransferView.message(for: .internal("batch commit failed"))
+        #expect(message.contains("サーバー内部エラー"))
+        #expect(message.contains("batch commit failed"))
+    }
+
+    @Test func internalError_withNilMessage_doesNotShowNilLiteral() {
+        let message = AccountTransferView.message(for: .internal(nil))
+        #expect(!message.contains("nil"))
+        #expect(message.contains("サーバー内部エラー"))
+    }
+
+    @Test func malformedResponse_message() {
+        #expect(AccountTransferView.message(for: .malformedResponse)
+            == "サーバーからの応答が不正です。アプリを最新版にアップデートしてください。")
+    }
+
+    @Test func transient_guidesToRetry() {
+        let nsError = NSError(domain: NSURLErrorDomain, code: NSURLErrorTimedOut)
+        let message = AccountTransferView.message(for: .transient(nsError))
+        #expect(message.contains("ネットワーク") || message.contains("一時"))
+        #expect(message.contains("再度お試し"))
+    }
+
+    @Test func unknown_includesDomainAndCode() {
+        let nsError = NSError(domain: "SomeDomain", code: 42)
+        let message = AccountTransferView.message(for: .unknown(nsError))
+        #expect(message.contains("SomeDomain"))
+        #expect(message.contains("42"))
+    }
+}

--- a/CareNoteTests/AccountTransferViewModelTests.swift
+++ b/CareNoteTests/AccountTransferViewModelTests.swift
@@ -1,0 +1,260 @@
+@testable import CareNote
+import Foundation
+import Testing
+
+/// `AccountTransferViewModel` の状態遷移と入力 validation を検証する。
+@Suite("AccountTransferViewModel state machine", .serialized)
+struct AccountTransferViewModelTests {
+    // MARK: - Stub service
+
+    private final class StubTransferOwnershipService: TransferOwnershipServicing, @unchecked Sendable {
+        var dryRunResult: Result<TransferOwnershipDryRunResult, TransferOwnershipError>?
+        var confirmResult: Result<TransferOwnershipConfirmResult, TransferOwnershipError>?
+        private(set) var dryRunCalls: [(fromUid: String, toUid: String)] = []
+        private(set) var confirmCalls: [String] = []
+
+        func dryRun(fromUid: String, toUid: String) async throws -> TransferOwnershipDryRunResult {
+            dryRunCalls.append((fromUid, toUid))
+            switch dryRunResult {
+            case let .success(value):
+                return value
+            case let .failure(error):
+                throw error
+            case .none:
+                Issue.record("dryRunResult not set on stub")
+                throw TransferOwnershipError.malformedResponse
+            }
+        }
+
+        func confirm(dryRunId: String) async throws -> TransferOwnershipConfirmResult {
+            confirmCalls.append(dryRunId)
+            switch confirmResult {
+            case let .success(value):
+                return value
+            case let .failure(error):
+                throw error
+            case .none:
+                Issue.record("confirmResult not set on stub")
+                throw TransferOwnershipError.malformedResponse
+            }
+        }
+    }
+
+    private static let sampleCounts = TransferOwnershipCounts(recordings: 12, templates: 3, whitelist: 1)
+    private static let sampleDryRunId = "abc123"
+
+    // MARK: - Initial state
+
+    @Test @MainActor
+    func 初期状態はidle() {
+        let stub = StubTransferOwnershipService()
+        let vm = AccountTransferViewModel(service: stub)
+        #expect(vm.state == .idle)
+        #expect(vm.fromUidInput == "")
+        #expect(vm.toUidInput == "")
+        #expect(vm.confirmCheckboxChecked == false)
+        #expect(vm.canConfirm == false)
+    }
+
+    // MARK: - Input validation
+
+    @Test @MainActor
+    func 旧uidが空文字の場合invalidArgumentで停止() async {
+        let stub = StubTransferOwnershipService()
+        let vm = AccountTransferViewModel(service: stub)
+        vm.fromUidInput = "  "
+        vm.toUidInput = "newUid"
+        await vm.runDryRun()
+        if case let .failed(error) = vm.state, case .invalidArgument = error {
+            // OK
+        } else {
+            Issue.record("Expected .failed(.invalidArgument), got \(vm.state)")
+        }
+        #expect(stub.dryRunCalls.isEmpty)
+    }
+
+    @Test @MainActor
+    func 新uidが空文字の場合invalidArgumentで停止() async {
+        let stub = StubTransferOwnershipService()
+        let vm = AccountTransferViewModel(service: stub)
+        vm.fromUidInput = "oldUid"
+        vm.toUidInput = ""
+        await vm.runDryRun()
+        if case let .failed(error) = vm.state, case .invalidArgument = error {
+            // OK
+        } else {
+            Issue.record("Expected .failed(.invalidArgument), got \(vm.state)")
+        }
+        #expect(stub.dryRunCalls.isEmpty)
+    }
+
+    @Test @MainActor
+    func fromUidとtoUidが同一だとinvalidArgumentで停止() async {
+        let stub = StubTransferOwnershipService()
+        let vm = AccountTransferViewModel(service: stub)
+        vm.fromUidInput = "sameUid"
+        vm.toUidInput = "sameUid"
+        await vm.runDryRun()
+        // AC-B4 の文言を明示的に assert (Issue #201 受け入れ基準)
+        #expect(vm.state == .failed(.invalidArgument("同一 uid は指定できません")))
+        #expect(stub.dryRunCalls.isEmpty)
+    }
+
+    @Test @MainActor
+    func 入力前後の空白はtrimしてサービスへ渡す() async {
+        let stub = StubTransferOwnershipService()
+        stub.dryRunResult = .success(
+            TransferOwnershipDryRunResult(dryRunId: Self.sampleDryRunId, counts: Self.sampleCounts)
+        )
+        let vm = AccountTransferViewModel(service: stub)
+        vm.fromUidInput = "  oldUid  "
+        vm.toUidInput = "\tnewUid\n"
+        await vm.runDryRun()
+        #expect(stub.dryRunCalls.count == 1)
+        #expect(stub.dryRunCalls.first?.fromUid == "oldUid")
+        #expect(stub.dryRunCalls.first?.toUid == "newUid")
+    }
+
+    // MARK: - dryRun success / failure
+
+    @Test @MainActor
+    func dryRun成功でpreview状態に遷移する() async {
+        let stub = StubTransferOwnershipService()
+        stub.dryRunResult = .success(
+            TransferOwnershipDryRunResult(dryRunId: Self.sampleDryRunId, counts: Self.sampleCounts)
+        )
+        let vm = AccountTransferViewModel(service: stub)
+        vm.fromUidInput = "oldUid"
+        vm.toUidInput = "newUid"
+        await vm.runDryRun()
+        #expect(vm.state == .preview(dryRunId: Self.sampleDryRunId, counts: Self.sampleCounts))
+    }
+
+    @Test @MainActor
+    func dryRun失敗でfailed状態に遷移する() async {
+        let stub = StubTransferOwnershipService()
+        stub.dryRunResult = .failure(.permissionDenied)
+        let vm = AccountTransferViewModel(service: stub)
+        vm.fromUidInput = "oldUid"
+        vm.toUidInput = "newUid"
+        await vm.runDryRun()
+        #expect(vm.state == .failed(.permissionDenied))
+    }
+
+    // MARK: - Two-step confirm
+
+    @Test @MainActor
+    func preview状態でcheckbox未チェックだとcanConfirmはfalse() async {
+        let stub = StubTransferOwnershipService()
+        stub.dryRunResult = .success(
+            TransferOwnershipDryRunResult(dryRunId: Self.sampleDryRunId, counts: Self.sampleCounts)
+        )
+        let vm = AccountTransferViewModel(service: stub)
+        vm.fromUidInput = "oldUid"
+        vm.toUidInput = "newUid"
+        await vm.runDryRun()
+        #expect(vm.canConfirm == false)
+        vm.confirmCheckboxChecked = true
+        #expect(vm.canConfirm == true)
+    }
+
+    @Test @MainActor
+    func checkbox未チェックでconfirmTransferを呼んでも状態変化しない() async {
+        let stub = StubTransferOwnershipService()
+        stub.dryRunResult = .success(
+            TransferOwnershipDryRunResult(dryRunId: Self.sampleDryRunId, counts: Self.sampleCounts)
+        )
+        stub.confirmResult = .success(
+            TransferOwnershipConfirmResult(updated: Self.sampleCounts)
+        )
+        let vm = AccountTransferViewModel(service: stub)
+        vm.fromUidInput = "oldUid"
+        vm.toUidInput = "newUid"
+        await vm.runDryRun()
+        // checkbox 未チェックで confirm
+        await vm.confirmTransfer()
+        #expect(vm.state == .preview(dryRunId: Self.sampleDryRunId, counts: Self.sampleCounts))
+        #expect(stub.confirmCalls.isEmpty)
+    }
+
+    @Test @MainActor
+    func checkboxチェック済でconfirm成功するとcompletedに遷移する() async {
+        let stub = StubTransferOwnershipService()
+        stub.dryRunResult = .success(
+            TransferOwnershipDryRunResult(dryRunId: Self.sampleDryRunId, counts: Self.sampleCounts)
+        )
+        stub.confirmResult = .success(
+            TransferOwnershipConfirmResult(updated: Self.sampleCounts)
+        )
+        let vm = AccountTransferViewModel(service: stub)
+        vm.fromUidInput = "oldUid"
+        vm.toUidInput = "newUid"
+        await vm.runDryRun()
+        vm.confirmCheckboxChecked = true
+        await vm.confirmTransfer()
+        #expect(vm.state == .completed(updated: Self.sampleCounts))
+        #expect(stub.confirmCalls == [Self.sampleDryRunId])
+    }
+
+    @Test @MainActor
+    func confirm失敗でfailedに遷移する() async {
+        let stub = StubTransferOwnershipService()
+        stub.dryRunResult = .success(
+            TransferOwnershipDryRunResult(dryRunId: Self.sampleDryRunId, counts: Self.sampleCounts)
+        )
+        stub.confirmResult = .failure(.alreadyExists)
+        let vm = AccountTransferViewModel(service: stub)
+        vm.fromUidInput = "oldUid"
+        vm.toUidInput = "newUid"
+        await vm.runDryRun()
+        vm.confirmCheckboxChecked = true
+        await vm.confirmTransfer()
+        #expect(vm.state == .failed(.alreadyExists))
+    }
+
+    // MARK: - Reset
+
+    // MARK: - Two-step confirm safety: re-run dryRun must reset checkbox
+
+    /// Evaluator 検出 (#201): preview 状態で checkbox を true にした後、入力を変えて
+    /// 再 dryRun した時、checkbox が true のまま残ると新しい preview で confirm ボタンが
+    /// 即時 enabled になり二段階 confirm の安全性が崩れる。dryRun 開始時にリセット必須。
+    @Test @MainActor
+    func dryRunを再実行するとconfirmCheckboxはリセットされる() async {
+        let stub = StubTransferOwnershipService()
+        stub.dryRunResult = .success(
+            TransferOwnershipDryRunResult(dryRunId: Self.sampleDryRunId, counts: Self.sampleCounts)
+        )
+        let vm = AccountTransferViewModel(service: stub)
+        vm.fromUidInput = "oldUid"
+        vm.toUidInput = "newUid"
+        await vm.runDryRun()
+        vm.confirmCheckboxChecked = true
+        #expect(vm.canConfirm == true)
+
+        // 入力を変えて再 dryRun
+        vm.toUidInput = "anotherNewUid"
+        await vm.runDryRun()
+        // 新しい preview で checkbox はリセットされ、canConfirm は false に戻る
+        #expect(vm.confirmCheckboxChecked == false)
+        #expect(vm.canConfirm == false)
+    }
+
+    @Test @MainActor
+    func resetでidle状態に戻り入力もクリアされる() async {
+        let stub = StubTransferOwnershipService()
+        stub.dryRunResult = .success(
+            TransferOwnershipDryRunResult(dryRunId: Self.sampleDryRunId, counts: Self.sampleCounts)
+        )
+        let vm = AccountTransferViewModel(service: stub)
+        vm.fromUidInput = "oldUid"
+        vm.toUidInput = "newUid"
+        vm.confirmCheckboxChecked = true
+        await vm.runDryRun()
+        vm.reset()
+        #expect(vm.state == .idle)
+        #expect(vm.fromUidInput == "")
+        #expect(vm.toUidInput == "")
+        #expect(vm.confirmCheckboxChecked == false)
+    }
+}

--- a/CareNoteTests/AccountTransferViewModelTests.swift
+++ b/CareNoteTests/AccountTransferViewModelTests.swift
@@ -95,7 +95,7 @@ struct AccountTransferViewModelTests {
         vm.fromUidInput = "sameUid"
         vm.toUidInput = "sameUid"
         await vm.runDryRun()
-        // AC-B4 の文言を明示的に assert (Issue #201 受け入れ基準)
+        // 文言は admin への直接的なフィードバック。リファクタで揺れさせない。
         #expect(vm.state == .failed(.invalidArgument("同一 uid は指定できません")))
         #expect(stub.dryRunCalls.isEmpty)
     }
@@ -216,9 +216,10 @@ struct AccountTransferViewModelTests {
 
     // MARK: - Two-step confirm safety: re-run dryRun must reset checkbox
 
-    /// Evaluator 検出 (#201): preview 状態で checkbox を true にした後、入力を変えて
-    /// 再 dryRun した時、checkbox が true のまま残ると新しい preview で confirm ボタンが
-    /// 即時 enabled になり二段階 confirm の安全性が崩れる。dryRun 開始時にリセット必須。
+    /// preview 状態で checkbox を true にした後、入力を変えて再 dryRun した時、
+    /// checkbox が true のまま残ると新しい preview で confirm ボタンが即時 enabled になり
+    /// 二段階 confirm の不変条件 (preview ∧ checkbox=true) が崩れる。
+    /// dryRun 開始時に必ずリセットすることを構造的に固定する。
     @Test @MainActor
     func dryRunを再実行するとconfirmCheckboxはリセットされる() async {
         let stub = StubTransferOwnershipService()

--- a/CareNoteTests/TransferOwnershipServiceTests.swift
+++ b/CareNoteTests/TransferOwnershipServiceTests.swift
@@ -68,6 +68,60 @@ struct TransferOwnershipErrorMapTests {
         }
     }
 
+    // MARK: - Transient classification (network / quota / SDK unavailable)
+
+    @Test(
+        "transient な FunctionsErrorCode は .transient に分類される",
+        arguments: [
+            FunctionsErrorCode.deadlineExceeded.rawValue,
+            FunctionsErrorCode.unavailable.rawValue,
+            FunctionsErrorCode.resourceExhausted.rawValue,
+            FunctionsErrorCode.cancelled.rawValue,
+        ]
+    )
+    func map_transientFunctionsCode(code: Int) {
+        let error = NSError(
+            domain: FunctionsErrorDomain,
+            code: code,
+            userInfo: [NSLocalizedDescriptionKey: "transient"]
+        )
+        let mapped = TransferOwnershipError.map(error)
+        if case .transient = mapped {
+            #expect(mapped.isTransient == true)
+        } else {
+            Issue.record("Expected .transient, got \(mapped)")
+        }
+    }
+
+    @Test("NSURLErrorDomain (オフライン等) は .transient に分類される")
+    func map_urlErrorIsTransient() {
+        let error = NSError(domain: NSURLErrorDomain, code: NSURLErrorNotConnectedToInternet)
+        let mapped = TransferOwnershipError.map(error)
+        if case .transient = mapped {
+            #expect(mapped.isTransient == true)
+        } else {
+            Issue.record("Expected .transient, got \(mapped)")
+        }
+    }
+
+    @Test("permanent エラーは isTransient == false")
+    func permanentErrorsAreNotTransient() {
+        let cases: [TransferOwnershipError] = [
+            .unauthenticated,
+            .permissionDenied,
+            .failedPrecondition,
+            .invalidArgument("x"),
+            .notFound,
+            .alreadyExists,
+            .internal("y"),
+            .malformedResponse,
+            .unknown(NSError(domain: "d", code: 1)),
+        ]
+        for c in cases {
+            #expect(c.isTransient == false, "Expected \(c) to be non-transient")
+        }
+    }
+
     // MARK: - Helpers
 
     /// `Functions.functions().httpsCallable(...).call(...)` が throw する形式の

--- a/CareNoteTests/TransferOwnershipServiceTests.swift
+++ b/CareNoteTests/TransferOwnershipServiceTests.swift
@@ -1,0 +1,83 @@
+import FirebaseFunctions
+import Foundation
+import Testing
+
+@testable import CareNote
+
+/// `TransferOwnershipError.map(_:)` の HttpsError → 内部エラー型 mapping を検証する。
+///
+/// Cloud Function `transferOwnership` (functions/src/transferOwnership.js) が throw する
+/// 各 HttpsError code を、UI で表示分岐できる内部エラー型にマッピングする。
+@Suite("TransferOwnershipError.map mapping")
+struct TransferOwnershipErrorMapTests {
+    // MARK: - Functions SDK code mapping
+
+    @Test("unauthenticated code → .unauthenticated")
+    func map_unauthenticated() {
+        let error = makeFunctionsError(code: .unauthenticated, message: "ログインが必要です")
+        #expect(TransferOwnershipError.map(error) == .unauthenticated)
+    }
+
+    @Test("permissionDenied code → .permissionDenied")
+    func map_permissionDenied() {
+        let error = makeFunctionsError(code: .permissionDenied, message: "管理者のみ実行可能です")
+        #expect(TransferOwnershipError.map(error) == .permissionDenied)
+    }
+
+    @Test("failedPrecondition code → .failedPrecondition")
+    func map_failedPrecondition() {
+        let error = makeFunctionsError(code: .failedPrecondition, message: "tenantId 不在")
+        #expect(TransferOwnershipError.map(error) == .failedPrecondition)
+    }
+
+    @Test("invalidArgument code → .invalidArgument(message)")
+    func map_invalidArgument() {
+        let error = makeFunctionsError(code: .invalidArgument, message: "fromUid must differ from toUid")
+        let mapped = TransferOwnershipError.map(error)
+        #expect(mapped == .invalidArgument("fromUid must differ from toUid"))
+    }
+
+    @Test("notFound code → .notFound")
+    func map_notFound() {
+        let error = makeFunctionsError(code: .notFound, message: "dryRunId 該当なし")
+        #expect(TransferOwnershipError.map(error) == .notFound)
+    }
+
+    @Test("alreadyExists code → .alreadyExists")
+    func map_alreadyExists() {
+        let error = makeFunctionsError(code: .alreadyExists, message: "同じ dryRunId が既に完了")
+        #expect(TransferOwnershipError.map(error) == .alreadyExists)
+    }
+
+    @Test("internal code → .internal(message)")
+    func map_internalError() {
+        let error = makeFunctionsError(code: .internal, message: "batch commit failed")
+        #expect(TransferOwnershipError.map(error) == .internal("batch commit failed"))
+    }
+
+    // MARK: - Non-Functions error
+
+    @Test("Functions 以外の error は .unknown でラップする")
+    func map_nonFunctionsError() {
+        let error = NSError(domain: "SomeOtherDomain", code: -1, userInfo: nil)
+        let mapped = TransferOwnershipError.map(error)
+        if case .unknown = mapped {
+            // OK
+        } else {
+            Issue.record("Expected .unknown, got \(mapped)")
+        }
+    }
+
+    // MARK: - Helpers
+
+    /// `Functions.functions().httpsCallable(...).call(...)` が throw する形式の
+    /// NSError を再現する。実 SDK は domain="com.firebase.functions"、
+    /// userInfo に NSLocalizedDescriptionKey でメッセージを格納する。
+    private func makeFunctionsError(code: FunctionsErrorCode, message: String) -> NSError {
+        NSError(
+            domain: FunctionsErrorDomain,
+            code: code.rawValue,
+            userInfo: [NSLocalizedDescriptionKey: message]
+        )
+    }
+}


### PR DESCRIPTION
## Summary

ADR-008 Phase 1 で実装済の `transferOwnership` Cloud Function (prod deploy 済 2026-04-23) を、admin が iOS アプリ内で **self-service 操作** できる UI として追加。CLI 代行運用 (`functions/scripts/call-transfer-ownership.mjs`) からの脱却。

「完全着地」フローのうち Phase B 実装。Build 37 / v0.1.2 として App Review 提出予定 (差分: PR #191 delete sync + #197 polling + #198 error 分類 + 本 PR Phase 2 admin UI)。

## 主要設計

- **Service**: `TransferOwnershipServicing` protocol で SDK を抽象化、ViewModel に DI してテスト可能化
- **ViewModel**: state machine (`idle → dryRunInFlight → preview → confirmInFlight → completed / failed`)、`@Observable @MainActor`、Sendable 維持のため associated value に SwiftData `@Model` を持たせない (PR #198 教訓)
- **View**: SwiftUI `Form` で 1 画面、admin 限定の `SettingsView` NavigationLink から遷移
- **Error**: `TransferOwnershipError.map(_:)` で `FunctionsErrorCode` 7 種を分類 (`unauthenticated` / `permissionDenied` / `failedPrecondition` / `invalidArgument` / `notFound` / `alreadyExists` / `internal`) + UI 文言マップ
- **二段階 confirm**: `preview` 状態 + checkbox 同時 true でのみ confirm 実行可、**dryRun 再実行時に checkbox を必ずリセット** (Evaluator 検出バグ修正)

## Acceptance Criteria

- [x] AC-B1: 非 admin にエントリポイント非表示 (`isAdmin` ガード、`SettingsView.swift:32`)
- [x] AC-B2: dryRun 成功時 counts 表示 (recordings / templates / whitelist 3 項目)
- [x] AC-B3: confirm 成功時 `migrationLogs/{id}` に `status: "completed"` 記録 (Cloud Function 側担保、`functions/test/transfer-ownership.test.js` AC-5 で検証済)
- [x] AC-B4: `fromUid==toUid` → 「同一 uid は指定できません」表示 + service call 抑止
- [x] AC-B5: `permission-denied` → 「管理者権限が必要です」表示
- [x] AC-B6: 二段階 confirm (checkbox 未チェック時 confirm 無効化 + no-op)
- [ ] AC-B7: 実機 smoke (Build 37 配布後に手動実施、Issue #201 で追跡)

## Quality Gate (3 層)

### `/simplify` 3 並列 (reuse / quality / efficiency)
反映: callable 名 + region constant 化、`Equatable` `==` の `unknown` 比較規則コメント追加。
見送り: dryRun/confirm の DRY 化 (2 箇所のみで ROI 負)、`Functions.functions(region:)` cache (SDK 内部 cache 済)、`@ViewBuilder` 統合 (admin 低頻度 UI で hot path でない)。

### Evaluator 分離プロトコル (5 ファイル + 新機能で発動)
- **HIGH 修正**: dryRun 再実行時の `confirmCheckboxChecked` リセット欠落 → 1 行追加 + 専用テスト
- **HIGH 修正**: AC-B4 文言を実装と AC で揃え (「同一 uid は指定できません」)
- **LOW 修正**: `final class TransferOwnershipService: TransferOwnershipServicing, Sendable` 明示
- **LOW 修正**: TextField に `accessibilityLabel` 追加 (VoiceOver 対応)

### CI
- iOS Tests: 173 → **194** (+21、`TransferOwnershipError.map` 8 + `AccountTransferViewModel state machine` 13)
- 全 24 suites green (Pre-merge CI で再確認)

## Test plan

- [x] `xcodebuild test` でローカル全 suite green
- [ ] Pre-merge CI (iOS Tests) green
- [ ] `/review-pr` 6 agent 並列レビューで Critical 0 確認
- [ ] (Build 37 配布後) 実機 smoke: dev TestFlight build で別 admin アカウント + 新規 user アカウント用意 → dryRun → counts 表示確認 → confirm → migrationLogs 記録確認 → 新 uid で旧 recordings 表示確認

## Build 37 提出時のチェック (memory: project_carenote_app_review.md より)

- [x] MARKETING_VERSION semver bump 必要 (0.1.1 → 0.1.2、本 PR では未対応、別 PR で project.yml + pbxproj sync)
- [x] CURRENT_PROJECT_VERSION 36 → 37 (同上、別 PR)
- [x] Sign in with Apple entitlement (upload-testflight.sh で自動 lint)
- [x] デモアカウント `demo-reviewer@carenote.jp` whitelist 維持 (作業前確認必須)
- [x] エラー表示 UI が赤字単色表示にならない構造 (Form Section + Label、過去リジェクト要因回避)
- [x] admin 限定機能が demo-reviewer (admin 権限) でテスト可能

## 関連

- Closes #201
- ADR-008 Phase 2 実装本体
- Phase 1 Cloud Function: PR #119 (prod deploy 済 2026-04-23)
- 既存 Callable パターン参照: `AuthViewModel.deleteAccount` (`AuthViewModel.swift:318`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)