### PR TITLE
chore(release): Build 37 / v0.1.2 bump (Phase B admin UI 統合)

### DIFF
--- a/CareNote.xcodeproj/project.pbxproj
+++ b/CareNote.xcodeproj/project.pbxproj
@@ -703,7 +703,7 @@
 				CODE_SIGN_ENTITLEMENTS = CareNote/CareNote.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 36;
+				CURRENT_PROJECT_VERSION = 37;
 				DEVELOPMENT_TEAM = C96A7EHVW8;
 				GENERATE_INFOPLIST_FILE = NO;
 				GID_CLIENT_ID = "781674225072-ggct0s6glel3ma7isb79ge72mn8sbivj.apps.googleusercontent.com";
@@ -713,7 +713,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.1.1;
+				MARKETING_VERSION = 0.1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = jp.carenote.app;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
@@ -803,7 +803,7 @@
 				CODE_SIGN_ENTITLEMENTS = CareNote/CareNote.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 36;
+				CURRENT_PROJECT_VERSION = 37;
 				DEVELOPMENT_TEAM = C96A7EHVW8;
 				GENERATE_INFOPLIST_FILE = NO;
 				GID_CLIENT_ID = "444137368705-6tppcletq10h3qhuprhafktpk5e2h1me.apps.googleusercontent.com";
@@ -813,7 +813,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.1.1;
+				MARKETING_VERSION = 0.1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = jp.carenote.app;
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;

--- a/project.yml
+++ b/project.yml
@@ -27,8 +27,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: jp.carenote.app
-        MARKETING_VERSION: "0.1.1"
-        CURRENT_PROJECT_VERSION: "36"
+        MARKETING_VERSION: "0.1.2"
+        CURRENT_PROJECT_VERSION: "37"
         INFOPLIST_FILE: CareNote/Info.plist
         SWIFT_VERSION: "6.0"
         GENERATE_INFOPLIST_FILE: false


### PR DESCRIPTION
## Summary

App Review 提出用バージョン bump。**Build 35 (現行 Unlisted 配布中) → Build 37 / v0.1.2** で、本セッション完遂の transferOwnership iOS admin UI と、その間 merge した bug fix を一括で App Review に提出。

## 含まれる差分 (Build 35 → Build 37)

| PR | Issue | 内容 | merge 日 |
|----|-------|------|----------|
| #191 | #182 | iOS delete Firestore 同期 | 2026-04-25 |
| #197 | #194 | polling silent catch logger 可視化 | 2026-04-25 |
| #198 | #193 | Firestore delete error 分類 + UI alert | 2026-04-25 |
| **#202** | **#201** | **transferOwnership iOS admin UI (ADR-008 Phase 2)** | **2026-04-26** |

## バージョン情報

| 項目 | Before | After |
|------|--------|-------|
| MARKETING_VERSION | 0.1.1 | **0.1.2** |
| CURRENT_PROJECT_VERSION | 36 | **37** |

`upload-testflight.sh` は build 番号のみ自動 bump するため、MARKETING_VERSION は手動変更 (project.yml + pbxproj 両方を sync)。

## 提出後の Apple Review チェック (memory: project_carenote_app_review.md)

- [x] MARKETING_VERSION semver bump 済 (0.1.1 → 0.1.2)
- [x] CURRENT_PROJECT_VERSION 36 → 37
- [ ] Sign in with Apple entitlement (`upload-testflight.sh` の lint で自動検証、archive 時)
- [ ] デモアカウント `demo-reviewer@carenote.jp` whitelist 維持確認 (upload 前)
- [x] エラー表示 UI が赤字単色表示にならない構造維持 (Form Section + Label、Phase B も同 pattern)
- [x] admin 限定機能 (アカウント引き継ぎ) は demo-reviewer (admin 権限) でテスト可能

## Test plan

- [x] xcodegen で project.yml ↔ pbxproj 整合
- [ ] Pre-merge CI (iOS Tests) green
- [ ] (merge 後) `./scripts/upload-testflight.sh 37` で archive + export + App Store Connect upload
- [ ] (upload 完了後) App Store Connect で Build 37 を選択 → App Review 提出 (ユーザー手動)
- [ ] (Apple 通過後) Unlisted release (ユーザー手動)
- [ ] メンバー App Store からアップデート → 「ドメイン自動加入 + admin UI でアカウント引き継ぎ」完全 self-service 動作確認

## 関連

- 「完全着地」フローのリリース工程
- ADR-008 Phase 2 完遂 (Issue #201, PR #202)
- 過去 Apple Review 経緯: `memory/project_carenote_app_review.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)