### PR TITLE
chore(release): Build 38 / v1.0.1 bump (ダウングレード回避のため再 bump)

### DIFF
--- a/CareNote.xcodeproj/project.pbxproj
+++ b/CareNote.xcodeproj/project.pbxproj
@@ -703,7 +703,7 @@
 				CODE_SIGN_ENTITLEMENTS = CareNote/CareNote.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 37;
+				CURRENT_PROJECT_VERSION = 38;
 				DEVELOPMENT_TEAM = C96A7EHVW8;
 				GENERATE_INFOPLIST_FILE = NO;
 				GID_CLIENT_ID = "781674225072-ggct0s6glel3ma7isb79ge72mn8sbivj.apps.googleusercontent.com";
@@ -713,7 +713,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.1.2;
+				MARKETING_VERSION = 1.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = jp.carenote.app;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
@@ -803,7 +803,7 @@
 				CODE_SIGN_ENTITLEMENTS = CareNote/CareNote.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 37;
+				CURRENT_PROJECT_VERSION = 38;
 				DEVELOPMENT_TEAM = C96A7EHVW8;
 				GENERATE_INFOPLIST_FILE = NO;
 				GID_CLIENT_ID = "444137368705-6tppcletq10h3qhuprhafktpk5e2h1me.apps.googleusercontent.com";
@@ -813,7 +813,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.1.2;
+				MARKETING_VERSION = 1.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = jp.carenote.app;
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;

--- a/project.yml
+++ b/project.yml
@@ -27,8 +27,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: jp.carenote.app
-        MARKETING_VERSION: "0.1.2"
-        CURRENT_PROJECT_VERSION: "37"
+        MARKETING_VERSION: "1.0.1"
+        CURRENT_PROJECT_VERSION: "38"
         INFOPLIST_FILE: CareNote/Info.plist
         SWIFT_VERSION: "6.0"
         GENERATE_INFOPLIST_FILE: false


### PR DESCRIPTION
## Summary

PR #203 で **v0.1.2** として bump + upload した Build 37 は、App Store Connect 確認の結果**ダウングレード問題で App Review 提出不可**と判明。**v1.0.1** に修正した Build 38 を再 upload するための version bump。

## 背景

- **App Store Connect の現行配信中バージョン = 1.0** (Image #5 で確認: 「iOSアプリ バージョン 1.0 配信準備完了」、App Review 履歴 4/16 「iOS 1.0 審査完了」)
- memory `project_carenote_app_review.md` の「Build 35 = v0.1.0」記録は**誤り** (実際は v1.0)
- Apple App Store は **新リリース > 旧リリース** (semver) を必須とするため、v0.1.2 < v1.0 でダウングレード扱い
- → Build 37 は App Store Connect で受け付けられない / リジェクトされる

## バージョン bump

| 項目 | Before | After |
|------|--------|-------|
| MARKETING_VERSION | 0.1.2 | **1.0.1** (現行 v1.0 からの patch bump) |
| CURRENT_PROJECT_VERSION | 37 | **38** |

## 後続作業

1. (本 PR merge 後) `./scripts/upload-testflight.sh 38` で **Build 38 / v1.0.1** を再 upload
2. App Store Connect で「+」→ 新バージョン枠 **1.0.1** 作成
3. Build 38 を紐付け → リリースノート記入 → App Review 提出
4. memory `project_carenote_app_review.md` の Build 別 version 記録を訂正 (Build 35 = v1.0 / Build 38 = v1.0.1)

## 含まれる機能差分 (v1.0 → v1.0.1)

PR #202 (transferOwnership iOS admin UI) + PR #191 (delete sync) + PR #197 (polling 可視化) + PR #198 (delete error 分類)。Phase B 本体は本 build で初めて配布。

## Test plan

- [x] xcodegen で project.yml ↔ pbxproj 整合
- [ ] Pre-merge CI (iOS Tests) green
- [ ] (merge 後) Build 38 upload 成功
- [ ] App Store Connect で v1.0.1 枠作成 + Build 38 紐付け + App Review 提出 (ユーザー手動)

🤖 Generated with [Claude Code](https://claude.com/claude-code)