### PR TITLE
docs(appstore): Build 38 / v1.0.1 App Review 提出反映 + Phase B Review Notes 統合

### DIFF
--- a/docs/appstore-metadata.md
+++ b/docs/appstore-metadata.md
@@ -78,37 +78,75 @@ CareNote AIは、ケアマネジャーの記録業務を効率化するアプリ
 
 ## 審査メモ（Review Notes）
 
-**For App Review: Please use the demo account via "Email Login" on the sign-in screen for the full review.**
+> **運用ノート**: 本セクションは App Store Connect の「App Reviewに関する情報 → メモ」欄に貼り付ける完全版。次回審査提出時はこのセクション全文を copy & paste する。
+>
+> **重要**: 提出前に必ず `demo-reviewer@carenote.jp` の権限を**両系統で確認**すること:
+> - Firestore: `tenants/279/whitelist/{id}` の `role` が `admin`
+> - Firebase Auth: customAttributes が `{"tenantId":"279","role":"admin"}`
+>
+> 権限判定の実体は **Firebase Auth custom claim** (`firestore.rules` の `isAdmin()` 参照)。whitelist の role は admin UI 表示用なので、実権限と乖離しないよう両方を一致させる。
+
+```
+For App Review: Please use the demo account via "Email Login" on the sign-in screen for the full review.
 
 This is an invite-only business app distributed as Unlisted. Access is managed per organization (tenant), and only pre-registered accounts can sign in.
 
 本アプリは招待制の業務用アプリです（Unlisted App Distribution）。
 事業所（テナント）単位で利用者を管理しており、管理者が事前に登録したアカウントのみサインインできます。
 
-### テスト用デモアカウント（Demo Account for Review）
-- メールアドレス / Email: demo-reviewer@carenote.jp
+【テスト用デモアカウント / Demo Account for Review】
+- メール / Email: demo-reviewer@carenote.jp
 - パスワード / Password: CareNote2026Review!
+- 権限 / Role: 管理者 (admin) — tenant 279
 - ログイン方法 / How to sign in:
-  1. サインイン画面下部の「メールでログイン / Email Login」をタップ / Tap "メールでログイン / Email Login" at the bottom of the sign-in screen
-  2. 上記メールアドレスとパスワードを入力 / Enter the email and password above
-  3. 「ログイン」ボタンをタップ / Tap the "ログイン" (Login) button
+  1. サインイン画面下部の「メールでログイン / Email Login」をタップ
+  2. 上記メールアドレスとパスワードを入力
+  3. 「ログイン」ボタンをタップ
 
-### Sign in with Apple について（Guest / Trial Mode）
+【Sign in with Apple について / About Sign in with Apple】
 - Sign in with Apple は誰でも利用可能です。未登録の Apple ID でサインインすると、体験用の独立したテナント（Guest Tenant）に自動的に割り当てられ、全機能を試用できます。
 - Sign in with Apple is available to everyone. When an unregistered Apple ID signs in, the user is automatically assigned to an isolated Guest Tenant where all app features can be tried.
-- この体験モードでは、他の事業所のデータから完全に分離された環境で録音・文字起こし・管理機能が利用できます。
-- In this trial mode, recording, transcription, and management features are available in a completely isolated environment from any other tenant's data.
 
-### Google Sign-In について
+【Google Sign-In について / About Google Sign-In】
 - Google Sign-In は招待制です（事前に管理者に登録されたアカウントのみ利用可能）。
 - Google Sign-In is invite-only (only accounts pre-registered by an administrator can sign in).
-- 未登録の Google アカウントでサインインすると、案内メッセージが表示されます。
-- If an unregistered Google account is used, a non-fatal informational message is displayed.
 
-### 推奨される審査手順 / Recommended Review Steps
-1. Sign in with Apple でレビュアーご自身の Apple ID からサインイン（自動で Guest Tenant へ割り当て）/ Sign in with Apple using your own Apple ID — you will be auto-assigned to the Guest Tenant
-2. または、上記デモアカウント（メール/パスワード）でメールログインから全機能をテスト / Or use the demo account above via Email Login to test all features
+【推奨される審査手順 / Recommended Review Steps】
+1. Sign in with Apple でレビュアーご自身の Apple ID からサインイン（自動で Guest Tenant へ割り当て）
+2. または、上記デモアカウント（メール/パスワード）でメールログインから全機能をテスト
 
-### アカウント削除 / Account Deletion
+【v1.0.1 新機能 / What's New in v1.0.1】
+
+■ アカウント引き継ぎ機能 (admin 専用) / Account Transfer (Admin Only)
+管理者が、改姓・組織変更等で uid が変わったメンバーのデータ（録音・テンプレート・ホワイトリスト登録）を旧 uid から新 uid に引き継げる機能を追加しました。
+
+A new admin-only feature allowing administrators to transfer data (recordings, templates, whitelist entries) from an old user uid to a new uid (for cases like name change or account migration).
+
+[テスト手順 / Test Steps]
+1. 上記デモアカウント (demo-reviewer@carenote.jp) でメールログイン
+   Sign in with the demo account above via Email Login
+2. 画面下部のタブから「設定」を開く
+   Open "Settings" from the bottom tab bar
+3. 管理者メニュー内の「アカウント引き継ぎ」をタップ
+   Tap "アカウント引き継ぎ / Account Transfer" in the Admin Menu section
+4. 旧 uid 入力欄に "test-old-uid"、新 uid 入力欄に "test-new-uid" を入力
+   Enter "test-old-uid" in the old uid field and "test-new-uid" in the new uid field
+5. 「件数プレビュー (dryRun)」ボタンをタップ
+   Tap "件数プレビュー (dryRun)" button
+6. UI がエラーメッセージを表示すること（存在しない uid のため、入力検証が機能していることが確認できます）
+   The UI displays an error message (confirming input validation works for non-existent uids)
+
+[Important / 重要]
+- 「件数プレビュー」(dryRun) は読み取り専用で、データを書き換えません。安全にテスト可能です。
+  The "dryRun" button is read-only and does not modify any data. It is safe to test.
+- 「引き継ぎを実行」(confirm) ボタンは本番データを書き換えるため、審査中は実行をお控えください。
+  Please do NOT tap the "実行 / Execute" button during review, as it modifies production data.
+
+【アカウント削除 / Account Deletion】
 - 設定画面の「アカウントを削除 / Delete Account」から、アカウント完全削除が可能です（Guideline 5.1.1(v) 準拠）。
 - Account deletion is available under Settings → "アカウントを削除 / Delete Account" (complies with Guideline 5.1.1(v)).
+```
+
+### 審査メモの What's New 部分は版ごとに差し替え
+
+新機能を追加するバージョンでは「【vX.Y.Z 新機能】」セクションを追記し、admin 限定機能の場合はテスト手順 + dryRun/confirm 等の安全運用注意を必ず明記する。


### PR DESCRIPTION
## Summary
- 2026-04-26 に **Build 38 / v1.0.1** を App Review に提出（Submission ID `736694f6-01af-4b69-8d28-8420cba31aa6`、現在審査中）
- `docs/appstore-metadata.md §審査メモ` を Phase B (transferOwnership admin UI) のテスト手順込み**完全版**に置換 — 次回提出時はこの全文をコピペするだけで運用可能に
- 提出前に踏むべきデモアカウントの権限二系統チェック（Firestore whitelist + Firebase Auth custom claim）を運用ノートとして明記

## 背景: Build 38 提出時に判明した「権限二系統」問題

提出準備で demo-reviewer の権限を検証したところ、`tenants/279/whitelist` の role と Firebase Auth custom claim の両方が `member` で、Phase B (admin 限定機能) のテスト不能状態だった（memory には「admin」と記載されており実態と乖離）。

`firestore.rules` の `isAdmin()` は Firebase Auth custom claim を権限判定ソースとしているため、whitelist だけ admin にしても効かない。逆に Auth claim だけ admin にしても admin UI 表示には whitelist との整合性が必要。**両系統を一致させて初めて Phase B 機能テストが可能**。

提出前に実施した修正:
- W1: `accounts:update` で custom claim を `{"tenantId":"279","role":"admin"}` に
- W2: `tenants/279/whitelist/D8a63ZM5iijgeBSIbRSQ` の role を `member` → `admin` に

詳細手順は memory `project_carenote_app_review.md` に runbook 化済み（別途 ~/.claude リポジトリで管理）。

## Test plan
- [ ] App Review 結果メール待機（最大 48 時間、y.honda@279279.net 宛）
- [ ] 通過時: App Store Connect で Unlisted release → URL 取得 → 社内共有
- [ ] リジェクト時: Review Notes 文言改善 → 再提出
- [x] docs 更新の文法・構成チェック（追加された運用ノート、What's New 部分の差し替え方針が明確）

## 関連
- 現行配信: Build 35 / v1.0
- 審査中: **Build 38 / v1.0.1** (本 PR で反映)
- PR #205 (Build 38 / v1.0.1 bump)
- PR #206 (前セッション handoff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)