### PR TITLE
docs(phase-0-9): 2026-04-27 状態確認 + Issue #111 close 条件明確化

### DIFF
--- a/docs/handoff/LATEST.md
+++ b/docs/handoff/LATEST.md
@@ -1,3 +1,76 @@
+# Handoff — 2026-04-27 続報セッション 2: Phase 0.9 (allowedDomains) 状態確認 + Issue #111 close 条件明確化
+
+## ✅ Phase 0.9 prod 設定 (2026-04-23 完了済) を再確認 + 実機 smoke test を社員ジョイン待ちでポストポーン継続
+
+ユーザーから「内部のアプリリンクを知る社員はテナント内のドメインなら誰でも入れるか?」の確認質問を受け、Issue #111 (Phase 0.9: allowedDomains 有効化) を再評価。RUNBOOK の実施ログから prod 設定が **2026-04-23 21:00 JST に完了済** であること、かつ前提フェーズ (Phase -1/0/0.5/1/Node 22) もすべて prod deploy 済であることを確認。残作業は実機 smoke test の AC 検証のみと判明。
+
+read-only verify で prod 技術設定の健全性 (`allowedDomains = ["279279.net"]` 維持 / `beforeSignIn` Cloud Function ACTIVE / 直近 7d エラー 0) を確認。実機 smoke test は新規 `@279279.net` 社員ジョイン時に自然観測する方針 (B2 ポストポーン) を確定し、Issue #111 に close 条件を明示してコメント追記、open 維持。あわせてユーザー質問「ホワイトリストの概念がなくなる?」に対し、`functions/index.js:41-73` の `beforeSignIn` 分岐確認結果から「whitelist は admin 任命・例外管理のために必須として残存、運用上の変化は一般社員が whitelist に記録されなくなる点」を明確化。
+
+### セッション成果サマリ
+
+| 変更 | リポジトリ | 内容 | 状態 |
+|----|----------|------|------|
+| **本 PR** | `system-279/carenote-ios` | `docs/runbook/phase-0-9-allowed-domains.md` 実施ログに 2026-04-27 確認エントリ追加 + `docs/handoff/LATEST.md` 続報セッション 2 追記 | 🔵 open |
+| **GitHub Issue #111** | `system-279/carenote-ios` | prod 設定健全性確認 + close 条件明確化コメント | コメント追加 |
+| **memory PR (別 push)** | `~/.claude` | `memory/project_carenote_app_review.md` に whitelist 運用変化セクション追加 | 後続 push |
+
+### 主要判断のハイライト
+
+- **「設定が未完了」と誤認していた状況を訂正**: ユーザー側で「ドメインだけで入れる状態にしたい」「まだできていないことに驚き」とのフィードバック。Issue #111 が open のため未完了と推定して `/impl-plan` 起動 → 実態は prod 設定 2026-04-23 完了済、Issue が open のままだったのは実機 smoke test 待ちのため。Issue タイトル「Phase 0.9: prod allowedDomains 有効化」が AC 全部を含む粒度のため、ステータス把握に runbook 実施ログまで遡る必要があった（次世代教訓: catchup で Issue タイトルだけでなく関連 RUNBOOK の実施ログまで遡る）
+- **B2 ポストポーン継続を判定**: A1 (whitelist 未登録 `@279279.net` 社員のジョイン予定あり) + B2 (社員ジョイン待ち) を選択。能動テスト用アカウント `test-phase09@279279.net` 発行案 (B プラン) は採用せず、「次回新規社員ジョイン時に自然観測」が運用上のオーバーヘッド最小と判断。Issue #111 を open 維持し再開トリガーを RUNBOOK に明記
+- **whitelist 概念は廃止せず併存**: ユーザーから「もはやホワイトリストという概念がなくなる?」の確認質問あり。`functions/index.js:41-73` の `beforeSignIn` 分岐確認の結果、whitelist は admin 権限付与・例外メンバー追加・権限変更のために必須として残存。allowedDomains 経由は強制的に `role: "member"`、admin 任命には依然として whitelist が必要。運用上の変化は「一般 `@279279.net` 社員は whitelist に記録されず Auth users にしか存在しない → 全メンバー一覧は Auth users API 経由で集計」
+- **prod read-only verify はユーザー明示承認後に実行**: CLAUDE.md MUST に従い、prod project ID を含むコマンド (Firestore GET + Cloud Logging) はユーザー明示承認 (「実行承認」) を取得した後にのみ実行。書き込み操作は一切なし
+
+### 実装実績
+
+- **変更ファイル**: 2 ファイル (carenote-ios) + 1 ファイル (~/.claude memory)
+  - `docs/runbook/phase-0-9-allowed-domains.md` — 実施ログ「2026-04-27 22:30 JST」セクション追記 (+45 行、健全性確認結果 + close 条件 + 観測コマンド 3 種)
+  - `docs/handoff/LATEST.md` — 本セッション handoff を先頭に追加
+  - `~/.claude/memory/project_carenote_app_review.md` — 「テナント加入動線 (allowedDomains + whitelist 併存設計)」セクション新設
+- **prod 操作**: read-only 2 件 (Firestore GET + Cloud Logging) のみ、書き込みなし
+- **GitHub Issue 操作**: #111 にコメント追加、open 維持
+- **iOS コード変更**: なし (ドキュメント + memory のみ)
+
+### Issue Net 計測
+
+| 開始時 | 終了時 | Net |
+|--------|--------|-----|
+| 7 件 (#192/#178/#111/#105/#92/#90/#65) | 7 件 (同上) | **0** |
+
+> **Net 0 の意味**: Issue #111 は close 条件を明確化したコメント追記、open 継続 (B2 ポストポーン)。新規 Issue 起票なし、close なし。triage 基準を満たす新規バグ発見なし
+
+### セッション内教訓 (handoff 次世代向け)
+
+1. **Issue open = 未着手 と即断しない**: Issue タイトルが大粒度な場合、prod 設定は完了していて AC 検証だけ pending、というケースがある。catchup の段階で Issue タイトルだけ見るのではなく、関連 RUNBOOK の実施ログまで遡って状態を把握する。今回 Issue #111「Phase 0.9 有効化」は実態が「設定完了 + smoke test 待ち」だった
+2. **ポストポーン Issue は再開トリガーを「機械的判定可能」に**: 「次回ジョイン時」だけだと曖昧 → 「Cloud Logging で新規 `@279279.net` の `beforeSignIn` 成功ログが出現した時点」のような自動検出可能な signal を併記する。今回は RUNBOOK 実施ログに観測コマンド 3 種を埋め込み、社員ジョイン後にコピペで実行できる状態にした
+3. **whitelist 廃止と聞かれたら「役割が変わる」と答える**: allowedDomains 有効化で「一般 member は whitelist 不要」になるが、admin 任命と例外管理には引き続き必須。`beforeSignIn` の分岐 (whitelist → allowedDomains → Apple → deny) は whitelist が先に評価されるため、admin の role 指定は whitelist 経由のみ
+4. **「メンバー一覧」の所在変化を運用ドキュメントに反映**: allowedDomains 有効化後、一般 `@279279.net` 社員は whitelist に痕跡を残さず Firebase Auth users にしか存在しない。今後「メンバー一覧」が必要なら Auth users API で集計する設計が必要 → 別 Issue 起票候補 (要件次第)
+
+### CI の現状
+
+- main `efdaf3b` (PR #209 merge 後): clean
+- 本セッションは documents のみのため CI 影響なし
+
+### 次セッション推奨アクション (優先順)
+
+1. **memory PR (~/.claude) push + merge**: `memory/project_carenote_app_review.md` の Phase 0.9 状態 + whitelist 運用変化セクション追記
+2. **新規 `@279279.net` 社員ジョイン時の Cloud Logging 観測 + Issue #111 close**: 社員初回ログイン後 24h 以内に RUNBOOK の close 条件 4 項目を確認 → Issue close
+3. **Build 38 配信後の admin UI smoke test**: admin UI でアカウント引き継ぎ self-service 実機確認 (Phase B 機能の本番検証、前 handoff の宿題)
+4. **既存 Issue 群** (#192 / #178 / #105 / #92 / #90 / #65): 当面は smoke 結果次第、優先度低
+5. **Info.plist `ITSAppUsesNonExemptEncryption: false` 追加** (任意、別 PR、前 handoff の宿題)
+6. **Build 37 (v0.1.2) 取り扱い**: 90 日で TestFlight 自動 expire (明示削除不要、前 handoff の宿題)
+
+### 関連リンク
+
+- [Issue #111](https://github.com/system-279/carenote-ios/issues/111) — Phase 0.9: prod tenants/279.allowedDomains 有効化 (open 維持、close 条件本セッションで明確化)
+- [docs/runbook/phase-0-9-allowed-domains.md](../runbook/phase-0-9-allowed-domains.md) — Phase 0.9 RUNBOOK (実施ログに 2026-04-27 確認エントリ追加)
+- [ADR-007 Guest Tenant for Apple Sign-In](../adr/ADR-007-guest-tenant-for-apple-signin.md) — Apple Sign-In Guest Tenant 設計 (allowedDomains の判定優先順)
+- [ADR-005 Auth Blocking Function](../adr/ADR-005-auth-blocking-function.md) — beforeSignIn 全体設計
+- `functions/index.js:41-73` — beforeSignIn の whitelist + allowedDomains 分岐実装
+- `~/.claude/memory/project_carenote_app_review.md` (グローバル) — Phase 0.9 状態 + whitelist 運用変化セクション
+
+---
+
 # Handoff — 2026-04-27 続報セッション: Build 38 / v1.0.1 APPROVED → Unlisted 配信開始
 
 ## ✅ Build 38 / v1.0.1 が App Review 通過 → Unlisted release 完了 + memory に Unlisted 新版仕様を整理

--- a/docs/runbook/phase-0-9-allowed-domains.md
+++ b/docs/runbook/phase-0-9-allowed-domains.md
@@ -307,16 +307,19 @@ rollback 後、`beforeSignIn` は次回実行時に Firestore を都度読み取
   - Cloud Logging エラー: 直近 7d で **0 件**
   - 直近のログイン試行: 2026-04-24 15:21 JST までエラーなし（設定後 18h 時点で実ログインあり、正常）
 - 判定: prod 技術設定は完全に健全、Build 38 / v1.0.1 配信中の今もエラーなし
-- 残作業 = Issue #111 close 条件:
-  - [ ] 新規 `@279279.net` 社員が初回 Google Sign-In 成功（Build 38 / v1.0.1 配信中の Unlisted URL から取得）
-  - [ ] Cloud Logging で `beforeSignIn` の allowedDomains match 経路を確認
-  - [ ] Firebase Auth に当該 user の `customClaims.tenantId === "279"` / `role === "member"` 反映確認
-  - [ ] `tenants/279/whitelist` に当該 entry が存在しないこと（allowedDomains 経由を担保）
+- 残作業 = Issue #111 close 条件 (元 AC 全 6 項目を網羅):
+  - [ ] **(allowedDomains 正常系)** 新規 `@279279.net` 社員が初回 Google Sign-In 成功（Build 38 / v1.0.1 配信中の Unlisted URL から取得）
+  - [ ] **(allowedDomains 正常系)** Cloud Logging で `beforeSignIn` の allowedDomains match 経路を確認
+  - [ ] **(allowedDomains 正常系)** Firebase Auth に当該 user の `customClaims.tenantId === "279"` / `role === "member"` 反映確認
+  - [ ] **(allowedDomains 正常系)** `tenants/279/whitelist` に当該 entry が存在しないこと（allowedDomains 経由を担保、whitelist 経由でないことの否定的確認）
+  - [ ] **(Apple Guest 経路)** 許可外ドメイン × Apple Sign-In が `demo-guest` tenant に振り分けられること（次回 App Store Review 提出時の審査員操作で事実上検証可、能動テストは任意。Build 33 以降通過実績ありで実質充足扱い可）
+  - [ ] **(既存ログイン非破壊)** 既存 `@279279.net` 社員のログインが allowedDomains 有効化後も継続成功（直近 7d Cloud Logging エラー 0 件で実質確認済、新規社員ジョイン時の既存メンバーの App Store 自動更新後ログインでも再確認）
 - 方針: A1 (whitelist 未登録の `@279279.net` 社員ジョイン予定者あり) + B2 (社員ジョイン待ち) でポストポーン継続。能動テスト用アカウント発行は採用せず、自然観測する
 - 再開トリガー: 新規 `@279279.net` 社員のオンボーディング発生時（social signal: 「社員が増えた」「アカウント発行した」等の発言、または Cloud Logging で新規 `@279279.net` の `beforeSignIn` 成功ログ出現）
-- 観測コマンド（社員初回ログイン後 24h 以内に実行）:
+- 観測コマンド（社員初回ログイン後 24h 以内に実行、`EMAIL` を観測対象の社員メールに置換）:
   ```bash
   TOKEN=$(CLOUDSDK_ACTIVE_CONFIG_NAME=carenote-prod gcloud auth print-access-token)
+  EMAIL="alice@279279.net"  # ← 観測対象の社員メールを指定（例、実際の値に置換）
 
   # 1. beforeSignIn の最新ログ（allowedDomains match 経路を確認）
   CLOUDSDK_ACTIVE_CONFIG_NAME=carenote-prod gcloud logging read \
@@ -324,19 +327,19 @@ rollback 後、`beforeSignIn` は次回実行時に Firestore を都度読み取
     --project=carenote-prod-279 --limit=10 --freshness=24h \
     --format='value(timestamp,severity,jsonPayload.message)'
 
-  # 2. Auth user の custom claim 確認（社員のメール指定）
+  # 2. Auth user の custom claim 確認
   curl -sS -X POST \
     -H "Authorization: Bearer $TOKEN" \
     -H "Content-Type: application/json" \
     -H "x-goog-user-project: carenote-prod-279" \
     "https://identitytoolkit.googleapis.com/v1/projects/carenote-prod-279/accounts:lookup" \
-    -d '{"email":["新規社員のメール"]}'
+    -d "{\"email\":[\"$EMAIL\"]}"
 
   # 3. whitelist に当該 entry がないこと確認（allowedDomains 経由担保）
   curl -sS -X POST \
     -H "Authorization: Bearer $TOKEN" \
     -H "Content-Type: application/json" \
     "https://firestore.googleapis.com/v1/projects/carenote-prod-279/databases/(default)/documents/tenants/279:runQuery" \
-    -d '{"structuredQuery":{"from":[{"collectionId":"whitelist"}],"where":{"fieldFilter":{"field":{"fieldPath":"email"},"op":"EQUAL","value":{"stringValue":"新規社員のメール"}}}}}'
+    -d "{\"structuredQuery\":{\"from\":[{\"collectionId\":\"whitelist\"}],\"where\":{\"fieldFilter\":{\"field\":{\"fieldPath\":\"email\"},\"op\":\"EQUAL\",\"value\":{\"stringValue\":\"$EMAIL\"}}}}}"
   ```
 

--- a/docs/runbook/phase-0-9-allowed-domains.md
+++ b/docs/runbook/phase-0-9-allowed-domains.md
@@ -296,3 +296,47 @@ rollback 後、`beforeSignIn` は次回実行時に Firestore を都度読み取
 - 24h 監視: 自社単独フェーズで短縮運用、`beforeSignIn` のエラー急増は自社ログインで即検知する前提
 - 運用基盤: Stage 2 GitHub Actions + Workload Identity Federation は follow-up Issue で整備（ADR-009 参照）
 
+### 2026-04-27 22:30 JST: prod 設定健全性 read-only verify + B2 ポストポーン継続判定
+
+- 実施者: system-279
+- きっかけ: ユーザーから「内部のアプリリンクを知る社員はテナント内のドメインなら誰でも入れるか?」確認、Issue #111 が open のため未完了と推定して再評価 → 実態は prod 設定 2026-04-23 完了済、実機 smoke test だけが pending と判明
+- 確認内容（read-only、ユーザー明示承認後に実行）:
+  - prod `tenants/279.allowedDomains` = `["279279.net"]` 維持確認（Firestore REST API GET）
+  - `tenants/279` フィールド構成 = `["allowedDomains", "createdAt", "name"]`
+  - `beforeSignIn` Cloud Function = ACTIVE / GEN_2（`gcloud functions list`）
+  - Cloud Logging エラー: 直近 7d で **0 件**
+  - 直近のログイン試行: 2026-04-24 15:21 JST までエラーなし（設定後 18h 時点で実ログインあり、正常）
+- 判定: prod 技術設定は完全に健全、Build 38 / v1.0.1 配信中の今もエラーなし
+- 残作業 = Issue #111 close 条件:
+  - [ ] 新規 `@279279.net` 社員が初回 Google Sign-In 成功（Build 38 / v1.0.1 配信中の Unlisted URL から取得）
+  - [ ] Cloud Logging で `beforeSignIn` の allowedDomains match 経路を確認
+  - [ ] Firebase Auth に当該 user の `customClaims.tenantId === "279"` / `role === "member"` 反映確認
+  - [ ] `tenants/279/whitelist` に当該 entry が存在しないこと（allowedDomains 経由を担保）
+- 方針: A1 (whitelist 未登録の `@279279.net` 社員ジョイン予定者あり) + B2 (社員ジョイン待ち) でポストポーン継続。能動テスト用アカウント発行は採用せず、自然観測する
+- 再開トリガー: 新規 `@279279.net` 社員のオンボーディング発生時（social signal: 「社員が増えた」「アカウント発行した」等の発言、または Cloud Logging で新規 `@279279.net` の `beforeSignIn` 成功ログ出現）
+- 観測コマンド（社員初回ログイン後 24h 以内に実行）:
+  ```bash
+  TOKEN=$(CLOUDSDK_ACTIVE_CONFIG_NAME=carenote-prod gcloud auth print-access-token)
+
+  # 1. beforeSignIn の最新ログ（allowedDomains match 経路を確認）
+  CLOUDSDK_ACTIVE_CONFIG_NAME=carenote-prod gcloud logging read \
+    'resource.type="cloud_run_revision" AND resource.labels.service_name="beforesignin"' \
+    --project=carenote-prod-279 --limit=10 --freshness=24h \
+    --format='value(timestamp,severity,jsonPayload.message)'
+
+  # 2. Auth user の custom claim 確認（社員のメール指定）
+  curl -sS -X POST \
+    -H "Authorization: Bearer $TOKEN" \
+    -H "Content-Type: application/json" \
+    -H "x-goog-user-project: carenote-prod-279" \
+    "https://identitytoolkit.googleapis.com/v1/projects/carenote-prod-279/accounts:lookup" \
+    -d '{"email":["新規社員のメール"]}'
+
+  # 3. whitelist に当該 entry がないこと確認（allowedDomains 経由担保）
+  curl -sS -X POST \
+    -H "Authorization: Bearer $TOKEN" \
+    -H "Content-Type: application/json" \
+    "https://firestore.googleapis.com/v1/projects/carenote-prod-279/databases/(default)/documents/tenants/279:runQuery" \
+    -d '{"structuredQuery":{"from":[{"collectionId":"whitelist"}],"where":{"fieldFilter":{"field":{"fieldPath":"email"},"op":"EQUAL","value":{"stringValue":"新規社員のメール"}}}}}'
+  ```
+


### PR DESCRIPTION
## Summary

- prod \`tenants/279.allowedDomains\` の健全性を read-only verify (2026-04-23 完了済の状態維持を確認)
- Issue #111 を B2 ポストポーンで継続維持、close 条件 4 項目と再開トリガーを RUNBOOK + Issue コメントに明文化
- ユーザー質問「ホワイトリスト概念がなくなる?」に対し handoff で運用変化を整理 (whitelist は admin 任命・例外管理のため残存、一般 \`@279279.net\` 社員のみ自動加入)

## 背景

ユーザーから「内部のアプリリンクを知る社員はテナント内のドメインなら誰でも入れるか?」確認質問を受け、Issue #111 (Phase 0.9: allowedDomains 有効化) を再評価。Issue が open のままだったのは prod 設定が完了していて実機 smoke test だけが pending だったため、と判明。

## 変更内容

### \`docs/runbook/phase-0-9-allowed-domains.md\` (+44 行)

実施ログに 2026-04-27 22:30 JST エントリを追加:

- prod 健全性 read-only verify 結果 (\`allowedDomains = ["279279.net"]\` 維持 / \`beforeSignIn\` ACTIVE / 直近 7d エラー 0)
- B2 ポストポーン継続判定 (社員ジョイン待ち、能動テスト用アカウント発行は不採用)
- 社員初回ログイン後 24h 以内に実行する観測コマンド 3 種 (Cloud Logging / Auth user lookup / whitelist 不在確認)

### \`docs/handoff/LATEST.md\` (+73 行)

続報セッション 2 を先頭追記:

- Phase 0.9 状態確認の経緯 (catchup → Issue 再評価 → prod verify → ポストポーン継続判定)
- whitelist 概念の運用変化 (\`functions/index.js:41-73\` の \`beforeSignIn\` 分岐確認結果)
- 次セッション推奨アクション 6 項目

## prod 操作

- read-only 2 件 (Firestore GET + Cloud Logging)、ユーザー明示承認後に実行
- 書き込み一切なし

## 関連 Issue / PR

- [Issue #111](https://github.com/system-279/carenote-ios/issues/111) (open 維持、コメント追加 https://github.com/system-279/carenote-ios/issues/111#issuecomment-4323056959)
- 関連 memory: \`~/.claude/memory/project_carenote_app_review.md\` にも whitelist 運用変化セクション追加 (別 PR で push 予定: yasushi-honda/claude-code-config #157 への追加コミット)

## Test plan

設定/ドキュメントのみの PR のため、構文検証 + 次セッション確認で可 (CLAUDE.md):

- [x] markdown 構文 OK (Edit ツールでの直接編集、Read で内容確認済)
- [x] runbook 末尾コードブロック整合性確認 (新エントリの bash ブロックが正しく閉じている)
- [x] handoff 既存セッション (続報セッション 1) の構造を破壊していない
- [ ] 次セッション catchup で本 handoff が正しく表示されること (merge 後確認)

🤖 Generated with [Claude Code](https://claude.com/claude-code)