### PR TITLE
docs(readme): AI 引き継ぎ可能なアーキテクチャ設計を README に front-load

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,75 +1,270 @@
 # CareNote
 
-ケアマネジャー向け録音・文字起こし iOS アプリ。
+ケアマネジャー向け録音・文字起こし iOS アプリ。Google Sign-In → Firebase Auth → Vertex AI Gemini による多テナント設計で、訪問記録の作成を音声主体に置き換える。
+
+**Status**: v1.0.1 App Store Connect Unlisted 配信中（2026-04-27 〜、Build 38 / iOS 17+）
+
+- [Quickstart](#quickstart) — ローカル起動 4 ステップ
+- [アーキテクチャ](#アーキテクチャ) — サービス構成 / データフロー / 認証フロー
+- [AI 向けアーキテクチャ引き継ぎ](#ai-向けアーキテクチャ引き継ぎ) — Claude Code / Codex 等の初回コンテキスト
+- [設計判断 (ADR)](#設計判断-adr) / [運用 Runbook](#運用-runbook)
+
+## Quickstart
+
+```bash
+git clone https://github.com/system-279/carenote-ios.git
+cd carenote-ios
+xcodegen generate                          # project.yml → CareNote.xcodeproj
+# CareNote/GoogleService-Info.plist を配置（Firebase Console → carenote-dev-279）
+open CareNote.xcodeproj                    # Xcode 26.3+ で開いて実行
+```
+
+CLI ビルド:
+
+```bash
+DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer \
+  xcodebuild build -project CareNote.xcodeproj -scheme CareNote \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' CODE_SIGNING_ALLOWED=NO
+```
+
+Xcode 操作は **XcodeBuildMCP 経由**（`mcp__xcodebuildmcp__build_sim_name_proj` 他）。TestFlight upload は `./scripts/upload-testflight.sh`。
 
 ## 技術スタック
 
 | カテゴリ | 技術 |
 |---------|------|
-| 言語 | Swift 6+ |
-| UI | SwiftUI |
-| アーキテクチャ | MVVM + Repository パターン (`@Observable`) |
-| ローカル DB | SwiftData |
-| 認証 | Google Sign-In → Firebase Auth |
-| バックエンド | Firebase (Firestore, Storage) |
-| 文字起こし | Vertex AI Gemini 2.5 Flash |
-| GCP 認証 | Workload Identity Federation (WIF) |
-| 録音 | AVAudioRecorder (M4A/AAC) |
+| 言語 / UI | Swift 6+ / SwiftUI |
+| アーキテクチャ | MVVM + Repository（`@Observable`）、`async/await` + `actor` |
+| ローカル DB | SwiftData（Repository 経由、View で `@Query` 直接禁止） |
+| Package Manager | Swift Package Manager |
+| 認証 | Firebase Auth + Google Sign-In / Apple Sign-In、Auth Blocking Function |
+| バックエンド | Firestore（multi-tenant）、Cloud Storage、Cloud Functions v2 (Node 22) |
+| 文字起こし | Vertex AI Gemini 2.5 Flash（`gemini-2.5-flash`、asia-northeast1、`thinkingBudget=0`）|
+| GCP 認証 | Workload Identity Federation → Service Account Impersonation |
+| 録音 | AVAudioRecorder（M4A/AAC、44.1kHz、mono、high quality） |
+| テスト | Swift Testing (`@Test`, `#expect`) / Mocha (functions) |
 
-## 前提条件
+## アーキテクチャ
 
-- macOS 15+ (Tahoe)
-- Xcode 26.3+
-- Swift 6.0+
-- [XcodeGen](https://github.com/yonaskolb/XcodeGen)
-- gcloud CLI (Firebase / GCP 操作用)
+### システム構成
 
-## セットアップ
+```mermaid
+flowchart TB
+    subgraph iOS["iOS App (Swift 6 / SwiftUI)"]
+        Features[Features: Auth / ClientSelect / SceneSelect /<br/>Recording / RecordingConfirm / RecordingList / Settings]
+        VM[ViewModel @Observable]
+        Repo[Repositories:<br/>ClientRepository / RecordingRepository]
+        Svc[Services: AudioRecorder / Firestore / Storage /<br/>WIFAuth / Transcription / OutboxSync / TransferOwnership]
+        SD[(SwiftData<br/>ローカル DB + Outbox)]
+    end
 
-```bash
-# 1. リポジトリクローン
-git clone https://github.com/system-279/carenote-ios.git
-cd carenote-ios
+    subgraph Firebase["Firebase (asia-northeast1)"]
+        FA[Firebase Auth]
+        BSI["beforeSignIn<br/>Auth Blocking Function<br/>(tenantId claim 付与)"]
+        FS[(Firestore<br/>tenants/tenantId/...)]
+        CS[(Cloud Storage<br/>project-audio)]
+        CF["Cloud Functions v2:<br/>transferOwnership /<br/>onUserDelete cleanup"]
+    end
 
-# 2. Xcode プロジェクト生成
-xcodegen generate
+    subgraph GCP["GCP (Vertex AI)"]
+        WIF[Workload Identity<br/>Federation / STS]
+        SA[Service Account<br/>Impersonation]
+        Gemini[Vertex AI<br/>Gemini 2.5 Flash]
+    end
 
-# 3. ビルド (CLI)
-DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer \
-  xcodebuild build \
-  -project CareNote.xcodeproj \
-  -scheme CareNote \
-  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' \
-  CODE_SIGNING_ALLOWED=NO
-
-# 4. GoogleService-Info.plist を CareNote/ に配置 (Firebase Console から取得)
+    Features --> VM --> Repo --> SD
+    VM --> Svc
+    Svc -->|Google / Apple Sign-In| FA
+    FA -.->|blocking| BSI
+    BSI -.->|"allowedDomains /<br/>Guest Tenant"| FA
+    Svc -->|CRUD| FS
+    Svc -->|m4a upload| CS
+    Svc -->|ID token| WIF --> SA --> Gemini
+    Svc -->|"transcribe(audio URI)"| Gemini
+    FA -.->|onUserDelete| CF -.-> FS
+    CF -.->|cleanup| CS
 ```
+
+### 録音〜文字起こしデータフロー
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant App as iOS App
+    participant Local as SwiftData
+    participant CS as Cloud Storage
+    participant G as Gemini 2.5 Flash
+    participant FS as Firestore
+
+    U->>App: 利用者・場面選択 → 録音開始
+    App->>App: AudioRecorderService (M4A/AAC)
+    App->>Local: Recording (draft, tenantId 紐付け)
+    U->>App: 録音停止 → RecordingConfirm
+    App->>CS: audio.m4a upload (tenants/tenantId/audio/id.m4a)
+    App->>G: transcribe(gs://... URI, prompt)
+    G-->>App: 文字起こしテキスト
+    App->>FS: tenants/tenantId/recordings/id create
+    App->>Local: Outbox 完了マーク
+    Note over App,FS: 失敗時は OutboxSyncService が再送
+```
+
+### 認証・多テナント
+
+```mermaid
+sequenceDiagram
+    participant App as iOS App
+    participant GS as Google/Apple Sign-In
+    participant FA as Firebase Auth
+    participant BSI as beforeSignIn (Cloud Function)
+    participant FS as Firestore
+
+    App->>GS: SDK sign-in
+    GS-->>App: id token
+    App->>FA: signIn(idToken)
+    FA->>BSI: Auth Blocking event
+    BSI->>FS: tenants/whitelist 参照
+    alt メールが tenant.allowedDomains に該当
+        BSI-->>FA: customClaims { tenantId }
+    else Apple Sign-In / 未登録
+        BSI-->>FA: customClaims { tenantId: "demo-guest" }
+    end
+    FA-->>App: user + custom claims
+    App->>App: tenantId を全 Firestore/Storage path に伝播
+```
+
+**Multi-tenant 原則**:
+
+- Firestore パス: `tenants/{tenantId}/{clients|recordings|templates|...}`
+- Storage パス: `{project}-audio/tenants/{tenantId}/audio/{recordingId}.m4a`
+- `tenantId` は Firebase Auth custom claim から取得（**ハードコーディング禁止**）
+- Security Rules: テナントメンバー限定（ADR-010）
 
 ## ディレクトリ構成
 
 ```
-CareNote/
-├── App/          # @main, AppConfig
-├── Features/     # 画面別モジュール
-│   ├── Auth/           # Google Sign-In
-│   ├── ClientSelect/   # 利用者選択
-│   ├── SceneSelect/    # 場面選択
-│   ├── Recording/      # 録音
-│   ├── RecordingConfirm/ # 録音確認
-│   └── RecordingList/  # 録音一覧
-├── Services/     # ビジネスロジック
-├── Repositories/ # SwiftData 抽象化層
-├── Models/       # SwiftData @Model, Firestore Codable
-└── Infrastructure/ # 環境管理
+carenote-ios/
+├── CareNote/                    # iOS アプリ本体
+│   ├── App/                     # @main (CareNoteApp), AppConfig
+│   ├── Features/                # 画面別モジュール (View + ViewModel)
+│   │   ├── Auth/                # Google/Apple Sign-In
+│   │   ├── ClientSelect/        # 利用者選択
+│   │   ├── SceneSelect/         # 場面（訪問/電話 等）選択
+│   │   ├── Recording/           # 録音画面
+│   │   ├── RecordingConfirm/    # 録音確定 → 文字起こし
+│   │   ├── RecordingList/       # 履歴一覧
+│   │   └── Settings/            # 設定・アカウント移行
+│   ├── Services/                # ビジネスロジック (async/await + actor)
+│   │   ├── AudioRecorderService, TranscriptionService, StorageService
+│   │   ├── FirestoreService, WIFAuthService, ClientCacheService
+│   │   └── OutboxSyncService, TransferOwnershipService, LocalDataCleaner
+│   ├── Repositories/            # SwiftData 抽象化層
+│   ├── Models/                  # SwiftData @Model, Firestore Codable, Enum
+│   ├── Infrastructure/          # AppEnvironment, KeychainHelper, TimeFormatting
+│   ├── Components/              # 再利用 SwiftUI View
+│   └── Firebase/                # dev/prod GoogleService-Info.plist (.gitignore)
+├── CareNoteTests/               # Swift Testing (20+ test files)
+├── functions/                   # Cloud Functions v2 (Node 22)
+│   ├── index.js                 # beforeSignIn (Auth Blocking), transferOwnership 等
+│   ├── src/transferOwnership.js
+│   └── test/                    # Mocha (rules test + auth blocking test)
+├── firestore.rules              # Multi-tenant security rules (ADR-010)
+├── storage.rules
+├── project.yml                  # XcodeGen 定義
+├── scripts/
+│   ├── upload-testflight.sh     # ビルド番号自動インクリメント + Archive + upload
+│   └── set-tenant-claim.sh      # 手動 tenant 割り当て
+├── docs/
+│   ├── adr/                     # 設計判断 (ADR-001 〜 010)
+│   ├── runbook/                 # 運用手順
+│   └── handoff/                 # セッション履歴 (LATEST.md + archive/)
+└── CLAUDE.md                    # AI 駆動開発の前提コンテキスト
 ```
+
+## AI 向けアーキテクチャ引き継ぎ
+
+Claude Code / Codex 等の LLM に本プロジェクトのアーキテクチャを引き継ぐ場合、以下を **この順** で読み込むと 5-10 分で全体像が掴める。
+
+1. **[CLAUDE.md](CLAUDE.md)** — Claude Code グローバル前提（XcodeBuildMCP 使用ルール / 命名規約 / dev-prod 分離ルール / 禁止事項）
+2. **本 README のアーキテクチャセクション** — システム構成 3 図（システム / データフロー / 認証）
+3. **[ADR 全 10 件](docs/adr/)** — 主要設計判断の Why（下記索引）
+4. **[docs/handoff/LATEST.md](docs/handoff/LATEST.md)** — 直近セッションの進捗・未解決 Issue・条件待ちタスク
+5. **[docs/runbook/](docs/runbook/)** — 運用手順（prod 反映、admin ID token、smoke test）
+6. **具体ソース**: `CareNote/Services/` → `CareNote/Features/` → `functions/index.js` の順に読めば実装マップが完成する
+
+> [!IMPORTANT]
+> セッション開始時は `/catchup` を実行するとハンドオフ状態・環境設定・積み残し Issue を自動集約する。
+
+### 設計判断 (ADR)
+
+| # | 決定 | 影響レイヤー |
+|---|-----|-------------|
+| [001](docs/adr/ADR-001-google-sign-in.md) | Google Sign-In 採用（Apple ID は Guest Tenant 経由） | Auth |
+| [002](docs/adr/ADR-002-wif-auth-flow.md) | WIF 経由で GCP アクセストークン取得（SA key 同梱禁止） | Auth / GCP |
+| [003](docs/adr/ADR-003-gemini-transcription.md) | 文字起こしは Gemini 2.5 Flash（`thinkingBudget=0` 固定） | Transcription |
+| [004](docs/adr/ADR-004-m4a-recording-format.md) | 録音は M4A/AAC 44.1kHz mono | Recording |
+| [005](docs/adr/ADR-005-auth-blocking-function.md) | `beforeSignIn` で tenantId custom claim 付与 | Auth / Backend |
+| [006](docs/adr/ADR-006-tenant-shared-templates.md) | テンプレート 2 層管理（テナント共有 + ユーザー個別） | Data model |
+| [007](docs/adr/ADR-007-guest-tenant-for-apple-signin.md) | Apple Sign-In は `demo-guest` テナントへ自動プロビジョニング | Auth |
+| [008](docs/adr/ADR-008-account-ownership-transfer.md) | アカウント所有権移行（Phase 0 + Phase 1 実装） | Callable Function |
+| [009](docs/adr/ADR-009-prod-firestore-write-access.md) | prod Firestore 書き込みは workflow 経由（監査証跡） | Ops |
+| [010](docs/adr/ADR-010-recordings-permission-model.md) | recordings Rules 権限モデル段階的強化 | Security Rules |
+
+### 運用 Runbook
+
+- [Phase 0.9 allowedDomains](docs/runbook/phase-0-9-allowed-domains.md) — `279279.net` 自動参加設定（prod 反映済、実機確認待ち）
+- [Phase 1 admin ID token](docs/runbook/phase-1-admin-id-token.md) — Callable Function を admin 権限で叩く手順
+- [Prod deploy smoke test](docs/runbook/prod-deploy-smoke-test.md) — Rules / Functions / Runtime 統合確認
+
+## Coding Standards
+
+- **Concurrency**: `async/await` + `actor`。`@Observable`（`ObservableObject` / `@Published` は使わない）
+- **DB access**: 全て Repository 経由。`View` に `@Query` 直接使用禁止
+- **Multi-tenant**: `tenantId` はハードコーディング禁止、パラメータで受け取る
+- **Testing**: Swift Testing (`@Test`, `#expect`)、境界値と異常系必須。Partial Update 関数は「更新対象外フィールドの値が変化しないこと」をテスト
+- **Xcode 操作**: 全て XcodeBuildMCP 経由
+
+詳細は [CLAUDE.md](CLAUDE.md) 参照。
+
+## 禁止事項
+
+- `tenantId` のハードコーディング
+- Service Account key (JSON) のアプリ同梱
+- 音声ファイルの Firestore 保存（必ず Cloud Storage を使う）
+- `thinkingBudget` を 0 以外に設定
+- Gemini 3 Flash / Preview モデルの使用
+- `@Query` の View 直接使用
+- prod GCP プロジェクト（`carenote-prod-279`）への読み書きをユーザー確認なしで実行
 
 ## GCP プロジェクト
 
-| 環境 | プロジェクト ID | プロジェクト番号 |
-|------|----------------|-----------------|
-| Dev | `carenote-dev-279` | `444137368705` |
-| Prod | `carenote-prod-279` | `781674225072` |
+| 環境 | プロジェクト ID | プロジェクト番号 | 切替方法 |
+|------|----------------|-----------------|--------|
+| Dev | `carenote-dev-279` | `444137368705` | `.envrc` で自動 active |
+| Prod | `carenote-prod-279` | `781674225072` | `CLOUDSDK_ACTIVE_CONFIG_NAME=carenote-prod <cmd>` |
 
-## ライセンス
+GCP アカウント: `system@279279.net`（dev/prod 共通、操作時は project 明示必須）
+GitHub アカウント: `system-279`
+Apple Team ID: `C96A7EHVW8` / Bundle ID: `jp.carenote.app` / App Store Connect 表示名: **CareNote AI**
+
+## Testing
+
+```bash
+# iOS Unit Tests (Swift Testing)
+mcp__xcodebuildmcp__test_sim_name_proj  # 推奨: XcodeBuildMCP 経由
+
+# Cloud Functions Tests (Mocha)
+cd functions && npm test                 # 全テスト
+npm run test:rules                       # Firestore Rules のみ
+npm run test:auth                        # beforeSignIn のみ
+```
+
+## Deploy
+
+- **TestFlight**: `./scripts/upload-testflight.sh`（ビルド番号自動 inc + XcodeGen + Archive + upload）
+- **Cloud Functions dev**: `firebase deploy --only functions -P default`
+- **Cloud Functions prod**: `firebase deploy --only functions -P prod`
+- **Firestore Rules prod**: workflow 経由（[ADR-009](docs/adr/ADR-009-prod-firestore-write-access.md) の 2 段承認）
+
+## License
 
 Private


### PR DESCRIPTION
## Summary

README を readme-pro 原則（Less is more + linked depth + front-loading）に沿って刷新し、Claude Code / Codex 等の AI が本プロジェクトのアーキテクチャを 5-10 分で把握できる状態を作った。

- **Mermaid 図 3 種追加**: システム構成 / 録音〜文字起こしフロー / 認証・多テナントフロー（GitHub 上でネイティブレンダリング）
- **AI 向けアーキテクチャ引き継ぎセクション新設**: CLAUDE.md → 本 README → ADR → handoff → runbook → ソースの 6 ステップ読み込み順を明示
- **ADR 全 10 件 / Runbook 3 件を索引化**: 1 行サマリ + 影響レイヤー付き
- **禁止事項 7 項目を CLAUDE.md から front-load**: `tenantId` ハードコーディング / SA key 同梱 / `thinkingBudget` 非 0 等
- **Quickstart 簡潔化**: 4 コマンドでコピペ実行可能
- **Status / Testing / Deploy セクション追加**: v1.0.1 Unlisted 配信中を明示

## 変更統計

- 270 行（< 300 目標、readme-pro セルフチェック PASS）
- +246 / -51、単一ファイル (`README.md`)
- 既存の License "Private" と GCP プロジェクト表は保持

## Test plan

- [ ] GitHub 上で PR ページを開き Mermaid 図 3 種が正しくレンダリングされることを目視確認
- [ ] ADR / Runbook / CLAUDE.md への相対リンク 15 本以上が全て 404 にならないこと（ファイル存在は既にローカル確認済）
- [ ] `## AI 向けアーキテクチャ引き継ぎ` セクションの読み込み順 6 ステップが実在ファイルを指していること

## Related

- readme-pro スキル起動（`/readme-pro で、詳細な設計を書いてこれをAIへアーキテクチャ引き継ぎ可能な状況にしてください。`）
- 前段の相談: docs/ HTML は Firebase Hosting 未配信 → GitHub の Markdown レンダリングで代替する方針を採用

🤖 Generated with [Claude Code](https://claude.com/claude-code)